### PR TITLE
More robust text field input

### DIFF
--- a/getgather/actions.py
+++ b/getgather/actions.py
@@ -140,29 +140,31 @@ async def handle_fill_single(frame: Frame | Page, field: Field, value: str) -> N
 
 
 async def handle_fill_multi(frame: Frame | Page, field: Field, values: str | list[str]) -> None:
-    """Fill repeated elements selected by `field.selectors`."""
+    """Fill repeated elements for text_multi type fields."""
     await frame.wait_for_timeout(500)
     # Coerce single string into a list for uniform processing.
     vals: list[str] = list(values) if isinstance(values, str) else values
-    outer = frame.locator(field.selectors)  # type: ignore[arg-type]
+    outer = frame.locator(field.selector)  # type: ignore[arg-type]
     await outer.first.wait_for(state="attached", timeout=5_000)
 
-    inner = frame.locator(f"{field.selectors} >>> input")
+    inner = frame.locator(f"{field.selector} >>> input")
     if await inner.count() > 0:
         await inner.first.wait_for(state="attached", timeout=5_000)
         target = inner
     else:
         # Fallback if no match
-        await frame.locator(f"css={field.selectors}").first.wait_for(
-            state="attached", timeout=5_000
-        )
-        target = frame.locator(f"css={field.selectors}")
+        await frame.locator(f"css={field.selector}").first.wait_for(state="attached", timeout=5_000)
+        target = frame.locator(f"css={field.selector}")
 
-    for idx, val in enumerate(vals):
-        logger.info(f"📝 Filling {field.name} {idx + 1}/{len(vals)}")
-        await target.nth(idx).clear()
-        await target.nth(idx).press_sequentially(val, delay=100)
-        await frame.wait_for_timeout(200)
+    if field.type == "text_multi_auto":
+        await target.first.click()
+        await target.first.press_sequentially("".join(vals), delay=100)
+    else:
+        for idx, val in enumerate(vals):
+            logger.info(f"📝 Filling {field.name} {idx + 1}/{len(vals)}")
+            await target.nth(idx).clear()
+            await target.nth(idx).press_sequentially(val, delay=100)
+            await frame.wait_for_timeout(200)
 
 
 async def handle_network_extraction(page: Page, predicate: str) -> Any:

--- a/getgather/connectors/brand_specs/adidas/specs.yml
+++ b/getgather/connectors/brand_specs/adidas/specs.yml
@@ -3,7 +3,7 @@ name: Adidas
 auth:
   fields:
     - name: email
-      type: email
+      type: text
       prompt: Email address
       selector: input#email
     - name: email_button

--- a/getgather/connectors/brand_specs/amazon/specs.yml
+++ b/getgather/connectors/brand_specs/amazon/specs.yml
@@ -25,7 +25,7 @@ auth:
       selector: text="Continue shopping"
 
     - name: email
-      type: email
+      type: text
       prompt: Email
       selector: input[type="email"]
 

--- a/getgather/connectors/brand_specs/amazonca/specs.yml
+++ b/getgather/connectors/brand_specs/amazonca/specs.yml
@@ -25,7 +25,7 @@ auth:
       selector: text="Continue shopping"
 
     - name: email
-      type: email
+      type: text
       prompt: Email
       selector: input[type="email"]
 

--- a/getgather/connectors/brand_specs/americanairlines/specs.yml
+++ b/getgather/connectors/brand_specs/americanairlines/specs.yml
@@ -27,8 +27,8 @@ auth:
       type: wait
       selector: hp-account-dropdown-button#accountButtonDesktop
     - name: mfa_code
-      type: text
-      selectors: '[type="text"][inputmode="numeric"]'
+      type: text_multi
+      selector: '[type="text"][inputmode="numeric"]'
       prompt: Enter the verification code you received by email
       label: span[class*='_info_'], span[class*='_email_']
     - name: mfa_code_submit

--- a/getgather/connectors/brand_specs/chewy/specs.yml
+++ b/getgather/connectors/brand_specs/chewy/specs.yml
@@ -3,7 +3,7 @@ name: Chewy
 auth:
   fields:
     - name: email
