### PR TITLE
Use noVNC to serve live (desktop) view at /live

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,14 +55,10 @@ RUN apt-get update && apt-get install -y \
     x11-apps \
     dbus \
     dbus-x11 \
-    novnc \
-    websockify \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-
-RUN ln -s /usr/share/novnc/vnc_lite.html /usr/share/novnc/index.html
 
 COPY --from=builder /app/.venv /opt/venv
 COPY --from=builder /app/getgather /app/getgather
@@ -82,7 +78,5 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 EXPOSE 8000
 # port for VNC server
 EXPOSE 5900
-# port for noVNC web client
-EXPOSE 6080
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -11,13 +11,7 @@ docker run -p 8000:8000 --name getgather -d getgather
 ```
 and then navigate to `http://localhost:8000/docs` to see the API docs.
 
-Optionally, if you want to live stream the container desktop, run it with additional parameters:
-
-```bash
--e VNC_PASSWORD=$YOUR_VNC_PASSWORD -p 6080:6080
-```
-
-and then open `localhost:6080` with a web browser.
+To live stream the container desktop, go to `http://localhost:8000/live`.
 
 All additional documentation is located in the [docs](./docs) directory:
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,29 +15,20 @@ echo "Xvfb running on DISPLAY=$DISPLAY"
 echo "Starting JWM (Joe's Window Manager)"
 jwm >/dev/null 2>&1 &
 
-# Start VNC server only if VNC_PASSWORD is set
-if [ -n "$VNC_PASSWORD" ]; then
-    # Create VNC password file
-    mkdir -p /root/.vnc
-    x11vnc -storepasswd "$VNC_PASSWORD" /root/.vncpass
+echo "Starting x11vnc server..."
+x11vnc \
+    -forever \
+    -nopw \
+    -rfbport 5900 \
+    -display :99 \
+    -listen 0.0.0.0 \
+    -quiet \
+    -no6 >/dev/null 2>&1 &
+echo "VNC server started on port 5900"
 
-    # Start x11vnc
-    echo "Starting x11vnc server..."
-    x11vnc \
-        -forever \
-        -usepw \
-        -rfbport 5900 \
-        -display :99 \
-        -rfbauth /root/.vncpass \
-        -listen 0.0.0.0 \
-        -quiet \
-        -no6 >/dev/null 2>&1 &
-    echo "VNC server started on port 5900"
-    websockify --web /usr/share/novnc/ 6080 localhost:5900 &
-    echo "noVNC viewer started on port 6080"
-else
-    echo "VNC_PASSWORD not set, VNC server not started"
-fi
+# So that the desktop is not completely empty
+xeyes &
+xclock &
 
 # Run D-BUS daemon
 echo "Starting D-BUS daemon..."

