### PR TITLE
Make uvicorn logging use all terminal width

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "predev": "npm run build",
-    "dev": "concurrently \"npm run dev:backend\" \"npm run dev:frontend\"",
+    "dev": "concurrently --raw \"npm run dev:backend\" \"npm run dev:frontend\"",
     "dev:backend": "uv run -m uvicorn getgather.api.main:app --reload --host 127.0.0.1 --port 8000",
     "dev:frontend": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
Disable `concurrently` formatting so that uvicorn can print out to entire terminal width, otherwise it's limited to 80 characters

We will need to distinguish backend and front logs by the format, which isn't too bad