### PR TITLE
Create separate mcp servers for different bundles of brands and tools

### DIFF
--- a/getgather/api/main.py
+++ b/getgather/api/main.py
@@ -1,6 +1,6 @@
 import asyncio
 import socket
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 from datetime import datetime
 from os import path
 from typing import Final
@@ -21,10 +21,10 @@ from getgather.config import settings
 from getgather.database.migrate import run_migration
 from getgather.hosted_link_manager import HostedLinkManager
 from getgather.logs import logger
-from getgather.mcp.main import create_mcp_app
+from getgather.mcp.main import create_mcp_apps
 
-# Create MCP app once and reuse for lifespan and mounting
-mcp_app = create_mcp_app()
+# Create MCP apps once and reuse for lifespan and mounting
+mcp_apps = create_mcp_apps()
 from getgather.startup import startup
 
 # Run database migrations
@@ -39,7 +39,9 @@ def custom_generate_unique_id(route: APIRoute) -> str:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await startup()
-    async with mcp_app.lifespan(app):  # type: ignore
+    async with AsyncExitStack() as stack:
+        for mcp_app in mcp_apps.values():
+            await stack.enter_async_context(mcp_app.lifespan(app))  # type: ignore
         yield
 
 
@@ -238,4 +240,6 @@ async def extended_health():
 app.include_router(brands_router)
 app.include_router(auth_router)
 app.include_router(link_router)
-app.mount("/mcp", mcp_app)
+for bundle_name, mcp_app in mcp_apps.items():
+    route_name = "/mcp" if bundle_name == "all" else f"/mcp-{bundle_name}"
+    app.mount(route_name, mcp_app)

--- a/getgather/mcp/brand/alltrails.py
+++ b/getgather/mcp/brand/alltrails.py
@@ -1,13 +1,12 @@
 from typing import Any
 
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
 
-alltrails_mcp = BrandMCPBase(prefix="alltrails", name="Alltrails MCP")
+alltrails_mcp = BrandMCPBase(brand_id="alltrails", name="Alltrails MCP")
 
 
 @alltrails_mcp.tool(tags={"private"})
 async def get_feed() -> dict[str, Any]:
     """Get feed of alltrails."""
-    return await extract(brand_id=BrandIdEnum("alltrails"))
+    return await extract(brand_id=alltrails_mcp.brand_id)

--- a/getgather/mcp/brand/amain.py
+++ b/getgather/mcp/brand/amain.py
@@ -1,26 +1,25 @@
 from typing import Any
 
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.connectors.spec_models import Schema as SpecSchema
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import start_browser_session, stop_browser_session
 from getgather.parse import parse_html
 
-amain_mcp = BrandMCPBase(prefix="amain", name="Amain MCP")
+amain_mcp = BrandMCPBase(brand_id="amain", name="Amain MCP")
 
 
 @amain_mcp.tool(tags={"private"})
 async def get_cart() -> dict[str, Any]:
     """Get cart of amain."""
 
-    browser_session = await start_browser_session(brand_id=BrandIdEnum("amain"))
+    browser_session = await start_browser_session(brand_id=amain_mcp.brand_id)
     page = await browser_session.page()
 
     await page.goto(f"https://www.amainhobbies.com/shopping-cart")
     await page.wait_for_selector("div.product-list")
     await page.wait_for_timeout(1000)
     html = await page.locator("div.product-list").inner_html()
-    await stop_browser_session(brand_id=BrandIdEnum("amain"))
+    await stop_browser_session(brand_id=amain_mcp.brand_id)
     spec_schema = SpecSchema.model_validate({
         "bundle": "",
         "format": "html",
@@ -32,5 +31,5 @@ async def get_cart() -> dict[str, Any]:
             {"name": "total_price", "selector": "div.total"},
         ],
     })
-    result = await parse_html(brand_id=BrandIdEnum("amain"), html_content=html, schema=spec_schema)
+    result = await parse_html(brand_id=amain_mcp.brand_id, html_content=html, schema=spec_schema)
     return {"cart_data": result.content}

--- a/getgather/mcp/brand/amazon.py
+++ b/getgather/mcp/brand/amazon.py
@@ -2,20 +2,19 @@ from typing import Any
 
 from getgather.browser.profile import BrowserProfile
 from getgather.browser.session import browser_session
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.connectors.spec_models import Schema as SpecSchema
 from getgather.database.repositories.brand_state_repository import BrandState
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract, start_browser_session
 from getgather.parse import parse_html
 
