### PR TITLE
fix: Dockerfile, pinning docker base image to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY pyproject.toml uv.lock* ./
 # Install dependencies without workspace members
 RUN uv sync --no-dev --no-install-workspace
 
-# Pre-install fonts - playwright --with-deps tries to install deprecated packages
+# Pre-install fonts - playwright --with-deps tries to install deprecated packages.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-unifont \
     fonts-liberation \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-
 ENV PATH="/root/.local/bin:$PATH"
 
 ENV PYTHONUNBUFFERED=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,13 @@ COPY pyproject.toml uv.lock* ./
 # Install dependencies without workspace members
 RUN uv sync --no-dev --no-install-workspace
 
-# Install Playwright browsers only for full deployment
+# Pre-install fonts - playwright --with-deps tries to install deprecated packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    fonts-unifont \
+    fonts-liberation \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Playwright browsers only for full deployment  
 # so it can be copied to the final stage easily.
 ENV PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright

--- a/test
+++ b/test
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Test file for CI testing
+echo "Running CI test..."
+echo "Test completed successfully"
+exit 0

--- a/test
+++ b/test
@@ -1,5 +1,0 @@
-#!/bin/bash
-# Test file for CI testing
-echo "Running CI test..."
-echo "Test completed successfully"
-exit 0


### PR DESCRIPTION
## Summary
- Debian 13 "Trixie" was released Aug 9, 2025. Python 3.13-slim images started using Trixie by default, but Playwright doesn't support it yet and tries to install deprecated font packages.


## Before
<img width="543" height="620" alt="image" src="https://github.com/user-attachments/assets/96ee8c32-8999-4a76-aae9-b5ab9fbe2a13" />

## After
<img width="958" height="669" alt="image" src="https://github.com/user-attachments/assets/15a64975-ad46-4694-befc-876a16981e0e" />
