### PR TITLE
Live view: automatically scale to the browser window

### DIFF
--- a/getgather/api/frontend/live.html
+++ b/getgather/api/frontend/live.html
@@ -162,7 +162,7 @@
 
       // Set parameters that can be changed on an active connection
       rfb.viewOnly = readQueryVariable("view_only", false);
-      rfb.scaleViewport = readQueryVariable("scale", false);
+      rfb.scaleViewport = readQueryVariable("scale", true);
     </script>
   </head>
 


### PR DESCRIPTION
This way, there is no need to zoom out manually.

To verify, build and run with Docker/Podman as usual:

```
podman build -t getgather .
podman run -p 8000:8000 --rm --name getgather getgather
```

and then open `localhost:8000`.

The whole desktop should be visible, scaled down as necessary to fit the browser window. Try resizing the browser window and the desktop will continue to scale up and down automatically.