-      type: email
+      type: text
       prompt: Email
       selector: input#username
     - name: continue

--- a/getgather/connectors/brand_specs/containerstore/specs.yml
+++ b/getgather/connectors/brand_specs/containerstore/specs.yml
@@ -3,7 +3,7 @@ name: Container Store
 auth:
   fields:
     - name: email
-      type: email
+      type: text
       prompt: Email
       selector: input#signInName
     - name: password

--- a/getgather/connectors/brand_specs/doordash/specs.yml
+++ b/getgather/connectors/brand_specs/doordash/specs.yml
@@ -18,9 +18,9 @@ auth:
       prompt: Sign In
       selector: button#login-submit-button
     - name: otp
-      type: text
+      type: text_multi
       prompt: 6-digit one time code
-      selectors: input[type="number"]
+      selector: input[type="number"]
   pages:
     - name: Email page
       fields: [email, email_continue]

--- a/getgather/connectors/brand_specs/ikea/specs.yml
+++ b/getgather/connectors/brand_specs/ikea/specs.yml
@@ -3,7 +3,7 @@ name: Ikea
 auth:
   fields:
     - name: email
-      type: email
+      type: text
       prompt: Email
       selector: input#username
     - name: continue

--- a/getgather/connectors/brand_specs/lenspure/specs.yml
+++ b/getgather/connectors/brand_specs/lenspure/specs.yml
@@ -3,7 +3,7 @@ name: Lenspure
 auth:
   fields:
     - name: email
-      type: email
+      type: text
       prompt: Email address
       selector: input[id="username"]
 

--- a/getgather/connectors/brand_specs/lululemon/specs.yml
+++ b/getgather/connectors/brand_specs/lululemon/specs.yml
@@ -3,7 +3,7 @@ name: Lululemon
 auth:
   fields:
     - name: email
-      type: email
+      type: text
       prompt: Email
       selector: input[name="identifier"]
 

--- a/getgather/connectors/brand_specs/nordstrom/specs.yml
+++ b/getgather/connectors/brand_specs/nordstrom/specs.yml
@@ -27,10 +27,13 @@ auth:
       selector: label:has-text("Keep me signed in.")
       expect_nav: false
     - name: otp
-      type: text
+      score: 10
+      type: text_multi_auto
       prompt: Please enter your one-time code
       label: '[role="dialog"] >> text=/^We sent a code to:/'
-      selectors: input[name^='otpEntry']
+      selector: input[name^='otpEntry']
+      expect_nav: true
+      url: https://www.nordstrom.com/
     - name: otp_choice_button
       prompt: Sign In with a Code Instead
       type: click

--- a/getgather/connectors/brand_specs/petsmart/specs.yml
+++ b/getgather/connectors/brand_specs/petsmart/specs.yml
@@ -3,7 +3,7 @@ name: Petsmart
 auth:
   fields:
     - name: email_account
-      type: email
+      type: text
       prompt: Email
       selector: form#signInForm input[name=username]
     - name: password_account
@@ -15,7 +15,7 @@ auth:
       prompt: Login
       selector: form#signInForm button#login
     - name: email
-      type: email
+      type: text
       prompt: Email
       selector: div[data-testid=sign-in-form-container] input[name=email]
     - name: password

--- a/getgather/connectors/brand_specs/quince/specs.yml
+++ b/getgather/connectors/brand_specs/quince/specs.yml
@@ -3,7 +3,7 @@ name: Quince
 auth:
   fields:
     - name: email
-      type: email
+      type: text
       prompt: Email address
       selector: input[type="email"]
     - name: password

--- a/getgather/connectors/brand_specs/revolve/specs.yml
+++ b/getgather/connectors/brand_specs/revolve/specs.yml
@@ -14,7 +14,7 @@ auth:
       prompt: Close dialog with No thanks button
       selector: '#ntf_just_let_shop'
     - name: email
-      type: email
+      type: text
       prompt: Email address
       selector: input#emailCustomer
     - name: password