-amazon_mcp = BrandMCPBase(prefix="amazon", name="Amazon MCP")
+amazon_mcp = BrandMCPBase(brand_id="amazon", name="Amazon MCP")
 
 
 @amazon_mcp.tool(tags={"private"})
 async def get_purchase_history() -> dict[str, Any]:
     """Get purchase/order history of a amazon."""
-    return await extract(brand_id=BrandIdEnum("amazon"))
+    return await extract(brand_id=amazon_mcp.brand_id)
 
 
 @amazon_mcp.tool
@@ -23,8 +22,8 @@ async def search_product(
     keyword: str,
 ) -> dict[str, Any]:
     """Search product on amazon."""
-    if BrandState.is_brand_connected(BrandIdEnum("amazon")):
-        profile_id = BrandState.get_browser_profile_id(BrandIdEnum("amazon"))
+    if BrandState.is_brand_connected(amazon_mcp.brand_id):
+        profile_id = BrandState.get_browser_profile_id(amazon_mcp.brand_id)
         profile = BrowserProfile(id=profile_id) if profile_id else BrowserProfile()
     else:
         profile = BrowserProfile()
@@ -51,7 +50,7 @@ async def search_product(
             {"name": "reviews", "selector": "div[data-cy='reviews-block']"},
         ],
     })
-    result = await parse_html(brand_id=BrandIdEnum("amazon"), html_content=html, schema=spec_schema)
+    result = await parse_html(brand_id=amazon_mcp.brand_id, html_content=html, schema=spec_schema)
     return {"product_list": result.content}
 
 
@@ -60,8 +59,8 @@ async def get_product_detail(
     product_url: str,
 ) -> dict[str, Any]:
     """Get product detail from amazon."""
-    if BrandState.is_brand_connected(BrandIdEnum("amazon")):
-        profile_id = BrandState.get_browser_profile_id(BrandIdEnum("amazon"))
+    if BrandState.is_brand_connected(amazon_mcp.brand_id):
+        profile_id = BrandState.get_browser_profile_id(amazon_mcp.brand_id)
         profile = BrowserProfile(id=profile_id) if profile_id else BrowserProfile()
     else:
         profile = BrowserProfile()
@@ -81,7 +80,7 @@ async def get_product_detail(
 @amazon_mcp.tool(tags={"private"})
 async def get_cart_summary() -> dict[str, Any]:
     """Get cart summary from amazon."""
-    browser_session = await start_browser_session(brand_id=BrandIdEnum("amazon"))
+    browser_session = await start_browser_session(brand_id=amazon_mcp.brand_id)
     page = await browser_session.page()
     await page.goto("https://www.amazon.com/gp/cart/view.html")
     await page.wait_for_selector("div#sc-active-cart")
@@ -93,7 +92,7 @@ async def get_cart_summary() -> dict[str, Any]:
 @amazon_mcp.tool(tags={"private"})
 async def get_browsing_history() -> dict[str, Any]:
     """Get browsing history from amazon."""
-    browser_session = await start_browser_session(brand_id=BrandIdEnum("amazon"))
+    browser_session = await start_browser_session(brand_id=amazon_mcp.brand_id)
     page = await browser_session.page()
     await page.goto("https://www.amazon.com/gp/history?ref_=nav_AccountFlyout_browsinghistory")
     await page.wait_for_timeout(1000)

--- a/getgather/mcp/brand/astro.py
+++ b/getgather/mcp/brand/astro.py
@@ -5,14 +5,13 @@ from patchright.async_api import Locator, Page
 
 from getgather.browser.profile import BrowserProfile
 from getgather.browser.session import browser_session
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.connectors.spec_models import Schema as SpecSchema
 from getgather.database.repositories.brand_state_repository import BrandState
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
 from getgather.parse import parse_html
 
-astro_mcp = BrandMCPBase(prefix="astro", name="Astro MCP")
+astro_mcp = BrandMCPBase(brand_id="astro", name="Astro MCP")
 
 
 async def _adjust_quantity_with_detection(
@@ -166,7 +165,7 @@ def _format_quantity_result(
 @astro_mcp.tool(tags={"private"})
 async def get_purchase_history() -> dict[str, Any]:
     """Get astro purchase history."""
-    return await extract(brand_id=BrandIdEnum("astro"))
+    return await extract(brand_id=astro_mcp.brand_id)
 
 
 @astro_mcp.tool
@@ -174,8 +173,8 @@ async def search_product(
     keyword: str,
 ) -> dict[str, Any]:
     """Search product on astro."""
-    if BrandState.is_brand_connected(BrandIdEnum("astro")):
-        profile_id = BrandState.get_browser_profile_id(BrandIdEnum("astro"))
+    if BrandState.is_brand_connected(astro_mcp.brand_id):
+        profile_id = BrandState.get_browser_profile_id(astro_mcp.brand_id)
         profile = BrowserProfile(id=profile_id) if profile_id else BrowserProfile()
     else:
         profile = BrowserProfile()
@@ -217,7 +216,7 @@ async def search_product(
             {"name": "stock_status", "selector": "span.MuiTypography-caption-tiny.css-1lb2yr7"},
         ],
     })
-    result = await parse_html(brand_id=BrandIdEnum("astro"), html_content=html, schema=spec_schema)
+    result = await parse_html(brand_id=astro_mcp.brand_id, html_content=html, schema=spec_schema)
     return {"product_list": result.content}
 
 
@@ -226,8 +225,8 @@ async def get_product_details(
     product_url: str,
 ) -> dict[str, Any]:
     """Get product detail from astro. Get product_url from search_product tool."""
-    if BrandState.is_brand_connected(BrandIdEnum("astro")):
-        profile_id = BrandState.get_browser_profile_id(BrandIdEnum("astro"))
+    if BrandState.is_brand_connected(astro_mcp.brand_id):
+        profile_id = BrandState.get_browser_profile_id(astro_mcp.brand_id)
         profile = BrowserProfile(id=profile_id) if profile_id else BrowserProfile()
     else:
         profile = BrowserProfile()
@@ -266,7 +265,7 @@ async def get_product_details(
             {"name": "add_to_cart_available", "selector": "button[data-testid='pdp-atc-btn']"},
         ],
     })
