### PR TITLE
Check Git Rev for Tailscale dokku

### DIFF
--- a/.github/workflows/deploy-dokku.yml
+++ b/.github/workflows/deploy-dokku.yml
@@ -40,3 +40,32 @@ jobs:
           git_remote_url: ${{ secrets.DOKKU_GIT_REMOTE_URL }}
           ssh_host_key: ${{ secrets.DOKKU_SSH_HOST_KEY }}
           ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}
+
+      - name: Verify deployment via health endpoint
+        env:
+          APP_URL: ${{ secrets.TAILSCALE_APP_URL }}
+
+        run: |-
+          LOCAL_COMMIT=$(git rev-parse HEAD)
+          echo "Local commit: $LOCAL_COMMIT"
+          echo "App URL: $APP_URL"
+
+          # Check health endpoint and extract git revision
+          HEALTH_RESPONSE=$(curl -s "${APP_URL}/health" || echo "FAILED")
+          echo "Health response: $HEALTH_RESPONSE"
+
+          if [[ "$HEALTH_RESPONSE" == "FAILED" ]]; then
+            echo "Error: Health endpoint is not accessible"
+            exit 1
+          fi
+
+          # Extract git revision from health response (format: "OK <timestamp> GIT_REV: <commit>")
+          REMOTE_COMMIT=$(echo "$HEALTH_RESPONSE" | grep -o "GIT_REV: [a-f0-9]*" | cut -d' ' -f2)
+          echo "Remote commit: $REMOTE_COMMIT"
+
+          if [ "$LOCAL_COMMIT" != "$REMOTE_COMMIT" ]; then
+            echo "Error: Local and remote commits do not match"
+            exit 1
+          fi
+
+          echo "✅ Deployment and health endpoint verified successfully"


### PR DESCRIPTION
Added code here to check the git revision on the container that is actually deployed by dokku and what is in the codebase. Based on the same code that existed in dax. 

I also updated the secrets to match the new container that is being pushed to. Once this is approved I'll turn the action back on so we can see if the deployment succeeds.