--- a/getgather/connectors/brand_specs/seatgeek/specs.yml
+++ b/getgather/connectors/brand_specs/seatgeek/specs.yml
@@ -3,7 +3,7 @@ name: SeatGeek
 auth:
   fields:
     - name: email
-      type: email
+      type: text
       prompt: Email address
       selector: div[role="dialog"] input[type=email]
     - name: login_with_email_button
@@ -16,9 +16,9 @@ auth:
       selector: div[role="dialog"] button[type=button] span:has-text("Use password instead")
 
     - name: otp
-      type: text
+      type: text_multi
       prompt: 6-digit code sent to email
-      selectors: div[role="dialog"] input[aria-label^="6-digit code digit"]
+      selector: div[role="dialog"] input[aria-label^="6-digit code digit"]
     - name: otp_submit_button
       type: click
       prompt: Confirm

--- a/getgather/connectors/brand_specs/starbucks/specs.yml
+++ b/getgather/connectors/brand_specs/starbucks/specs.yml
@@ -3,7 +3,7 @@ name: Starbucks
 auth:
   fields:
     - name: email
-      type: email
+      type: text
       prompt: Email address
       selector: input[type=email]#username
     - name: password

--- a/getgather/connectors/brand_specs/ubereats/specs.yml
+++ b/getgather/connectors/brand_specs/ubereats/specs.yml
@@ -11,17 +11,17 @@ auth:
       prompt: Password
       selector: input#PASSWORD
     - name: email_otp
-      type: text
+      type: text_multi
       prompt: OTP sent to email
-      selectors: input[id^="EMAIL_OTP_CODE-"]
+      selector: input[id^="EMAIL_OTP_CODE-"]
     - name: sms_otp
-      type: text
+      type: text_multi
       prompt: OTP sent to SMS
-      selectors: input[id^="PHONE_SMS_OTP-"]
+      selector: input[id^="PHONE_SMS_OTP-"]
     - name: voice_otp
-      type: text
+      type: text_multi
       prompt: OTP sent to Voice
-      selectors: input[id^="PHONE_VOICE_OTP-"]
+      selector: input[id^="PHONE_VOICE_OTP-"]
     - name: continue
       type: click
       prompt: Continue

--- a/getgather/connectors/brand_specs/zillow/specs.yml
+++ b/getgather/connectors/brand_specs/zillow/specs.yml
@@ -3,7 +3,7 @@ name: Zillow
 auth:
   fields:
     - name: email
-      type: email
+      type: text
       prompt: Email
       selector: input#username
     - name: password

--- a/getgather/connectors/spec_models.py
+++ b/getgather/connectors/spec_models.py
@@ -160,64 +160,52 @@ class SpecModel(BaseModel, Generic[TYML]):
         )
 
 
+FIELD_TYPES = Literal[
+    "text",  # single input field
+    "text_multi",  # multiple input fields in a sequence
+    "text_multi_auto",  # multiple input fields in a sequence, auto-advancing
+    "password",  # single input field with masking
+    "autoclick",
+    "click",
+    "press",
+    "navigate",
+    "wait",
+    "message",
+    "selection",
+]
+
+
 class FieldYML(YMLModel):
     name: str
-    type: Literal[
-        "text",
-        "email",
-        "password",
-        "autoclick",
-        "click",
-        "press",
-        "navigate",
-        "wait",
-        "message",
-        "selection",
-    ]
+    score: int = 1  # used to score matching page for detection
+    type: FIELD_TYPES
     prompt: str | None = None
     label: str | None = None
     iframe_selector: str | None = None
     selector: str | None = None
-    selectors: str | None = None
     url: str | None = None
     expect_nav: bool = False
     delay_ms: int | None = None
 
     @model_validator(mode="after")
-    def validate_selectors(self) -> Self:
+    def validate_selector(self) -> Self:
         if self.type == "navigate":
             assert self.url is not None, "URL is required for navigate field"
             assert self.expect_nav is not False, "expect_nav must be True for navigate field"
             return self
         elif self.type != "selection":