-    result = await parse_html(brand_id=BrandIdEnum("astro"), html_content=html, schema=spec_schema)
+    result = await parse_html(brand_id=astro_mcp.brand_id, html_content=html, schema=spec_schema)
 
     product_details: dict[str, Any] = (
         result.content[0] if result.content and len(result.content) > 0 else {}
@@ -281,7 +280,7 @@ async def add_item_to_cart(
     quantity: int = 1,
 ) -> dict[str, Any]:
     """Add item to cart on astro (add new item or update existing quantity). Get product_url from search_product tool."""
-    profile_id = BrandState.get_browser_profile_id(BrandIdEnum("astro"))
+    profile_id = BrandState.get_browser_profile_id(astro_mcp.brand_id)
     profile = BrowserProfile(id=profile_id) if profile_id else BrowserProfile()
 
     # Ensure the product URL is a full URL
@@ -354,7 +353,7 @@ async def update_cart_quantity(
     quantity: int,
 ) -> dict[str, Any]:
     """Update cart item quantity on astro (set quantity to 0 to remove item). Use product name from cart summary."""
-    profile_id = BrandState.get_browser_profile_id(BrandIdEnum("astro"))
+    profile_id = BrandState.get_browser_profile_id(astro_mcp.brand_id)
     profile = BrowserProfile(id=profile_id) if profile_id else BrowserProfile()
 
     async with browser_session(profile) as session:
@@ -409,7 +408,7 @@ async def update_cart_quantity(
 @astro_mcp.tool(tags={"private"})
 async def get_cart_summary() -> dict[str, Any]:
     """Get cart summary from astro."""
-    profile_id = BrandState.get_browser_profile_id(BrandIdEnum("astro"))
+    profile_id = BrandState.get_browser_profile_id(astro_mcp.brand_id)
     profile = BrowserProfile(id=profile_id) if profile_id else BrowserProfile()
 
     async with browser_session(profile) as session:
@@ -451,7 +450,7 @@ async def get_cart_summary() -> dict[str, Any]:
     })
 
     available_items_result = await parse_html(
-        brand_id=BrandIdEnum("astro"), html_content=html, schema=available_items_schema
+        brand_id=astro_mcp.brand_id, html_content=html, schema=available_items_schema
     )
 
     # Extract unavailable items
@@ -474,7 +473,7 @@ async def get_cart_summary() -> dict[str, Any]:
     })
 
     unavailable_items_result = await parse_html(
-        brand_id=BrandIdEnum("astro"), html_content=html, schema=unavailable_items_schema
+        brand_id=astro_mcp.brand_id, html_content=html, schema=unavailable_items_schema
     )
 
     # Extract totals
