### PR TITLE
rename GetGather Portal to GetGather Station

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="GetGather" />
-    <title>GetGather</title>
+    <title>GetGather Station</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -13,7 +13,7 @@ export default function Layout() {
           <div className="flex items-center gap-2">
             <div className="w-2 h-2 bg-green-400 rounded-full"></div>
             <span className="text-sm">
-              Come to GetGather Portal to help your agent when it gets stuck
+              Come to GetGather Station to help your agent when it gets stuck
               with access
             </span>
           </div>
@@ -33,7 +33,7 @@ export default function Layout() {
             GG
           </div>
           <h1 className="text-2xl font-bold text-slate-800">
-            GetGather Portal
+            GetGather Station
           </h1>
         </div>
       </header>

--- a/frontend/src/pages/GetStarted.tsx
+++ b/frontend/src/pages/GetStarted.tsx
@@ -6,7 +6,7 @@ export default function GetStarted() {
   return (
     <div className="max-w-4xl mx-auto px-6 py-8">
       <PageHeader
-        title="Welcome to GetGather Portal"
+        title="Welcome to GetGather Station"
         description="Bridge the gap between AI agents and real-world data. Get started in 3 simple steps! See getgather operations in Live View and weigh in as needed."
         badge={{
           text: "AI-Powered Data Access",

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -103,7 +103,7 @@ export default function Settings() {
         <div>
           <h1 className="text-3xl font-semibold tracking-tight">Settings</h1>
           <p className="text-muted-foreground mt-1">
-            Configure GetGather Portal to work with your preferred tools and
+            Configure GetGather Station to work with your preferred tools and
             data sources
           </p>
         </div>


### PR DESCRIPTION
updating the name of the getgather portal to be "GetGather Station" instead of "GetGather Studio", simply because studio is used at different places already and internally confusing.