### PR TITLE
add toggle for blocking unwanted resources (e.g. images)

### DIFF
--- a/getgather/auth_orchestrator.py
+++ b/getgather/auth_orchestrator.py
@@ -81,9 +81,9 @@ class AuthOrchestrator:
                 await browser_session.start()
 
             page = await browser_session.page()
-
-            # For now block the images etc
-            await self._block_unwanted_resources(page)
+            if settings.SHOULD_BLOCK_UNWANTED_RESOURCES:
+                # For now block the images etc
+                await self._block_unwanted_resources(page)
         except BrowserStartupError as e:
             sentry_sdk.capture_exception(e)
             raise

--- a/getgather/config.py
+++ b/getgather/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     BUNDLES_DIR: str = ""
     SCREENSHOTS_DIR: str = ""
     HEADLESS: bool = False
+    SHOULD_BLOCK_UNWANTED_RESOURCES: bool = False
 
     # Browser-use settings
     BROWSER_USE_MODEL: str = "o4-mini"


### PR DESCRIPTION
We may eventually want to block images etc at the proxy service level but first stab it doesn't seem to be as simple as I thought. 

This is a nice ratchet and we can eventually followup with that.