@@ -500,7 +499,7 @@ async def get_cart_summary() -> dict[str, Any]:
     })
 
     summary_result = await parse_html(
-        brand_id=BrandIdEnum("astro"), html_content=html, schema=summary_schema
+        brand_id=astro_mcp.brand_id, html_content=html, schema=summary_schema
     )
 
     # Extract final total
@@ -519,7 +518,7 @@ async def get_cart_summary() -> dict[str, Any]:
     })
 
     total_result = await parse_html(
-        brand_id=BrandIdEnum("astro"), html_content=html, schema=total_schema
+        brand_id=astro_mcp.brand_id, html_content=html, schema=total_schema
     )
 
     # Process available items

--- a/getgather/mcp/brand/audible.py
+++ b/getgather/mcp/brand/audible.py
@@ -1,13 +1,12 @@
 from typing import Any
 
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
 
-audible_mcp = BrandMCPBase(prefix="audible", name="Audible MCP")
+audible_mcp = BrandMCPBase(brand_id="audible", name="Audible MCP")
 
 
 @audible_mcp.tool(tags={"private"})
 async def get_book_list() -> dict[str, Any]:
     """Get book list from Audible.com."""
-    return await extract(BrandIdEnum("audible"))
+    return await extract(audible_mcp.brand_id)

--- a/getgather/mcp/brand/bbc.py
+++ b/getgather/mcp/brand/bbc.py
@@ -1,13 +1,12 @@
 from typing import Any
 
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
 
-bbc_mcp = BrandMCPBase(prefix="bbc", name="BBC MCP")
+bbc_mcp = BrandMCPBase(brand_id="bbc", name="BBC MCP")
 
 
 @bbc_mcp.tool(tags={"private"})
 async def get_bookmarks() -> dict[str, Any]:
     """Get bookmarks of bbc."""
-    return await extract(brand_id=BrandIdEnum("bbc"))
+    return await extract(brand_id=bbc_mcp.brand_id)

--- a/getgather/mcp/brand/cnn.py
+++ b/getgather/mcp/brand/cnn.py
@@ -1,13 +1,12 @@
 from typing import Any
 
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
 
-cnn_mcp = BrandMCPBase(prefix="cnn", name="CNN MCP")
+cnn_mcp = BrandMCPBase(brand_id="cnn", name="CNN MCP")
 
 
 @cnn_mcp.tool(tags={"private"})
 async def get_newsletter() -> dict[str, Any]:
     """Get bookmarks of cnn."""
-    return await extract(brand_id=BrandIdEnum("cnn"))
+    return await extract(brand_id=cnn_mcp.brand_id)

--- a/getgather/mcp/brand/doordash.py
+++ b/getgather/mcp/brand/doordash.py
@@ -1,13 +1,12 @@
 from typing import Any
 
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
 
-doordash_mcp = BrandMCPBase(prefix="doordash", name="Doordash MCP")
+doordash_mcp = BrandMCPBase(brand_id="doordash", name="Doordash MCP")
 
 
 @doordash_mcp.tool(tags={"private"})
 async def get_orders() -> dict[str, Any]:
     """Get orders from Doordash.com."""
-    return await extract(BrandIdEnum("doordash"))
+    return await extract(brand_id=doordash_mcp.brand_id)

--- a/getgather/mcp/brand/ebird.py
+++ b/getgather/mcp/brand/ebird.py
@@ -2,20 +2,19 @@ from typing import Any
 
 from getgather.browser.profile import BrowserProfile
 from getgather.browser.session import browser_session
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.connectors.spec_models import Schema as SpecSchema
 from getgather.database.repositories.brand_state_repository import BrandState
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
 from getgather.parse import parse_html
 
-ebird_mcp = BrandMCPBase(prefix="ebird", name="Ebird MCP")
+ebird_mcp = BrandMCPBase(brand_id="ebird", name="Ebird MCP")
 
 
 @ebird_mcp.tool(tags={"private"})
 async def get_life_list() -> dict[str, Any]:
     """Get life list of a ebird."""
-    return await extract(brand_id=BrandIdEnum("ebird"))
+    return await extract(brand_id=ebird_mcp.brand_id)
 
 
 @ebird_mcp.tool
@@ -23,8 +22,8 @@ async def get_explore_species_list(
     keyword: str,
 ) -> dict[str, Any]:
     """Get species list from ebird to be explored."""
