### PR TITLE
improve hosted link and forwarding for tunnel

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,4 +38,4 @@ dbus-daemon --system --fork
 echo "D-BUS daemon started with pid: $(cat /run/dbus/pid)"
 
 # Start FastAPI server
-/opt/venv/bin/python -m uvicorn getgather.api.main:app --host 0.0.0.0 --port 8000
+    /opt/venv/bin/python -m uvicorn getgather.api.main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips='*'

--- a/getgather/api/routes/link/endpoints.py
+++ b/getgather/api/routes/link/endpoints.py
@@ -21,9 +21,25 @@ async def create_hosted_link(
         HostedLinkTokenRequest, "Request data for creating a hosted link."
     ],
 ) -> HostedLinkTokenResponse:
-    logger.info(f"Creating hosted link for brand: {hosted_link_request.brand_id}")
+    logger.info(
+        f"[create_hosted_link] Creating hosted link for brand: {hosted_link_request.brand_id}"
+    )
+
+    # Log incoming request details
+    relevant_headers = {
+        "host": request.headers.get("host"),
+        "x-forwarded-host": request.headers.get("x-forwarded-host"),
+        "x-forwarded-proto": request.headers.get("x-forwarded-proto"),
+        "x-forwarded-port": request.headers.get("x-forwarded-port"),
+        "user-agent": request.headers.get("user-agent"),
+    }
+    logger.info(f"[create_hosted_link] Request URL: {request.url}")
+    logger.info(f"[create_hosted_link] Relevant headers: {relevant_headers}")
+
     try:
         redirect_url = hosted_link_request.redirect_url or ""
