### PR TITLE
MCP Inspector in the GetGather UI

### DIFF
--- a/getgather/api/frontend/old-index.html
+++ b/getgather/api/frontend/old-index.html
@@ -136,6 +136,7 @@
           type="text"
           placeholder="Search brand"
         />
+        <a href="/inspector" role="button" target="_blank" rel="noopener noreferrer">MCP Inspector</a>
       </aside>
       <main class="main-content">
         <div


### PR DESCRIPTION
This PR adds a new `/inspector` endpoint to the GetGather homepage (via a side panel button) that opens a running MCP inspector page in a new tab that is hooked up to our `/mcp` mount automatically. 

It works locally only (not sure if it would work in a published container) since it needs to run an npx command to access the MCP inspector's node. We redirect the browser to the Inspector’s UI with a token and the server URL prefilled, so it auto-connects to our MCP server at `/mcp`.

I tried it out and got it working on various tools in our MCP arsenal, and it was actually really cool. If you try it out make sure to wait a second after the clicking the button, as the inspector has to spin up first.

Disclaimer: I had GPT-5 write this code in cursor, so while it works (beautifully), I had to chat with it quite a bit afterward to understand what it did. I'm not a web expert so someone with a keener eye for this stuff should take a close look at the code and see how well it did.