-    if BrandState.is_brand_connected(BrandIdEnum("ebird")):
-        profile_id = BrandState.get_browser_profile_id(BrandIdEnum("ebird"))
+    if BrandState.is_brand_connected(ebird_mcp.brand_id):
+        profile_id = BrandState.get_browser_profile_id(ebird_mcp.brand_id)
         profile = BrowserProfile(id=profile_id) if profile_id else BrowserProfile()
     else:
         profile = BrowserProfile()
@@ -48,7 +47,7 @@ async def get_explore_species_list(
             {"name": "sci_name", "selector": "span.Suggestion-text span"},
         ],
     })
-    result = await parse_html(brand_id=BrandIdEnum("ebird"), html_content=html, schema=spec_schema)
+    result = await parse_html(brand_id=ebird_mcp.brand_id, html_content=html, schema=spec_schema)
     return {"species_list": result.content}
 
 
@@ -57,8 +56,8 @@ async def explore_species(
     sci_name: str,
 ) -> dict[str, Any]:
     """Explore species on Ebird from get_explore_species_list."""
-    if BrandState.is_brand_connected(BrandIdEnum("ebird")):
-        profile_id = BrandState.get_browser_profile_id(BrandIdEnum("ebird"))
+    if BrandState.is_brand_connected(ebird_mcp.brand_id):
+        profile_id = BrandState.get_browser_profile_id(ebird_mcp.brand_id)
         profile = BrowserProfile(id=profile_id) if profile_id else BrowserProfile()
     else:
         profile = BrowserProfile()

--- a/getgather/mcp/brand/gofood.py
+++ b/getgather/mcp/brand/gofood.py
@@ -1,13 +1,12 @@
 from typing import Any
 
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
 
-gofood_mcp = BrandMCPBase(prefix="gofood", name="Gofood MCP")
+gofood_mcp = BrandMCPBase(brand_id="gofood", name="Gofood MCP")
 
 
 @gofood_mcp.tool(tags={"private"})
 async def get_purchase_history() -> dict[str, Any]:
     """Get gofood purchase history."""
-    return await extract(brand_id=BrandIdEnum("gofood"))
+    return await extract(brand_id=gofood_mcp.brand_id)

--- a/getgather/mcp/brand/goodreads.py
+++ b/getgather/mcp/brand/goodreads.py
@@ -3,18 +3,17 @@ from typing import Any
 from fastmcp import Context
 
 from getgather.browser.agent import run_agent
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.logs import logger
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract, start_browser_session
 
-goodreads_mcp = BrandMCPBase(prefix="goodreads", name="Goodreads MCP")
+goodreads_mcp = BrandMCPBase(brand_id="goodreads", name="Goodreads MCP")
 
 
 @goodreads_mcp.tool(tags={"private"})
 async def get_book_list() -> dict[str, Any]:
     """Get the book list from a user's Goodreads account."""
-    return await extract(brand_id=BrandIdEnum("goodreads"))
+    return await extract(brand_id=goodreads_mcp.brand_id)
 
 
 @goodreads_mcp.tool(tags={"private"})
