### PR TITLE
refactor: remove unused mcp context

### DIFF
--- a/getgather/mcp/brand/alltrails.py
+++ b/getgather/mcp/brand/alltrails.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-from fastmcp import Context
-
 from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
@@ -10,8 +8,6 @@ alltrails_mcp = BrandMCPBase(prefix="alltrails", name="Alltrails MCP")
 
 
 @alltrails_mcp.tool(tags={"private"})
-async def get_feed(
-    ctx: Context,
-) -> dict[str, Any]:
+async def get_feed() -> dict[str, Any]:
     """Get feed of alltrails."""
     return await extract(brand_id=BrandIdEnum("alltrails"))

--- a/getgather/mcp/brand/amain.py
+++ b/getgather/mcp/brand/amain.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-from fastmcp import Context
-
 from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.connectors.spec_models import Schema as SpecSchema
 from getgather.mcp.registry import BrandMCPBase
@@ -12,9 +10,7 @@ amain_mcp = BrandMCPBase(prefix="amain", name="Amain MCP")
 
 
 @amain_mcp.tool(tags={"private"})
-async def get_cart(
-    ctx: Context,
-) -> dict[str, Any]:
+async def get_cart() -> dict[str, Any]:
     """Get cart of amain."""
 
     browser_session = await start_browser_session(brand_id=BrandIdEnum("amain"))

--- a/getgather/mcp/brand/amazon.py
+++ b/getgather/mcp/brand/amazon.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-from fastmcp import Context
-
 from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.connectors.spec_models import Schema as SpecSchema
 from getgather.mcp.registry import BrandMCPBase
@@ -12,9 +10,7 @@ amazon_mcp = BrandMCPBase(prefix="amazon", name="Amazon MCP")
 
 
 @amazon_mcp.tool(tags={"private"})
-async def get_purchase_history(
-    ctx: Context,
-) -> dict[str, Any]:
+async def get_purchase_history() -> dict[str, Any]:
     """Get purchase/order history of a amazon."""
     return await extract(brand_id=BrandIdEnum("amazon"))
 
