### PR TITLE
fix: slow search product amazon

### DIFF
--- a/getgather/connectors/spec_models.py
+++ b/getgather/connectors/spec_models.py
@@ -586,6 +586,7 @@ class SchemaYML(YMLModel):
     output: str
     row_selector: str
     columns: list[ColumnYML]
+    use_evaluate_extraction: bool = False
 
 
 class Schema(SpecModel[SchemaYML]):
@@ -594,6 +595,7 @@ class Schema(SpecModel[SchemaYML]):
     output: str
     row_selector: str
     columns: list[Column]
+    use_evaluate_extraction: bool = False
 
 
 class BrandSpecYML(YMLModel):

--- a/getgather/connectors/spec_models.py
+++ b/getgather/connectors/spec_models.py
@@ -586,7 +586,7 @@ class SchemaYML(YMLModel):
     output: str
     row_selector: str
     columns: list[ColumnYML]
-    use_evaluate_extraction: bool = False
+    extraction_method: Literal["locator", "evaluate"] = "locator"
 
 
 class Schema(SpecModel[SchemaYML]):
@@ -595,7 +595,7 @@ class Schema(SpecModel[SchemaYML]):
     output: str
     row_selector: str
     columns: list[Column]
-    use_evaluate_extraction: bool = False
+    extraction_method: Literal["locator", "evaluate"] = "locator"
 
 
 class BrandSpecYML(YMLModel):

--- a/getgather/connectors/spec_models.py
+++ b/getgather/connectors/spec_models.py
@@ -586,7 +586,7 @@ class SchemaYML(YMLModel):
     output: str
     row_selector: str
     columns: list[ColumnYML]
-    extraction_method: Literal["locator", "evaluate"] = "locator"
+    extraction_method: Literal["locator", "evaluator"] = "locator"
 
 
 class Schema(SpecModel[SchemaYML]):
@@ -595,7 +595,7 @@ class Schema(SpecModel[SchemaYML]):
     output: str
     row_selector: str
     columns: list[Column]
-    extraction_method: Literal["locator", "evaluate"] = "locator"
+    extraction_method: Literal["locator", "evaluator"] = "locator"
 
 
 class BrandSpecYML(YMLModel):