@@ -22,7 +21,7 @@ async def add_book_to_want_to_read(ctx: Context, book_name: str) -> dict[str, An
     """Add a book to the 'Want to Read' list on Goodreads."""
     browser_session = None
     try:
-        browser_session = await start_browser_session(BrandIdEnum("goodreads"))
+        browser_session = await start_browser_session(goodreads_mcp.brand_id)
         task = f"Add {book_name} to my Goodreads 'Want to Read' list"
         logger.info(f"Running agent with task: {task}")
         await run_agent(ctx, browser_session.context, task)
@@ -40,7 +39,7 @@ async def get_recommendation(ctx: Context) -> dict[str, Any]:
     """Get recommendation of a goodreads."""
     browser_session = None
     try:
-        browser_session = await start_browser_session(BrandIdEnum("goodreads"))
+        browser_session = await start_browser_session(goodreads_mcp.brand_id)
         task = "Get recommendation of a goodreads"
         logger.info(f"Running agent with task: {task}")
         result = await run_agent(ctx, browser_session.context, task)

--- a/getgather/mcp/brand/hardcover.py
+++ b/getgather/mcp/brand/hardcover.py
@@ -1,13 +1,12 @@
 from typing import Any
 
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
 
-hardcover_mcp = BrandMCPBase(prefix="hardcover", name="Hardcover MCP")
+hardcover_mcp = BrandMCPBase(brand_id="hardcover", name="Hardcover MCP")
 
 
 @hardcover_mcp.tool(tags={"private"})
 async def get_book_list() -> dict[str, Any]:
     """Get book list from Hardcover.app."""
-    return await extract(BrandIdEnum("hardcover"))
+    return await extract(brand_id=hardcover_mcp.brand_id)

--- a/getgather/mcp/brand/kindle.py
+++ b/getgather/mcp/brand/kindle.py
@@ -1,13 +1,12 @@
 from typing import Any
 
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
 
-kindle_mcp = BrandMCPBase(prefix="kindle", name="Kindle MCP")
+kindle_mcp = BrandMCPBase(brand_id="kindle", name="Kindle MCP")
 
 
 @kindle_mcp.tool(tags={"private"})
 async def get_book_list() -> dict[str, Any]:
     """Get book list from Amazon Kindle."""
-    return await extract(BrandIdEnum("kindle"))
+    return await extract(brand_id=kindle_mcp.brand_id)

--- a/getgather/mcp/brand/shopee.py
+++ b/getgather/mcp/brand/shopee.py
@@ -3,20 +3,19 @@ from urllib.parse import quote
 
 from getgather.browser.profile import BrowserProfile
 from getgather.browser.session import browser_session
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.connectors.spec_models import Schema as SpecSchema
 from getgather.database.repositories.brand_state_repository import BrandState
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
 from getgather.parse import parse_html
 
-shopee_mcp = BrandMCPBase(prefix="shopee", name="Shopee MCP")
+shopee_mcp = BrandMCPBase(brand_id="shopee", name="Shopee MCP")
 
 
 @shopee_mcp.tool(tags={"private"})
 async def get_purchase_history() -> dict[str, Any]:
     """Get purchase history of a shopee."""
-    return await extract(brand_id=BrandIdEnum("shopee"))
+    return await extract(brand_id=shopee_mcp.brand_id)
 
 
 @shopee_mcp.tool
@@ -25,8 +24,8 @@ async def search_product(
     page_number: int = 1,
 ) -> dict[str, Any]:
     """Search product on shopee."""
-    if BrandState.is_brand_connected(BrandIdEnum("shopee")):
-        profile_id = BrandState.get_browser_profile_id(BrandIdEnum("shopee"))
+    if BrandState.is_brand_connected(shopee_mcp.brand_id):
+        profile_id = BrandState.get_browser_profile_id(shopee_mcp.brand_id)
         profile = BrowserProfile(id=profile_id) if profile_id else BrowserProfile()
     else:
         profile = BrowserProfile()
@@ -66,5 +65,5 @@ async def search_product(
             },
         ],
     })
-    result = await parse_html(brand_id=BrandIdEnum("shopee"), html_content=html, schema=spec_schema)
+    result = await parse_html(brand_id=shopee_mcp.brand_id, html_content=html, schema=spec_schema)
     return {"product_list": result.content}

--- a/getgather/mcp/brand/tokopedia.py
+++ b/getgather/mcp/brand/tokopedia.py
@@ -6,7 +6,6 @@ from urllib.parse import quote, urlparse
 from getgather.actions import handle_graphql_response
 from getgather.browser.profile import BrowserProfile
 from getgather.browser.session import browser_session
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.connectors.spec_models import Schema as SpecSchema
 from getgather.database.repositories.brand_state_repository import BrandState
 from getgather.logs import logger
@@ -14,7 +13,7 @@ from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import start_browser_session
 from getgather.parse import parse_html
 
-tokopedia_mcp = BrandMCPBase(prefix="tokopedia", name="Tokopedia MCP")
+tokopedia_mcp = BrandMCPBase(brand_id="tokopedia", name="Tokopedia MCP")
 
 
 @tokopedia_mcp.tool
@@ -63,7 +62,7 @@ async def search_product(
                 ],
             })
             result = await parse_html(
-                brand_id=BrandIdEnum("tokopedia"), html_content=html, schema=spec_schema
+                brand_id=tokopedia_mcp.brand_id, html_content=html, schema=spec_schema
             )
             await page.close()
             return {kw: result.content}
@@ -82,8 +81,8 @@ async def get_product_details(
     product_url: str,
 ) -> dict[str, Any]:
     """Get product details from tokopedia. Get product_url from search_product tool."""
