### PR TITLE
Autoclick in Office Depot

### DIFF
--- a/getgather/connectors/brand_specs/officedepot/specs.yml
+++ b/getgather/connectors/brand_specs/officedepot/specs.yml
@@ -51,7 +51,7 @@ auth:
       label: label[for="email"]
       expect_nav: false
     - name: send-code-btn
-      type: click
+      type: autoclick
       prompt: Send Code
       selector: button:has-text("Send Code")
     - name: validation-code
@@ -59,7 +59,7 @@ auth:
       prompt: Validation Code
       selector: input[name="validationCode"], input#validation-code-input-element
     - name: validation-btn
-      type: click
+      type: autoclick
       prompt: Validate
       selector: button.validate-code-btn
       expect_nav: true


### PR DESCRIPTION
Make certain "click" fields "autoclick" because we don't need user into to know to click them.