--- a/getgather/mcp/brand/amazon.py
+++ b/getgather/mcp/brand/amazon.py
@@ -38,7 +38,7 @@ async def search_product(
             "format": "html",
             "output": "search_results.json",
             "row_selector": "div[data-component-type='s-search-result']",
-            "use_evaluate_extraction": True,
+            "extraction_method": "evaluate",
             "columns": [
                 {"name": "product_name", "selector": "h2 span"},
                 {

--- a/getgather/mcp/brand/amazon.py
+++ b/getgather/mcp/brand/amazon.py
@@ -32,13 +32,13 @@ async def search_product(
         page = await session.page()
         await page.goto(f"https://www.amazon.com/s?k={keyword}", wait_until="commit")
         await page.wait_for_selector("div[data-component-type='s-search-result']")
-        await page.wait_for_timeout(500)
 
         spec_schema = SpecSchema.model_validate({
             "bundle": "search_results.html",
             "format": "html",
             "output": "search_results.json",
             "row_selector": "div[data-component-type='s-search-result']",
+            "use_evaluate_extraction": True,
             "columns": [
                 {"name": "product_name", "selector": "h2 span"},
                 {

--- a/getgather/mcp/brand/amazon.py
+++ b/getgather/mcp/brand/amazon.py
@@ -38,7 +38,7 @@ async def search_product(
             "format": "html",
             "output": "search_results.json",
             "row_selector": "div[data-component-type='s-search-result']",
-            "extraction_method": "evaluate",
+            "extraction_method": "evaluator",
             "columns": [
                 {"name": "product_name", "selector": "h2 span"},
                 {

--- a/getgather/parse.py
+++ b/getgather/parse.py
@@ -270,7 +270,7 @@ async def _extract_data_from_page(
 
     # Determine which method to use (default to locator)
     use_evaluate = False
-    
+
     if not has_custom_functions:
         if force_method == "evaluate":
             use_evaluate = True

--- a/getgather/parse.py
+++ b/getgather/parse.py
@@ -3,7 +3,7 @@ import base64
 import json
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from patchright.async_api import Locator, Page, async_playwright
 from pydantic import BaseModel
@@ -108,6 +108,7 @@ async def _parse_by_format(
 
 
 async def _get_value(brand_id: BrandIdEnum, column: Column, element: Locator) -> str | None:
+    """Extract value from an element based on column configuration."""
     if column.attribute is not None:
         return await element.get_attribute(column.attribute)
     elif column.function is not None:
@@ -117,23 +118,39 @@ async def _get_value(brand_id: BrandIdEnum, column: Column, element: Locator) ->
         return await element.inner_text()
 
 
-async def _extract_data_from_page(
+async def _extract_data_with_locators(
     brand_id: BrandIdEnum,
     schema: Schema,
     page: Page,
 ) -> list[dict[str, str | list[str]]]:
-    """Extract data from a page using schema selectors."""
-    data: list[dict[str, str | list[str]]] = []
+    """
+    Extract data from a page using Playwright locators.
 
+    This is the original extraction method that uses individual DOM queries.
+    Best for: Authentication flows, interactive elements, complex waiting conditions.
+
+    Args:
+        brand_id: Brand identifier for custom parsing functions
+        schema: Schema definition with CSS selectors
+        page: Live Playwright page object
+
+    Returns:
+        List of dictionaries containing extracted data
+    """
+    data: list[dict[str, str | list[str]]] = []
     lc_rows = page.locator(schema.row_selector)
+
     for lc in await lc_rows.all():
         row: dict[str, str | list[str]] = {}
+
         for column in schema.columns:
             elements = lc.locator(column.selector)
             count = await elements.count()
+
             if count == 0:
                 row[column.name] = [] if column.multiple else ""
                 continue
+
             if column.multiple:
                 values = await asyncio.gather(*[
                     _get_value(brand_id, column, element) for element in await elements.all()
@@ -144,8 +161,132 @@ async def _extract_data_from_page(
                 row[column.name] = value if value is not None else ""
 
         data.append(row)
-
     return data
+
+
+async def _extract_data_with_evaluate(
+    brand_id: BrandIdEnum,
+    schema: Schema,
+    page: Page,
+) -> list[dict[str, Any]]:
+    """
+    Extract data from a page using JavaScript evaluation.
+
+    This method executes all extraction logic in the browser context in a single call.
+    Best for: Bulk data extraction, search results, product listings, read-only operations.
+
+    Args:
+        brand_id: Brand identifier (not used in evaluate method but kept for consistency)
+        schema: Schema definition with CSS selectors
+        page: Live Playwright page object
+
+    Returns:
+        List of dictionaries containing extracted data
+    """
+    # Prepare column data for JavaScript
+    columns_for_js: list[dict[str, Any]] = []
+    for col in schema.columns:
+        col_data: dict[str, Any] = {
+            "name": col.name,
+            "selector": col.selector,
+            "attribute": col.attribute,
+            "multiple": col.multiple if hasattr(col, "multiple") else False,
+        }
+        columns_for_js.append(col_data)
+
+    # Execute all extraction in a single browser call
+    data: list[dict[str, Any]] = await page.evaluate(
+        """
+        ({rowSelector, columns}) => {
+            const rows = document.querySelectorAll(rowSelector);
+            const results = [];
+
+            for (const row of rows) {
+                const rowData = {};
+
+                for (const col of columns) {
+                    if (col.multiple) {
+                        const elements = row.querySelectorAll(col.selector);
+                        const values = [];
+                        for (const el of elements) {
+                            if (col.attribute) {
+                                values.push(el.getAttribute(col.attribute) || "");
+                            } else {
+                                values.push(el.innerText || "");
+                            }
+                        }
+                        rowData[col.name] = values;
+                    } else {
+                        const el = row.querySelector(col.selector);
+                        if (el) {
+                            if (col.attribute) {
+                                rowData[col.name] = el.getAttribute(col.attribute) || "";
+                            } else {
+                                rowData[col.name] = el.innerText || "";
+                            }
+                        } else {
+                            rowData[col.name] = "";
+                        }
+                    }
+                }
+
+                results.push(rowData);
+            }
+
+            return results;
+        }
+    """,
+        {"rowSelector": schema.row_selector, "columns": columns_for_js},
+    )
+    return data
+
+
+async def _extract_data_from_page(
+    brand_id: BrandIdEnum,
+    schema: Schema,
+    page: Page,
+    *,
+    force_method: Literal["locator", "evaluate", None] = None,
+) -> list[dict[str, str | list[str]]]:
+    """
+    Router function that chooses the appropriate extraction method.
+
+    Decides between locator-based and evaluate-based extraction based on:
+    1. force_method parameter (if specified)
+    2. schema.use_evaluate_extraction flag
+    3. Presence of custom functions (forces locator method)
+
+    Args:
+        brand_id: Brand identifier for custom parsing functions
+        schema: Schema definition with CSS selectors
+        page: Live Playwright page object
+        force_method: Force a specific extraction method
+
+    Returns:
+        List of dictionaries containing extracted data
+    """
+    # Check if we need to use locator method due to custom functions
+    has_custom_functions = any(col.function is not None for col in schema.columns)
+
+    # Determine which method to use (default to locator)
+    use_evaluate = False
+    
+    if not has_custom_functions:
+        if force_method == "evaluate":
+            use_evaluate = True
+        elif force_method != "locator":
+            # Use schema configuration
+            use_evaluate = getattr(schema, "use_evaluate_extraction", False)
+
+    # Execute the appropriate extraction method
+    if use_evaluate:
+        try:
+            return await _extract_data_with_evaluate(brand_id, schema, page)
+        except Exception as e:
+            print(f"[PARSE] Evaluate extraction failed: {e}, falling back to locator method")
+            return await _extract_data_with_locators(brand_id, schema, page)
+    else:
+        return await _extract_data_with_locators(brand_id, schema, page)
 
 
 async def parse_html(
@@ -214,7 +355,7 @@ async def parse_html(
         with open(output_path, "w") as f:
             json.dump(data, f)
         logger.info(f"{len(data)} rows written to {output_path}")
-        return BundleOutput(
+        result = BundleOutput(
             name=schema.bundle,
             parsed=True,
             parse_schema=schema,
@@ -225,12 +366,14 @@ async def parse_html(
         logger.info(
             f"Returning data directly: {data[:200] if data else 'None'}", extra={"schema": schema}
         )
-        return BundleOutput(
+        result = BundleOutput(
             name=schema.bundle,
             parsed=True,
             parse_schema=schema,
             content=data,
         )
+
+    return result
 
 
 # test with:


### PR DESCRIPTION
The amazon search product tools can be very slow. Tried searching for tumbler, it gives ~60 products, but I need to wait for more than a minute to get result. 
In cases like this where we're getting in bulk, I think we can use evaluate to make the process faster, because we don't have to do back and forth between browser and python. 
Using `evaluate` we can save more time significantly when there are a lot of search result. For this instance, we can reduce HTML parsing time from 105.2 s to 0.2s. 

This is what happen with locator:
```
[PARSE] Using locator extraction method
[PARSE] Starting locator-based data extraction from page...
[PARSE] Found 60 rows in 0.216s using locators
[PARSE] Row 1 processed in 1.902s
[PARSE] Row 2 processed in 1.615s
[PARSE] Row 3 processed in 1.693s
[PARSE] Row 4 processed in 1.639s
[PARSE] Row 5 processed in 1.589s
[PARSE] Row 6 processed in 1.590s
[PARSE] Row 7 processed in 1.911s
[PARSE] Row 8 processed in 2.379s
[PARSE] Row 9 processed in 3.291s
[PARSE] Row 10 processed in 2.166s
...
```

For comparison:
- with locator:
```
[AMAZON SEARCH] Time breakdown:
  - Profile setup: 0.001s (0.0%)
  - Session init: 2.424s (2.1%)
  - Page creation: 0.000s (0.0%)
  - Navigation: 1.813s (1.6%)
  - Wait for results: 3.606s (3.2%)
  - Schema creation: 0.003s (0.0%)
  - HTML parsing: 105.179s (93.1%)
```
- with evaluate:
```
[AMAZON SEARCH] Time breakdown:
  - Profile setup: 0.000s (0.0%)
  - Session init: 2.441s (29.8%)
  - Page creation: 0.000s (0.0%)
  - Navigation: 1.884s (23.0%)
  - Wait for results: 3.660s (44.8%)
  - Schema creation: 0.003s (0.0%)
  - HTML parsing: 0.189s (2.3%)
```