-    if BrandState.is_brand_connected(BrandIdEnum("tokopedia")):
-        profile_id = BrandState.get_browser_profile_id(BrandIdEnum("tokopedia"))
+    if BrandState.is_brand_connected(tokopedia_mcp.brand_id):
+        profile_id = BrandState.get_browser_profile_id(tokopedia_mcp.brand_id)
         profile = BrowserProfile(id=profile_id) if profile_id else BrowserProfile()
     else:
         profile = BrowserProfile()
@@ -125,7 +124,7 @@ async def get_product_details(
         ],
     })
     result = await parse_html(
-        brand_id=BrandIdEnum("tokopedia"), html_content=html, schema=spec_schema
+        brand_id=tokopedia_mcp.brand_id, html_content=html, schema=spec_schema
     )
     return {"product_detail": result.content}
 
@@ -135,8 +134,8 @@ async def search_shop(
     keyword: str,
 ) -> dict[str, Any]:
     """Search shop on tokopedia."""
-    if BrandState.is_brand_connected(BrandIdEnum("tokopedia")):
-        profile_id = BrandState.get_browser_profile_id(BrandIdEnum("tokopedia"))
+    if BrandState.is_brand_connected(tokopedia_mcp.brand_id):
+        profile_id = BrandState.get_browser_profile_id(tokopedia_mcp.brand_id)
         profile = BrowserProfile(id=profile_id) if profile_id else BrowserProfile()
     else:
         profile = BrowserProfile()
@@ -186,7 +185,7 @@ async def search_shop(
         ],
     })
     result = await parse_html(
-        brand_id=BrandIdEnum("tokopedia"), html_content=html, schema=spec_schema
+        brand_id=tokopedia_mcp.brand_id, html_content=html, schema=spec_schema
     )
     return {"shop_list": result.content}
 
@@ -241,8 +240,8 @@ async def get_shop_details(
     if not target_url:
         return {"error": "Could not determine valid shop URL"}
 
-    if BrandState.is_brand_connected(BrandIdEnum("tokopedia")):
-        profile_id = BrandState.get_browser_profile_id(BrandIdEnum("tokopedia"))
+    if BrandState.is_brand_connected(tokopedia_mcp.brand_id):
+        profile_id = BrandState.get_browser_profile_id(tokopedia_mcp.brand_id)
         profile = BrowserProfile(id=profile_id) if profile_id else BrowserProfile()
     else:
         profile = BrowserProfile()
@@ -265,7 +264,7 @@ async def get_shop_details(
         ],
     })
     result = await parse_html(
-        brand_id=BrandIdEnum("tokopedia"), html_content=html, schema=spec_schema
+        brand_id=tokopedia_mcp.brand_id, html_content=html, schema=spec_schema
     )
     return {"shop_detail": result.content}
 
@@ -276,7 +275,7 @@ async def get_purchase_history(
 ) -> dict[str, Any]:
     """Get purchase history of a tokopedia."""
 