@@ -22,7 +18,6 @@ async def get_purchase_history(
 @amazon_mcp.tool
 async def search_product(
     keyword: str,
-    ctx: Context,
 ) -> dict[str, Any]:
     """Search product on amazon."""
     browser_session = await start_browser_session(brand_id=BrandIdEnum("amazon"))
@@ -54,7 +49,6 @@ async def search_product(
 @amazon_mcp.tool
 async def get_product_detail(
     product_url: str,
-    ctx: Context,
 ) -> dict[str, Any]:
     """Get product detail from amazon."""
     browser_session = await start_browser_session(brand_id=BrandIdEnum("amazon"))
@@ -70,9 +64,7 @@ async def get_product_detail(
 
 
 @amazon_mcp.tool(tags={"private"})
-async def get_cart_summary(
-    ctx: Context,
-) -> dict[str, Any]:
+async def get_cart_summary() -> dict[str, Any]:
     """Get cart summary from amazon."""
     browser_session = await start_browser_session(brand_id=BrandIdEnum("amazon"))
     page = await browser_session.page()
@@ -84,9 +76,7 @@ async def get_cart_summary(
 
 
 @amazon_mcp.tool(tags={"private"})
-async def get_browsing_history(
-    ctx: Context,
-) -> dict[str, Any]:
+async def get_browsing_history() -> dict[str, Any]:
     """Get browsing history from amazon."""
     browser_session = await start_browser_session(brand_id=BrandIdEnum("amazon"))
     page = await browser_session.page()

--- a/getgather/mcp/brand/bbc.py
+++ b/getgather/mcp/brand/bbc.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-from fastmcp import Context
-
 from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
@@ -10,8 +8,6 @@ bbc_mcp = BrandMCPBase(prefix="bbc", name="BBC MCP")
 
 
 @bbc_mcp.tool(tags={"private"})
-async def get_bookmarks(
-    ctx: Context,
-) -> dict[str, Any]:
+async def get_bookmarks() -> dict[str, Any]:
     """Get bookmarks of bbc."""
     return await extract(brand_id=BrandIdEnum("bbc"))

--- a/getgather/mcp/brand/cnn.py
+++ b/getgather/mcp/brand/cnn.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-from fastmcp import Context
-
 from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
@@ -10,8 +8,6 @@ cnn_mcp = BrandMCPBase(prefix="cnn", name="CNN MCP")
 
 
 @cnn_mcp.tool(tags={"private"})
-async def get_newsletter(
-    ctx: Context,
-) -> dict[str, Any]:
+async def get_newsletter() -> dict[str, Any]:
     """Get bookmarks of cnn."""
     return await extract(brand_id=BrandIdEnum("cnn"))

--- a/getgather/mcp/brand/ebird.py
+++ b/getgather/mcp/brand/ebird.py
@@ -16,7 +16,9 @@ async def get_life_list() -> dict[str, Any]:
 
 
 @ebird_mcp.tool
-async def get_explore_species_list(keyword: str) -> dict[str, Any]:
+async def get_explore_species_list(
+    keyword: str,
+) -> dict[str, Any]:
     """Get species list from ebird to be explored."""
     browser_session = await start_browser_session(brand_id=BrandIdEnum("ebird"))
     page = await browser_session.page()
@@ -42,7 +44,9 @@ async def get_explore_species_list(keyword: str) -> dict[str, Any]:
 
 
 @ebird_mcp.tool
-async def explore_species(sci_name: str) -> dict[str, Any]:
+async def explore_species(
+    sci_name: str,
+) -> dict[str, Any]:
     """Explore species on Ebird from get_explore_species_list."""
     browser_session = await start_browser_session(brand_id=BrandIdEnum("ebird"))
     page = await browser_session.page()
@@ -53,6 +57,6 @@ async def explore_species(sci_name: str) -> dict[str, Any]:
     species_statistic_html = await page.locator("div.Species-regionalData-stats").inner_html()
     return {
         "species_description_html": species_description_html,
-        "species_description_html": species_identification_html,
-        "species_description_html": species_statistic_html,
+        "species_identification_html": species_identification_html,
+        "species_statistic_html": species_statistic_html,
     }

--- a/getgather/mcp/brand/shopee.py
+++ b/getgather/mcp/brand/shopee.py
@@ -1,8 +1,6 @@
 from typing import Any
 from urllib.parse import quote
 
-from fastmcp import Context
-
 from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.connectors.spec_models import Schema as SpecSchema
 from getgather.mcp.registry import BrandMCPBase
@@ -13,16 +11,13 @@ shopee_mcp = BrandMCPBase(prefix="shopee", name="Shopee MCP")
 
 
 @shopee_mcp.tool(tags={"private"})
-async def get_purchase_history(
-    ctx: Context,
-) -> dict[str, Any]:
+async def get_purchase_history() -> dict[str, Any]:
     """Get purchase history of a shopee."""
     return await extract(brand_id=BrandIdEnum("shopee"))
 
 
 @shopee_mcp.tool
 async def search_product(
-    ctx: Context,
     keyword: str,
     page_number: int = 1,
 ) -> dict[str, Any]:

--- a/getgather/mcp/brand/tokopedia.py
+++ b/getgather/mcp/brand/tokopedia.py
@@ -2,8 +2,6 @@ import json
 from typing import Any
 from urllib.parse import quote, urlparse
 
-from fastmcp import Context
-
 from getgather.actions import handle_graphql_response
 from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.connectors.spec_models import Schema as SpecSchema
@@ -16,7 +14,6 @@ tokopedia_mcp = BrandMCPBase(prefix="tokopedia", name="Tokopedia MCP")
 
 @tokopedia_mcp.tool
 async def search_product(
-    ctx: Context,
     keyword: str,
 ) -> dict[str, Any]:
     """Search product on tokopedia."""
@@ -50,7 +47,6 @@ async def search_product(
 
 @tokopedia_mcp.tool
 async def get_product_details(
-    ctx: Context,
     product_url: str,
 ) -> dict[str, Any]:
     """Get product details from tokopedia. Get product_url from search_product tool."""
@@ -96,7 +92,6 @@ async def get_product_details(
 
 @tokopedia_mcp.tool
 async def search_shop(
-    ctx: Context,
     keyword: str,
 ) -> dict[str, Any]:
     """Search shop on tokopedia."""
@@ -151,7 +146,6 @@ async def search_shop(
 
 @tokopedia_mcp.tool
 async def get_shop_details(
-    ctx: Context,
     product_url: str | None = None,
     shop_url: str | None = None,
 ) -> dict[str, Any]:
@@ -223,7 +217,6 @@ async def get_shop_details(
 
 @tokopedia_mcp.tool(tags={"private"})
 async def get_purchase_history(
-    ctx: Context,
     page_number: int = 1,
 ) -> dict[str, Any]:
     """Get purchase history of a tokopedia."""
@@ -271,9 +264,7 @@ async def get_purchase_history(
 
 
 @tokopedia_mcp.tool(tags={"private"})
-async def get_cart(
-    ctx: Context,
-) -> dict[str, Any]:
+async def get_cart() -> dict[str, Any]:
     """Get cart of a tokopedia."""
 
     browser_session = await start_browser_session(brand_id=BrandIdEnum("tokopedia"))
@@ -316,7 +307,6 @@ async def get_cart(
 
 @tokopedia_mcp.tool(tags={"private"})
 async def get_wishlist(
-    ctx: Context,
     page_number: int = 1,
 ) -> dict[str, Any]:
     """Get purchase history of a tokopedia."""


### PR DESCRIPTION
- remove unused mcp context, since we didn't use session_id from the context
- fix typo on ebird tool