### PR TITLE
chore: add volta pin to specific nodejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "mcp-getgather",
   "version": "0.0.0",
   "type": "module",
+  "volta": {
+    "node": "22.18.0",
+    "npm": "10.8.2"
+  },
   "scripts": {
     "predev": "npm run build",
     "dev": "concurrently \"npm run dev:backend\" \"npm run dev:frontend\"",


### PR DESCRIPTION
Since we need to make sure everyone’s using the same Node version (and not everyone’s on Nix), I added a Volta pin so it automatically uses the right version.