-            # For normal interactive fields exactly one of selector/selectors is required.
-            # Dynamic "selection" fields derive their target via ``option_items`` at runtime,
-            # so they are exempt.
-            assert bool(self.selector) ^ bool(self.selectors), (
-                "One and only one of selector and selectors must be provided for non-navigate fields"
-            )
+            assert self.selector is not None, "selector is required for non-selection fields"
         return self
 
 
 class Field(SpecModel[FieldYML]):
     name: str
-    type: Literal[
-        "text",
-        "email",
-        "password",
-        "autoclick",
-        "click",
-        "press",
-        "navigate",
-        "wait",
-        "message",
-        "selection",
-    ]
+    score: int = 1  # used to score matching page for detection
+    type: FIELD_TYPES
     prompt: str | None = None
     label: str | None = None
     iframe_selector: str | None = None
     selector: str | None = None
-    selectors: str | None = None
     # Dynamic selection helpers (only used when type == 'selection')
     option_items: str | None = None
     option_label: str | None = None
@@ -227,7 +215,15 @@ class Field(SpecModel[FieldYML]):
 
     @property
     def needs_input(self) -> bool:
-        return self.type in ["text", "email", "password", "click", "press", "selection"]
+        return self.type in [
+            "text",
+            "text_multi",
+            "text_multi_auto",
+            "password",
+            "click",
+            "press",
+            "selection",
+        ]
 
     @property
     def needs_action(self) -> bool:
@@ -236,7 +232,8 @@ class Field(SpecModel[FieldYML]):
             "click",
             "press",
             "text",
-            "email",
+            "text_multi",
+            "text_multi_auto",
             "password",
             "navigate",
             "selection",

--- a/getgather/detect.py
+++ b/getgather/detect.py
@@ -125,7 +125,7 @@ class PageSpecDetector:
 
 
 async def _detect_field(field: Field, page: Page):
-    selector = field.selector or field.selectors
+    selector = field.selector
     if selector is None:
         return True
 
@@ -148,25 +148,26 @@ async def _detect_fields(fields: list[Field], page: Page) -> dict[str, bool]:
 class PageDetectResult(BaseModel):
     page_name: str
     url: bool | None  # whether the url matches
-    fields: float  # percentage of fields that are visible
-    score: int
+    recall: float  # percentage of required fields that are visible
+    score: int  # sum of scores of required fields that are visible
 
     @property
     def matched(self) -> bool:
-        return self.url is not False and self.fields == 1.0
+        return self.url is not False and self.recall == 1.0
 
 
 def _detect_page_spec(
     spec: PageSpec, url: str, visible_fields: dict[str, bool]
 ) -> PageDetectResult:
     url_match = url.startswith(str(spec.url)) if spec.url else None
-    fields_match = {
-        fld.name: visible_fields.get(fld.name, False) for fld in spec.fields(include="required")
-    }
-
-    score = sum(fields_match.values())
-    fields_match_ratio = score / len(fields_match) if fields_match else 1.0
+    num_required = len(spec.fields(include="required"))
+    required_visible = [
+        f for f in spec.fields(include="required") if visible_fields.get(f.name, False)
+    ]
 
     return PageDetectResult(
-        page_name=spec.name, url=url_match, fields=fields_match_ratio, score=score
+        page_name=spec.name,
+        url=url_match,
+        recall=len(required_visible) / num_required if num_required > 0 else 1.0,
+        score=sum([f.score for f in required_visible]),
     )