+        logger.info(f"[create_hosted_link] Redirect URL: {redirect_url}")
+
         link_data = HostedLinkManager.create_link(
             brand_id=BrandIdEnum(hosted_link_request.brand_id),
             redirect_url=redirect_url,
@@ -33,14 +49,37 @@ async def create_hosted_link(
         link_id = link_data["link_id"]
         expiration = link_data["expiration"]
         profile_id = link_data["profile_id"]
-        base_url = str(request.base_url).rstrip("/")
+        logger.info(f"[create_hosted_link] Created link_id: {link_id}, profile_id: {profile_id}")
+
+        # URL construction with detailed logging
+        original_scheme = request.url.scheme
+        original_host = request.headers.get("host")
+        forwarded_proto = request.headers.get("x-forwarded-proto")
+        forwarded_host = request.headers.get("x-forwarded-host")
+
+        scheme = forwarded_proto or original_scheme
+        host = forwarded_host or original_host
+        base_url = f"{scheme}://{host}".rstrip("/")
         hosted_link_url = f"{base_url}/link/{link_id}"
-        return HostedLinkTokenResponse(
+
+        logger.info(f"[create_hosted_link] URL construction:")
+        logger.info(f"  - original_scheme: {original_scheme}")
+        logger.info(f"  - original_host: {original_host}")
+        logger.info(f"  - forwarded_proto: {forwarded_proto}")
+        logger.info(f"  - forwarded_host: {forwarded_host}")
+        logger.info(f"  - final_scheme: {scheme}")
+        logger.info(f"  - final_host: {host}")
+        logger.info(f"  - base_url: {base_url}")
+        logger.info(f"  - hosted_link_url: {hosted_link_url}")
+
+        response = HostedLinkTokenResponse(
             link_id=link_id,
             profile_id=profile_id,
             hosted_link_url=hosted_link_url,
             expiration=expiration,
         )
+        logger.info(f"[create_hosted_link] Returning response with URL: {response.hosted_link_url}")
+        return response
     except HTTPException:
         raise
     except Exception as e:
@@ -53,18 +92,29 @@ async def create_hosted_link(
 
 @router.get("/status/{link_id}", response_model=TokenLookupResponse)
 async def get_hosted_link(
+    request: Request,
     link_id: str,
 ) -> TokenLookupResponse:
-    logger.info(f"Retrieving hosted link: {link_id}")
+    logger.info(f"[get_hosted_link] Retrieving hosted link: {link_id}")
+    logger.info(f"[get_hosted_link] Request URL: {request.url}")
+
     try:
         link_data = HostedLinkManager.get_link_data(link_id)
         if not link_data:
+            logger.warning(f"[get_hosted_link] Link not found: {link_id}")
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Hosted link '{link_id}' not found",
             )
 
-        return TokenLookupResponse(
+        logger.info(f"[get_hosted_link] Found link data:")
+        logger.info(f"  - brand_id: {link_data.brand_id}")
+        logger.info(f"  - profile_id: {link_data.profile_id}")
+        logger.info(f"  - status: {link_data.status}")
+        logger.info(f"  - redirect_url: {link_data.redirect_url}")
+        logger.info(f"  - status_message: {link_data.status_message}")
+
+        response = TokenLookupResponse(
             link_id=link_id,
             profile_id=link_data.profile_id,
             brand_id=str(link_data.brand_id),
@@ -76,6 +126,8 @@ async def get_hosted_link(
             extract_result=link_data.extract_result,
             message=link_data.status_message or "Auth in progress...",
         )
+        logger.info(f"[get_hosted_link] Returning status response: {response.status}")
+        return response
     except HTTPException:
         raise
     except Exception as e:
@@ -88,33 +140,46 @@ async def get_hosted_link(
 
 @router.patch("/status/{link_id}")
 async def update_hosted_link(
+    request: Request,
     link_id: str,
     update_data: LinkDataUpdate,
 ) -> TokenLookupResponse:
-    logger.info(f"Updating hosted link status: {link_id}")
+    logger.info(f"[update_hosted_link] Updating hosted link status: {link_id}")
+    logger.info(f"[update_hosted_link] Request URL: {request.url}")
+    logger.info(f"[update_hosted_link] Update data: {update_data.model_dump()}")
+
     try:
         link_data = HostedLinkManager.get_link_data(link_id)
         if not link_data:
+            logger.warning(f"[update_hosted_link] Link not found: {link_id}")
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Hosted link '{link_id}' not found",
             )
 
+        logger.info(f"[update_hosted_link] Current link status: {link_data.status}")
+
         updated_link = HostedLinkManager.update_link(link_id, update_data)
         if not updated_link:
             if HostedLinkManager.is_expired(link_data):
+                logger.warning(f"[update_hosted_link] Link expired: {link_id}")
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"Hosted link '{link_id}' has expired",
                 )
             else:
+                logger.warning(f"[update_hosted_link] Link not found for update: {link_id}")
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail=f"Hosted link '{link_id}' not found for update",
                 )
 
-        logger.info(f"Updated hosted link {link_id} with status: {updated_link.status}")
-        return TokenLookupResponse(
+        logger.info(f"[update_hosted_link] Successfully updated {link_id}:")
+        logger.info(f"  - new_status: {updated_link.status}")
+        logger.info(f"  - brand_id: {updated_link.brand_id}")
+        logger.info(f"  - profile_id: {updated_link.profile_id}")
+
+        response = TokenLookupResponse(
             link_id=link_id,
             profile_id=updated_link.profile_id,
             brand_id=str(updated_link.brand_id),
@@ -126,6 +191,10 @@ async def update_hosted_link(
             extract_result=updated_link.extract_result,
             message="Link status updated successfully",
         )
+        logger.info(
+            f"[update_hosted_link] Returning updated response with status: {response.status}"
+        )
+        return response
     except HTTPException:
         raise
     except Exception as e:


### PR DESCRIPTION
<img width="333" height="720" alt="image" src="https://github.com/user-attachments/assets/b6eddcd3-7af1-4374-be2d-73f656465cc2" />


Previously I was running into all kinds of wonky issues with hosted link when using a tunnel/gateway like ngrok with a container. 

I went down a rabbit hole and found that it was due to the scheme and the headers that were being sent not being recognized. 

So in a nutshell I: 
1. Ran uvicorn with `--proxy-headers --forwarded-allow-ips='*'` to accept the headers from ngrok for the real client. In a future world, we probably only want to allow specific ips instead of all but ratcheting.
2. inferred the host and therefore created the proper url with the proper scheme
3. Improved logging 