### PR TITLE
Add Kindle spec and mcp

### DIFF
--- a/getgather/connectors/brand_specs/kindle/specs.yml
+++ b/getgather/connectors/brand_specs/kindle/specs.yml
@@ -1,0 +1,45 @@
+name: Kindle
+auth:
+  fields:
+    - name: email
+      type: text
+      prompt: Email
+      selector: input#ap_email
+    - name: password
+      type: password
+      prompt: Password
+      selector: input#ap_password
+    - name: sign_in
+      type: click
+      prompt: Sign In
+      selector: input#signInSubmit
+    - name: content_page_title
+      type: wait
+      selector: div#content-page-title
+  pages:
+    - name: Sign in page
+      fields: [email, password, sign_in]
+    - name: Content page
+      fields: [content_page_title]
+      end: true
+  start: https://www.amazon.com/hz/mycd/digital-console/contentlist/booksAll/dateDsc/
+extract:
+  steps:
+    - name: Go to Content page
+      url: https://www.amazon.com/hz/mycd/digital-console/contentlist/booksAll/dateDsc/
+    - name: Extract the list of books
+      bundle: books.html
+      slurp_selector: div#CONTENT_LIST
+parse:
+  - bundle: books.html
+    format: html
+    output: books.json
+    row_selector: td > div
+    columns:
+      - name: cover
+        selector: div[id^=content-image-] img
+        attribute: src
+      - name: title
+        selector: div[id^=content-title-]
+      - name: author
+        selector: div[id^=content-author-]

--- a/getgather/flow.py
+++ b/getgather/flow.py
@@ -412,9 +412,10 @@ async def flow_step(*, page: Page, flow_state: FlowState) -> FlowState:
     if step.bundle:
         if step.slurp_selector:
             logger.info(f"📦 Slurping and packaging {step.slurp_selector}...")
-            content = await page.eval_on_selector_all(
-                step.slurp_selector,
-                'elements => elements.map(element => element.innerHTML).join("")',
+            locator = page.locator(step.slurp_selector)
+            await locator.wait_for(state="visible")
+            content = await locator.evaluate_all(
+                'elements => elements.map(element => element.innerHTML).join("")'
             )
             bundle = Bundle(name=step.bundle, content=content)
             logger.info(f"📦 {step.bundle} is {len(content)} bytes.")

--- a/getgather/mcp/brand/kindle.py
+++ b/getgather/mcp/brand/kindle.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+from getgather.connectors.spec_loader import BrandIdEnum
+from getgather.mcp.registry import BrandMCPBase
+from getgather.mcp.shared import extract
+
+kindle_mcp = BrandMCPBase(prefix="kindle", name="Kindle MCP")
+
+
+@kindle_mcp.tool(tags={"private"})
+async def get_book_list() -> dict[str, Any]:
+    """Get book list from Amazon Kindle."""
+    return await extract(BrandIdEnum("kindle"))


### PR DESCRIPTION
Explicitly wait for `slurp_selector` so extraction is more reliable

TODO: need a different way to extract url since there is no `<a>` tag on the page

Verified Kindle auth and extraction with Claude Desktop