--- a/getgather/api/frontend/live.html
+++ b/getgather/api/frontend/live.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+
+    <!--
+    noVNC example: lightweight example using minimal UI and features
+
+    This is a self-contained file which doesn't import WebUtil or external CSS.
+
+    Copyright (C) 2019 The noVNC Authors
+    noVNC is licensed under the MPL 2.0 (see LICENSE.txt)
+    This file is licensed under the 2-Clause BSD license (see LICENSE.txt).
+
+    Connect parameters are provided in query string:
+        http://example.com/?host=HOST&port=PORT&scale=true
+    -->
+    <title>Live View</title>
+
+    <meta charset="utf-8">
+
+    <style>
+
+        body {
+            margin: 0;
+            background-color: dimgrey;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+        }
+        html {
+            height: 100%;
+        }
+
+        #top_bar {
+            background-color: #6e84a3;
+            color: white;
+            font: bold 12px Helvetica;
+            padding: 6px 5px 4px 5px;
+            border-bottom: 1px outset;
+        }
+        #status {
+            text-align: center;
+        }
+
+        #screen {
+            flex: 1; /* fill remaining space */
+            overflow: hidden;
+        }
+
+    </style>
+
+    <script type="module" crossorigin="anonymous">
+        // RFB holds the API to connect and communicate with a VNC server
+        import RFB from './core/rfb.js';
+
+        let rfb;
+        let desktopName;
+
+        // When this function is called we have
+        // successfully connected to a server
+        function connectedToServer(e) {
+            status("Connected to " + desktopName);
+        }
+
+        // This function is called when we are disconnected
+        function disconnectedFromServer(e) {
+            if (e.detail.clean) {
+                status("Disconnected");
+            } else {
+                status("Something went wrong, connection is closed");
+            }
+        }
+
+        // When this function is called, the server requires
+        // credentials to authenticate
+        function credentialsAreRequired(e) {
+            const password = prompt("Password Required:");
+            rfb.sendCredentials({ password: password });
+        }
+
+        // When this function is called we have received
+        // a desktop name from the server
+        function updateDesktopName(e) {
+            desktopName = e.detail.name;
+        }
+
+        // Since most operating systems will catch Ctrl+Alt+Del
+        // before they get a chance to be intercepted by the browser,
+        // we provide a way to emulate this key sequence.
+        function sendCtrlAltDel() {
+            rfb.sendCtrlAltDel();
+            return false;
+        }
+
+        // Show a status text in the top bar
+        function status(text) {
+            document.getElementById('status').textContent = text;
+        }
+
+        // This function extracts the value of one variable from the
+        // query string. If the variable isn't defined in the URL
+        // it returns the default value instead.
+        function readQueryVariable(name, defaultValue) {
+            // A URL with a query parameter can look like this (But will most probably get logged on the http server):
+            // https://www.example.com?myqueryparam=myvalue
+            //
+            // For privacy (Using a hastag #, the parameters will not be sent to the server)
+            // the url can be requested in the following way:
+            // https://www.example.com#myqueryparam=myvalue&password=secreatvalue
+            //
+            // Even Mixing public and non public parameters will work:
+            // https://www.example.com?nonsecretparam=example.com#password=secreatvalue
+            //
+            // Note that we use location.href instead of location.search
+            // because Firefox < 53 has a bug w.r.t location.search
+            const re = new RegExp('.*[?&]' + name + '=([^&#]*)'),
+                  match = ''.concat(document.location.href, window.location.hash).match(re);
+
+            if (match) {
+                // We have to decode the URL since want the cleartext value
+                return decodeURIComponent(match[1]);
+            }
+
+            return defaultValue;
+        }
+
+        // Read parameters specified in the URL query string
+        // By default, use the host and port of server that served this file
+        const host = readQueryVariable('host', window.location.hostname);
+        let port = readQueryVariable('port', window.location.port);
+        const password = readQueryVariable('password');
+        const path = readQueryVariable('path', 'websockify');
+
+        // | | |         | | |
+        // | | | Connect | | |
+        // v v v         v v v
+
+        status("Connecting");
+
+        // Build the websocket URL used to connect
+        let url;
+        if (window.location.protocol === "https:") {
+            url = 'wss';
+        } else {
+            url = 'ws';
+        }
+        url += '://' + host;
+        if(port) {
+            url += ':' + port;
+        }
+        url += '/' + path;
+
+        // Creating a new RFB object will start a new connection
+        rfb = new RFB(document.getElementById('screen'), url,
+                      { credentials: { password: password } });
+
+        // Add listeners to important events from the RFB module
+        rfb.addEventListener("connect",  connectedToServer);
+        rfb.addEventListener("disconnect", disconnectedFromServer);
+        rfb.addEventListener("credentialsrequired", credentialsAreRequired);
+        rfb.addEventListener("desktopname", updateDesktopName);
+
+        // Set parameters that can be changed on an active connection
+        rfb.viewOnly = readQueryVariable('view_only', false);
+        rfb.scaleViewport = readQueryVariable('scale', false);
+    </script>
+</head>
+
+<body>
+    <div id="top_bar">
+        <div id="status">Loading</div>
+    </div>
+    <div id="screen">
+        <!-- This is where the remote screen will appear -->
+    </div>
+</body>
+</html>

--- a/getgather/api/main.py
+++ b/getgather/api/main.py
@@ -1,10 +1,13 @@
+import asyncio
+import socket
 from contextlib import asynccontextmanager
 from datetime import datetime
 from os import path
 from typing import Final
 
-from fastapi import FastAPI
-from fastapi.responses import HTMLResponse, PlainTextResponse
+import httpx
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse, PlainTextResponse, Response, RedirectResponse
 from fastapi.routing import APIRoute
 from fastapi.staticfiles import StaticFiles
 from jinja2 import Template
