### PR TITLE
Wait on Office Depot 2FA page

### DIFF
--- a/getgather/connectors/brand_specs/officedepot/specs.yml
+++ b/getgather/connectors/brand_specs/officedepot/specs.yml
@@ -3,7 +3,7 @@ name: Office Depot
 auth:
   fields:
     - name: dismiss_cookies
-      type: click
+      type: autoclick
       prompt: Accept cookies
       selector: '#onetrust-accept-btn-handler'
       expect_nav: false
@@ -71,6 +71,8 @@ auth:
     - name: welcome-text
       type: wait
       selector: div.od-container:has-text("Welcome")
+    - name: sleep
+      type: wait
 
   pages:
     - name: Log in
@@ -90,13 +92,13 @@ auth:
         groups:
           - name: text
             prompt: Text Message (SMS)
-            fields: [text-radio-btn, send-code-btn]
+            fields: [text-radio-btn, send-code-btn, sleep]
           - name: voice
             prompt: Voice
-            fields: [voice-radio-btn, send-code-btn]
+            fields: [voice-radio-btn, send-code-btn, sleep]
           - name: email
             prompt: Email
-            fields: [email-radio-btn, send-code-btn]
+            fields: [email-radio-btn, send-code-btn, sleep]
     - name: 2FA code page
       fields: [validation-code, validation-btn]
     - name: Home page

--- a/getgather/connectors/spec_models.py
+++ b/getgather/connectors/spec_models.py
@@ -189,12 +189,12 @@ class FieldYML(YMLModel):
             assert self.url is not None, "URL is required for navigate field"
             assert self.expect_nav is not False, "expect_nav must be True for navigate field"
             return self
-        elif self.type != "selection":
+        elif self.type not in ["selection", "wait"]:
             # For normal interactive fields exactly one of selector/selectors is required.
             # Dynamic "selection" fields derive their target via ``option_items`` at runtime,
             # so they are exempt.
             assert bool(self.selector) ^ bool(self.selectors), (
-                "One and only one of selector and selectors must be provided for non-navigate fields"
+                "One and only one of selector and selectors must be provided for non-navigate and non-wait fields"
             )
         return self
 

--- a/getgather/flow.py
+++ b/getgather/flow.py
@@ -385,6 +385,8 @@ async def flow_step(*, page: Page, flow_state: FlowState) -> FlowState:
                     raise ValueError(f"⚠️ No selector provided for {field.name}")
             elif field.type == "wait" and field.selector:
                 await wait_for_selector(current_page, field.selector, timeout=timeout)
+            elif field.type == "wait" and not field.selector:
+                await page.wait_for_timeout(4000)
             elif field.selectors:
                 await handle_fill_multi(current_page, field, value)
             elif field.selector:


### PR DESCRIPTION
Adds a 4 second wait to the end of the 2FA method selection screen because after clicking submit we are auto-detecting the "next" page too quickly, before giving it a change to move on. This kept us stuck on the method selection while the actual page moved to code entry. Now we sleep for 4 seconds after submitting our choice to give the page time to load the code entry screen.