### PR TITLE
Container: explicitly launch the D-BUS daemon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ RUN apt-get update && apt-get install -y \
     xfce4 \
     xfce4-goodies \
     x11vnc \
+    dbus \
+    dbus-x11 \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,5 +29,12 @@ else
     echo "VNC_PASSWORD not set, VNC server not started"
 fi
 
+# Run D-BUS daemon
+echo "Starting D-BUS daemon..."
+rm -rf /run/dbus
+mkdir -p /run/dbus
+dbus-daemon --system --fork
+echo "D-BUS daemon started with pid: $(cat /run/dbus/pid)"
+
 # Start FastAPI server
 /opt/venv/bin/python -m uvicorn getgather.api.main:app --host 0.0.0.0 --port 8000 --log-level debug


### PR DESCRIPTION
Without this, starting the machine (looked at via VNC) will result in the following error:

<img width="767" height="170" alt="image" src="https://github.com/user-attachments/assets/c3bc46fc-6848-4179-bf5d-20fa9b9e77ae" />