@@ -45,11 +48,115 @@ STATIC_ASSETS_DIR = path.abspath(path.join(path.dirname(__file__), "..", "static
 app.mount("/assets", StaticFiles(directory=STATIC_ASSETS_DIR), name="assets")
 
 
+@app.get("/live")
+def read_live():
+    return RedirectResponse(url="/live/", status_code=301)
+
+
+@app.get("/live/{file_path:path}")
+async def proxy_live_files(file_path: str):
+    # noVNC lite's main web UI
+    if file_path == "" or file_path == "index.html":
+        local_file_path = path.join(path.dirname(__file__), "frontend", "live.html")
+        with open(local_file_path) as f:
+            return HTMLResponse(content=f.read())
+
+    # Proxy noVNC libraries to unpkg.com
+    unpkg_url = f"https://unpkg.com/@novnc/novnc@1.3.0/{file_path}"
+
+    print(f"Proxying {file_path} to {unpkg_url}")
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(unpkg_url)
+            content = response.content
+            print(f"Response's length: {len(content)}")
+
+            # Filter out headers that can cause decoding issues
+            headers = dict(response.headers)
+            for header in ["content-encoding", "content-length", "transfer-encoding"]:
+                headers.pop(header, None)
+
+            return Response(status_code=response.status_code, content=content, headers=headers)
+        except httpx.RequestError:
+            return Response(status_code=404)
+
+
 @app.get("/", response_class=HTMLResponse)
 def index():
     file_path = path.join(path.dirname(__file__), "frontend", "index.html")
     with open(file_path) as f:
         return HTMLResponse(content=f.read())
+
+
+@app.websocket("/websockify")
+async def vnc_websocket_proxy(websocket: WebSocket):
+    """WebSocket proxy to bridge NoVNC client and VNC server."""
+    await websocket.accept()
+
+    vnc_socket = None
+    websocket_closed = asyncio.Event()
+
+    try:
+        vnc_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        vnc_socket.connect(("localhost", 5900))
+        vnc_socket.setblocking(False)
+
+        async def forward_to_vnc():
+            try:
+                while not websocket_closed.is_set():
+                    data = await websocket.receive_bytes()
+                    vnc_socket.send(data)
+            except WebSocketDisconnect:
+                websocket_closed.set()
+            except Exception as e:
+                print(f"Error forwarding to VNC: {e}")
+                websocket_closed.set()
+
+        async def forward_from_vnc():
+            try:
+                while not websocket_closed.is_set():
+                    await asyncio.sleep(0.001)
+                    try:
+                        data = vnc_socket.recv(4096)
+                        if data:
+                            if not websocket_closed.is_set():
+                                await websocket.send_bytes(data)
+                        else:
+                            break  # VNC connection closed
+                    except socket.error:
+                        continue
+            except Exception as e:
+                print(f"Error forwarding from VNC: {e}")
+            finally:
+                websocket_closed.set()
+
+        await asyncio.gather(forward_to_vnc(), forward_from_vnc(), return_exceptions=True)
+
+    except ConnectionRefusedError:
+        if not websocket_closed.is_set():
+            try:
+                await websocket.send_text("Error: Could not connect to VNC server on port 5900")
+            except:
+                pass
+    except Exception as e:
+        if not websocket_closed.is_set():
+            try:
+                await websocket.send_text(f"Error: {str(e)}")
+            except:
+                pass
+    finally:
+        websocket_closed.set()
+        try:
+            if vnc_socket is not None:
+                vnc_socket.close()
+        except:
+            pass
+        try:
+            if websocket.client_state.value <= 2:  # CONNECTING or CONNECTED
+                await websocket.close()
+        except:
+            pass
 
 
 @app.get("/start/{brand}", response_class=HTMLResponse)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,12 @@ dependencies = [
   "rich>=14.0.0",
   "fastapi>=0.115.12",
   "jinja2>=3.1.6",
-  "uvicorn>=0.34.2",
+  "uvicorn[standard]>=0.34.2",
   # Browser Automation: Locked to specific versions to avoid breaking changes.
   "patchright==1.52.5",
   "fastmcp>=2.10.5",
   "requests>=2.32.4",
+  "httpx>=0.28.1",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -507,6 +507,7 @@ dependencies = [
     { name = "aiofiles" },
     { name = "fastapi" },
     { name = "fastmcp" },
+    { name = "httpx" },
     { name = "jinja2" },
     { name = "nanoid" },
     { name = "patchright" },
@@ -516,7 +517,7 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "sentry-sdk", extra = ["fastapi"] },
-    { name = "uvicorn" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.dev-dependencies]
@@ -539,6 +540,7 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "fastmcp", specifier = ">=2.10.5" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "nanoid", specifier = ">=2.0.0" },
     { name = "patchright", specifier = "==1.52.5" },
@@ -548,7 +550,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.4" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.29.1" },
-    { name = "uvicorn", specifier = ">=0.34.2" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Because this web-based VNC needs to run at localhost:8000/live and not at localhost:6080, we can't use the standard built of novnc and websockify anymore.

To verify, first run a VNC server session. The easiest is to use GetGather container itself (note that only port 5900 is mapped, for VNC):

```
docker build -t getgather .
docker run -p 5900:5900 getgather
```

Then run this MCP server locally:
```
uv run -m uvicorn getgather.api.main:app
```

While `localhost:8000` should serve the main GetGather page, now `localhost:8000/live` should display the Linux desktop via VNC.

<img width="1178" height="865" alt="Screenshot 2025-08-04 at 3 04 34 PM" src="https://github.com/user-attachments/assets/237238a0-9f25-4a0d-b0ea-a07cd26fb250" />
