### PR TITLE
Avoid hardcoded log level in the container entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,4 +38,4 @@ dbus-daemon --system --fork
 echo "D-BUS daemon started with pid: $(cat /run/dbus/pid)"
 
 # Start FastAPI server
-/opt/venv/bin/python -m uvicorn getgather.api.main:app --host 0.0.0.0 --port 8000 --log-level debug
+/opt/venv/bin/python -m uvicorn getgather.api.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
This way, `LOG_LEVEL` env can be still honored.