### PR TITLE
docs: Allow HTTP in the MCP config for Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ For Claude Desktop:
       "command": "npx",
       "args": [
         "mcp-remote",
-        "http://127.0.0.1:8000/mcp"
+        "http://127.0.0.1:8000/mcp",
+        "--allow-http"
       ]
     }
   }


### PR DESCRIPTION
Technically this is not needed for localhost or 127.0.0.1, but just in case the user changes it to point to a non-local address, they don't get surprised by the failure and/or need to figure out the solution themselves.