--- a/getgather/flow.py
+++ b/getgather/flow.py
@@ -189,9 +189,9 @@ async def _handle_fields(fld: Field, current_frame: Frame | Page, flow_state: Fl
         if not fld.selector:
             raise ValueError(f"⚠️ No selector provided for click field '{fld.name}'")
         await handle_click(current_frame, fld.selector, None, flow_state.bundle_dir)
-    elif fld.selectors:
+    elif fld.type == "text_multi" or fld.type == "text_multi_auto":
         await handle_fill_multi(current_frame, fld, value)
-    elif fld.selector:
+    elif fld.type == "text" or fld.type == "password":
         await handle_fill_single(current_frame, fld, value)
     elif fld.type == "navigate":
         if not fld.url:
@@ -387,9 +387,9 @@ async def flow_step(*, page: Page, flow_state: FlowState) -> FlowState:
                     raise ValueError(f"⚠️ No selector provided for {field.name}")
             elif field.type == "wait" and field.selector:
                 await wait_for_selector(current_page, field.selector, timeout=timeout)
-            elif field.selectors:
+            elif field.type == "text_multi" or field.type == "text_multi_auto":
                 await handle_fill_multi(current_page, field, value)
-            elif field.selector:
+            elif field.type == "text" or field.type == "password":
                 await handle_fill_single(current_page, field, value)
 
         flow_state.prompt = (

--- a/tests/connectors/brand_specs/acme-email-then-otp-multi-inputs.yml
+++ b/tests/connectors/brand_specs/acme-email-then-otp-multi-inputs.yml
@@ -7,9 +7,9 @@ auth:
       prompt: Please enter your email address
       selector: input[type=email]
     - name: otp
-      type: text
+      type: text_multi
       prompt: Please enter the one-time code
-      selectors: input[name^="otp_"]
+      selector: input[name^="otp_"]
     - name: submit
       type: click
       prompt: Submit

--- a/tests/connectors/test_spec_models.py
+++ b/tests/connectors/test_spec_models.py
@@ -17,13 +17,9 @@ def test_field():
     txt = """
     fields:
       - name: field_with_selector
-        type: email
+        type: text
         prompt: Enter your email
         selector: input[name="email"]
-      - name: field_with_selectors
-        type: text
-        prompt: Enter your OTP
-        selectors: input[name^="otp"]
       - name: navigate_field
         type: navigate
         prompt: Navigate to the page
@@ -35,7 +31,7 @@ def test_field():
         Field.from_yml(FieldYML.model_validate(f), fields_map={}, pages_map={})
         for f in yml["fields"]
     ]
-    assert len(spec) == 3
+    assert len(spec) == 2
 
 
 def test_field_without_selector():
@@ -46,28 +42,7 @@ def test_field_without_selector():
         prompt: Enter your text
     """
     yml = yaml.load(txt, Loader=RegexLoader)
-    with pytest.raises(
-        ValueError, match="One and only one of selector and selectors must be provided"
-    ):
-        [
-            Field.from_yml(FieldYML.model_validate(f), fields_map={}, pages_map={})
-            for f in yml["fields"]
-        ]
-
-
-def test_field_with_both_selector_and_selectors():
-    txt = """
-    fields:
-      - name: field
-        type: text
-        prompt: Enter your text
-        selector: input[name="text"]
-        selectors: input[name="text"]
-    """
-    yml = yaml.load(txt, Loader=RegexLoader)
-    with pytest.raises(
-        ValueError, match="One and only one of selector and selectors must be provided"
-    ):
+    with pytest.raises(ValueError, match="selector is required for non-selection fields"):
         [
             Field.from_yml(FieldYML.model_validate(f), fields_map={}, pages_map={})
             for f in yml["fields"]
@@ -140,14 +115,14 @@ def test_page_with_optional_fields():
         type: text
         prompt: Enter your text
         selector: input[name="text"]
-      - name: optional_field 
+      - name: optional_field
         type: text
         prompt: Enter your text
         selector: input[name="text"]
     pages:
       - name: page_with_fields
         url: https://example.com
-        fields: 
+        fields:
           required: [required_field]
           optional: [optional_field]
     """
@@ -207,7 +182,7 @@ def test_page_with_choices():
         selector: input[name="text"]
     pages:
       - name: page_with_choices
-        url: https://example.com 
+        url: https://example.com
         choices:
           name: a list of choices
           prompt: Choose one of the following options


### PR DESCRIPTION
Added better support for handling multi input fields that auto-advances, such as Nordstrom OTP. It requires some specific keyboard events to trigger submission

Cleaned up input types
- removed `email`, which is just an alias of `text`
- added `text_multi` and `text_multi_auto` to distinguish different types of multi input fields
- `selectors` is redundant since 'text_multi` can indicate multiple matches of `selector`

Nordstrom otp page also needs improvements on page detection scoring function so that we can correctly detect otp form