-    browser_session = await start_browser_session(brand_id=BrandIdEnum("tokopedia"))
+    browser_session = await start_browser_session(brand_id=tokopedia_mcp.brand_id)
     page = await browser_session.page()
     await page.goto(f"https://www.tokopedia.com/order-list?page={page_number}")
     raw_data = await handle_graphql_response(
@@ -322,7 +321,7 @@ async def get_purchase_history(
 async def get_cart() -> dict[str, Any]:
     """Get cart of a tokopedia."""
 
-    browser_session = await start_browser_session(brand_id=BrandIdEnum("tokopedia"))
+    browser_session = await start_browser_session(brand_id=tokopedia_mcp.brand_id)
     page = await browser_session.page()
     await page.goto(f"https://www.tokopedia.com/cart")
     raw_data = await handle_graphql_response(
@@ -366,7 +365,7 @@ async def get_wishlist(
 ) -> dict[str, Any]:
     """Get purchase history of a tokopedia."""
 
-    browser_session = await start_browser_session(brand_id=BrandIdEnum("tokopedia"))
+    browser_session = await start_browser_session(brand_id=tokopedia_mcp.brand_id)
     page = await browser_session.page()
     await page.goto(f"https://www.tokopedia.com/wishlist/all?page={page_number}")
     raw_data = await handle_graphql_response(
@@ -401,7 +400,7 @@ async def add_to_cart(
     """Add a product to cart of a tokopedia."""
 
     logger.info(f"Adding product to cart: {product_url}")
-    profile_id = BrandState.get_browser_profile_id(BrandIdEnum("tokopedia"))
+    profile_id = BrandState.get_browser_profile_id(tokopedia_mcp.brand_id)
     profile = BrowserProfile(id=profile_id) if profile_id else BrowserProfile()
 
     product_urls = [product_url] if isinstance(product_url, str) else product_url

--- a/getgather/mcp/brand/ubereats.py
+++ b/getgather/mcp/brand/ubereats.py
@@ -1,13 +1,12 @@
 from typing import Any
 
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
 
-ubereats_mcp = BrandMCPBase(prefix="ubereats", name="UberEats MCP")
+ubereats_mcp = BrandMCPBase(brand_id="ubereats", name="UberEats MCP")
 
 
 @ubereats_mcp.tool(tags={"private"})
 async def get_orders() -> dict[str, Any]:
     """Get orders from UberEats.com."""
-    return await extract(BrandIdEnum("ubereats"))
+    return await extract(brand_id=ubereats_mcp.brand_id)

--- a/getgather/mcp/brand/zillow.py
+++ b/getgather/mcp/brand/zillow.py
@@ -1,13 +1,12 @@
 from typing import Any
 
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
 
-zillow_mcp = BrandMCPBase(prefix="zillow", name="Zillow MCP")
+zillow_mcp = BrandMCPBase(brand_id="zillow", name="Zillow MCP")
 
 
 @zillow_mcp.tool(tags={"private"})
 async def get_favorites() -> dict[str, Any]:
     """Get favorites of zillow."""
-    return await extract(brand_id=BrandIdEnum("zillow"))
+    return await extract(brand_id=zillow_mcp.brand_id)

--- a/getgather/mcp/calendar_utils.py
+++ b/getgather/mcp/calendar_utils.py
@@ -4,12 +4,10 @@ from typing import Any, Literal
 from urllib.parse import urlencode
 from zoneinfo import ZoneInfo
 
-from fastmcp import Context
-
-from getgather.mcp.registry import BrandMCPBase
+from fastmcp import Context, FastMCP
 
 # Create a generic calendar MCP
-calendar_mcp = BrandMCPBase(prefix="calendar", name="Calendar MCP")
+calendar_mcp = FastMCP[Context](name="Calendar MCP")
 
 
 def escape_ics_text(value: str) -> str:

--- a/getgather/mcp/registry.py
+++ b/getgather/mcp/registry.py
@@ -1,13 +1,16 @@
+from typing import ClassVar
+
 from fastmcp import Context, FastMCP
 
+from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.logs import logger
 
 
 class BrandMCPBase(FastMCP[Context]):
-    registry: dict[str, FastMCP[Context]] = {}
+    registry: ClassVar[dict[BrandIdEnum, "BrandMCPBase"]] = {}
 
-    def __init__(self, *, prefix: str, name: str) -> None:
+    def __init__(self, *, brand_id: str, name: str) -> None:
         super().__init__(name=name)
-        self._prefix = prefix
-        BrandMCPBase.registry[prefix] = self
-        logger.debug(f"Registered MCP with prefix '{prefix}' and name '{name}'")
+        self.brand_id = BrandIdEnum(brand_id)
+        BrandMCPBase.registry[self.brand_id] = self
+        logger.debug(f"Registered MCP with brand_id '{brand_id}' and name '{name}'")


### PR DESCRIPTION
Create 3 types of bundles
- "all" bundle has all brands and tools
- [brand] bundle has tools from a single brand
- [category] bundle has tools from a category of brands, e.g., books, food

Added `brand_id` to the `BrandMCPBase` class for convenience

Now the mcp client can use the config like the following to pick different bundles
```
{
  "mcpServers": {
    "getgather": {
      "command": "npx",
      "args": ["mcp-remote", "http://127.0.0.1:8000/mcp", "--allow-http"]
    },
    "getgather-books": {
      "command": "npx",
      "args": ["mcp-remote", "http://127.0.0.1:8000/mcp-books", "--allow-http"]
    },
    "getgather-amazon": {
      "command": "npx",
      "args": ["mcp-remote", "http://127.0.0.1:8000/mcp-amazon", "--allow-http"]
    }
  }
}
``` 
Here are the screenshots of the above configuration
<img width="565" height="703" alt="Screenshot 2025-08-13 at 2 53 13 PM" src="https://github.com/user-attachments/assets/bb769e12-64da-4a88-9dd2-89a98c7eb2f3" />

<img width="565" height="703" alt="Screenshot 2025-08-13 at 2 53 18 PM" src="https://github.com/user-attachments/assets/0903dc92-8691-43ce-b0e1-cbbf1f387171" />
