### PR TITLE
store brand_id and browser_session in mcp context

### DIFF
--- a/getgather/api/main.py
+++ b/getgather/api/main.py
@@ -224,7 +224,7 @@ IP_CHECK_URL: Final[str] = "https://ifconfig.me/ip"
 
 @app.get("/extended-health")
 async def extended_health():
-    session = await BrowserSession.get(BrowserProfile())
+    session = BrowserSession.get(BrowserProfile())
     try:
         await session.start()
         page = await session.page()

--- a/getgather/auth_flow.py
+++ b/getgather/auth_flow.py
@@ -66,7 +66,7 @@ async def auth_flow(
         else:
             browser_profile = BrowserProfile()
 
-        browser_session = await BrowserSession.get(browser_profile)
+        browser_session = BrowserSession.get(browser_profile)
         await browser_session.start()
         auth_orchestrator = AuthOrchestrator(
             brand_id=brand_id,

--- a/getgather/auth_orchestrator.py
+++ b/getgather/auth_orchestrator.py
@@ -69,7 +69,7 @@ class AuthOrchestrator:
             f"🔥 Starting authentication for {self.brand_id}",
         )
         try:
-            browser_session = await BrowserSession.get(self.browser_profile)
+            browser_session = BrowserSession.get(self.browser_profile)
             await self.state.init(
                 browser_profile_id=self.browser_profile.id, brand_id=self.brand_id
             )
@@ -157,7 +157,7 @@ class AuthOrchestrator:
             f"🚩 Finalizing auth for {self.brand_id}",
             extra={"profile_id": self.browser_profile.id},
         )
-        browser_session = await BrowserSession.get(self.browser_profile)
+        browser_session = BrowserSession.get(self.browser_profile)
         await browser_session.stop()
 
     async def _block_unwanted_resources(self, page: Page) -> None:

--- a/getgather/browser/session.py
+++ b/getgather/browser/session.py
@@ -26,7 +26,7 @@ class BrowserSession:
         self._context: BrowserContext | None = None
 
     @classmethod
-    async def get(cls, profile: BrowserProfile) -> BrowserSession:
+    def get(cls, profile: BrowserProfile) -> BrowserSession:
         if profile.id in cls._sessions:  # retrieve active session
             return cls._sessions[profile.id]
         else:  # create new session
@@ -93,7 +93,7 @@ class BrowserSession:
 
 @asynccontextmanager
 async def browser_session(profile: BrowserProfile, *, nested: bool = False):
-    session = await BrowserSession.get(profile)
+    session = BrowserSession.get(profile)
     if not nested:
         await session.start()
     try:

--- a/getgather/mcp/agent.py
+++ b/getgather/mcp/agent.py
@@ -1,31 +1,30 @@
 from typing import Any
 
-from browser_use import Agent, BrowserSession
+from browser_use import Agent, BrowserSession as BrowserUseBrowserSession
 from browser_use.agent.views import AgentOutput
 from browser_use.browser.views import BrowserStateSummary
 from browser_use.llm import ChatOpenAI
-from fastmcp import Context
+from fastmcp.server.dependencies import get_context
 from patchright.async_api import BrowserContext
 
 from getgather.config import settings
-from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.logs import logger
-from getgather.mcp.shared import start_browser_session
+from getgather.mcp.shared import get_mcp_browser_session, with_brand_browser_session
 
 
-async def run_agent(mcp_context: Context, browser_context: BrowserContext, task: str) -> str | None:
+async def run_agent(browser_context: BrowserContext, task: str) -> str | None:
     # TODO: Add support for non-OpenAI models
     if not settings.BROWSER_USE_MODEL or not settings.OPENAI_API_KEY:
         raise ValueError("BROWSER_USE_MODEL or OPENAI_API_KEY is not set")
 
-    browser_session = BrowserSession(browser_context=browser_context)
+    browser_session = BrowserUseBrowserSession(browser_context=browser_context)
     llm = ChatOpenAI(model=settings.BROWSER_USE_MODEL, api_key=settings.OPENAI_API_KEY)
 
     async def callback(
         browser_state_summary: BrowserStateSummary, agent_output: AgentOutput, step_number: int
     ):
         update = f"[Thinking]: {agent_output.thinking}\n [Next goal]: {agent_output.next_goal}"
-        await mcp_context.report_progress(progress=step_number, message=update)
+        await get_context().report_progress(progress=step_number, message=update)
 
     agent = Agent[Any, Any](
         task=task,
@@ -37,21 +36,15 @@ async def run_agent(mcp_context: Context, browser_context: BrowserContext, task:
     return results.final_result()
 
 
-async def run_agent_for_brand(
-    *, brand_id: BrandIdEnum, task: str, mcp_ctx: Context
-) -> dict[str, Any]:
-    browser_session = None
+@with_brand_browser_session
+async def run_agent_for_brand(task: str) -> dict[str, Any]:
+    browser_session = get_mcp_browser_session()
     try:
-        browser_session = await start_browser_session(brand_id)
-
         logger.info(f"Running agent with task: {task}")
-        result = await run_agent(mcp_ctx, browser_session.context, task)
+        result = await run_agent(browser_session.context, task)
         logger.info(f"Agent result: {result}")
 
         return {"status": "success", "result": result}
     except Exception as e:
         logger.error(f"Error running agent: {e}")
         return {"status": "error", "message": str(e)}
-    finally:
-        if browser_session:
-            await browser_session.stop()

--- a/getgather/mcp/brand/alltrails.py
+++ b/getgather/mcp/brand/alltrails.py
@@ -9,4 +9,4 @@ alltrails_mcp = BrandMCPBase(brand_id="alltrails", name="Alltrails MCP")
 @alltrails_mcp.tool(tags={"private"})
 async def get_feed() -> dict[str, Any]:
     """Get feed of alltrails."""
-    return await extract(brand_id=alltrails_mcp.brand_id)
+    return await extract()

--- a/getgather/mcp/brand/amain.py
+++ b/getgather/mcp/brand/amain.py
@@ -2,24 +2,24 @@ from typing import Any
 
 from getgather.connectors.spec_models import Schema as SpecSchema
 from getgather.mcp.registry import BrandMCPBase
-from getgather.mcp.shared import start_browser_session, stop_browser_session
+from getgather.mcp.shared import get_mcp_browser_session, with_brand_browser_session
 from getgather.parse import parse_html
 
 amain_mcp = BrandMCPBase(brand_id="amain", name="Amain MCP")
 
 
 @amain_mcp.tool(tags={"private"})
+@with_brand_browser_session
 async def get_cart() -> dict[str, Any]:
     """Get cart of amain."""
 
-    browser_session = await start_browser_session(brand_id=amain_mcp.brand_id)
+    browser_session = get_mcp_browser_session()
     page = await browser_session.page()
 
     await page.goto(f"https://www.amainhobbies.com/shopping-cart")
     await page.wait_for_selector("div.product-list")
     await page.wait_for_timeout(1000)
     html = await page.locator("div.product-list").inner_html()
-    await stop_browser_session(brand_id=amain_mcp.brand_id)
     spec_schema = SpecSchema.model_validate({
         "bundle": "",
         "format": "html",

--- a/getgather/mcp/brand/amazon.py
+++ b/getgather/mcp/brand/amazon.py
@@ -5,7 +5,7 @@ from getgather.browser.session import browser_session
 from getgather.connectors.spec_models import Schema as SpecSchema
 from getgather.database.repositories.brand_state_repository import BrandState
 from getgather.mcp.registry import BrandMCPBase
-from getgather.mcp.shared import extract, start_browser_session
+from getgather.mcp.shared import extract, get_mcp_browser_session, with_brand_browser_session
 from getgather.parse import parse_html
 
 amazon_mcp = BrandMCPBase(brand_id="amazon", name="Amazon MCP")
@@ -14,7 +14,7 @@ amazon_mcp = BrandMCPBase(brand_id="amazon", name="Amazon MCP")
 @amazon_mcp.tool(tags={"private"})
 async def get_purchase_history() -> dict[str, Any]:
     """Get purchase/order history of a amazon."""
-    return await extract(brand_id=amazon_mcp.brand_id)
+    return await extract()
 
 
 @amazon_mcp.tool
@@ -78,9 +78,10 @@ async def get_product_detail(
 
 
 @amazon_mcp.tool(tags={"private"})
+@with_brand_browser_session
 async def get_cart_summary() -> dict[str, Any]:
     """Get cart summary from amazon."""
-    browser_session = await start_browser_session(brand_id=amazon_mcp.brand_id)
+    browser_session = get_mcp_browser_session()
     page = await browser_session.page()
     await page.goto("https://www.amazon.com/gp/cart/view.html")
     await page.wait_for_selector("div#sc-active-cart")
@@ -90,9 +91,10 @@ async def get_cart_summary() -> dict[str, Any]:
 
 
 @amazon_mcp.tool(tags={"private"})
+@with_brand_browser_session
 async def get_browsing_history() -> dict[str, Any]:
     """Get browsing history from amazon."""
-    browser_session = await start_browser_session(brand_id=amazon_mcp.brand_id)
+    browser_session = get_mcp_browser_session()
     page = await browser_session.page()
     await page.goto("https://www.amazon.com/gp/history?ref_=nav_AccountFlyout_browsinghistory")
     await page.wait_for_timeout(1000)

--- a/getgather/mcp/brand/astro.py
+++ b/getgather/mcp/brand/astro.py
@@ -165,7 +165,7 @@ def _format_quantity_result(
 @astro_mcp.tool(tags={"private"})
 async def get_purchase_history() -> dict[str, Any]:
     """Get astro purchase history."""
-    return await extract(brand_id=astro_mcp.brand_id)
+    return await extract()
 
 
 @astro_mcp.tool

--- a/getgather/mcp/brand/audible.py
+++ b/getgather/mcp/brand/audible.py
@@ -9,4 +9,4 @@ audible_mcp = BrandMCPBase(brand_id="audible", name="Audible MCP")
 @audible_mcp.tool(tags={"private"})
 async def get_book_list() -> dict[str, Any]:
     """Get book list from Audible.com."""
-    return await extract(audible_mcp.brand_id)
+    return await extract()

--- a/getgather/mcp/brand/bbc.py
+++ b/getgather/mcp/brand/bbc.py
@@ -9,4 +9,4 @@ bbc_mcp = BrandMCPBase(brand_id="bbc", name="BBC MCP")
 @bbc_mcp.tool(tags={"private"})
 async def get_bookmarks() -> dict[str, Any]:
     """Get bookmarks of bbc."""
-    return await extract(brand_id=bbc_mcp.brand_id)
+    return await extract()

--- a/getgather/mcp/brand/cnn.py
+++ b/getgather/mcp/brand/cnn.py
@@ -9,4 +9,4 @@ cnn_mcp = BrandMCPBase(brand_id="cnn", name="CNN MCP")
 @cnn_mcp.tool(tags={"private"})
 async def get_newsletter() -> dict[str, Any]:
     """Get bookmarks of cnn."""
-    return await extract(brand_id=cnn_mcp.brand_id)
+    return await extract()

--- a/getgather/mcp/brand/doordash.py
+++ b/getgather/mcp/brand/doordash.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from fastmcp import Context
 
-from getgather.browser.agent import run_agent_for_brand
+from getgather.mcp.agent import run_agent_for_brand
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
 
@@ -12,7 +12,7 @@ doordash_mcp = BrandMCPBase(brand_id="doordash", name="Doordash MCP")
 @doordash_mcp.tool(tags={"private"})
 async def get_orders() -> dict[str, Any]:
     """Get orders from Doordash.com."""
-    return await extract(brand_id=doordash_mcp.brand_id)
+    return await extract()
 
 
 @doordash_mcp.tool(tags={"private"})
@@ -30,7 +30,7 @@ async def reorder_previous_order(ctx: Context, restaurant_name: str) -> dict[str
         "   and the delivery address is the same as the last order."
         " 5. At the end, confirm the order is placed successfully."
     )
-    return await run_agent_for_brand(brand_id=doordash_mcp.brand_id, task=task, mcp_ctx=ctx)
+    return await run_agent_for_brand(task)
 
 
 @doordash_mcp.tool(tags={"private"})
@@ -43,4 +43,4 @@ async def check_order_status(ctx: Context) -> dict[str, Any]:
         " 2. Find the most recent in progress order on the top of the page,"
         " 3. Extract the order status and return the result."
     )
-    return await run_agent_for_brand(brand_id=doordash_mcp.brand_id, task=task, mcp_ctx=ctx)
+    return await run_agent_for_brand(task)

--- a/getgather/mcp/brand/ebird.py
+++ b/getgather/mcp/brand/ebird.py
@@ -14,7 +14,7 @@ ebird_mcp = BrandMCPBase(brand_id="ebird", name="Ebird MCP")
 @ebird_mcp.tool(tags={"private"})
 async def get_life_list() -> dict[str, Any]:
     """Get life list of a ebird."""
-    return await extract(brand_id=ebird_mcp.brand_id)
+    return await extract()
 
 
 @ebird_mcp.tool

--- a/getgather/mcp/brand/gofood.py
+++ b/getgather/mcp/brand/gofood.py
@@ -9,4 +9,4 @@ gofood_mcp = BrandMCPBase(brand_id="gofood", name="Gofood MCP")
 @gofood_mcp.tool(tags={"private"})
 async def get_purchase_history() -> dict[str, Any]:
     """Get gofood purchase history."""
-    return await extract(brand_id=gofood_mcp.brand_id)
+    return await extract()

--- a/getgather/mcp/brand/goodreads.py
+++ b/getgather/mcp/brand/goodreads.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from fastmcp import Context
 
-from getgather.browser.agent import run_agent_for_brand
+from getgather.mcp.agent import run_agent_for_brand
 from getgather.mcp.registry import BrandMCPBase
 from getgather.mcp.shared import extract
 
@@ -12,7 +12,7 @@ goodreads_mcp = BrandMCPBase(brand_id="goodreads", name="Goodreads MCP")
 @goodreads_mcp.tool(tags={"private"})
 async def get_book_list() -> dict[str, Any]:
     """Get the book list from a user's Goodreads account."""
-    return await extract(brand_id=goodreads_mcp.brand_id)
+    return await extract()
 
 
 @goodreads_mcp.tool(tags={"private"})
@@ -21,11 +21,11 @@ async def add_book_to_want_to_read(ctx: Context, book_name: str) -> dict[str, An
     task = (
         f"You are already logged in Goodreads. Find {book_name} and add it to 'Want to Read' list."
     )
-    return await run_agent_for_brand(brand_id=goodreads_mcp.brand_id, task=task, mcp_ctx=ctx)
+    return await run_agent_for_brand(task)
 
 
 @goodreads_mcp.tool(tags={"private"})
 async def get_recommendation(ctx: Context) -> dict[str, Any]:
     """Get recommendation of a goodreads."""
     task = "Get recommendation of a goodreads"
-    return await run_agent_for_brand(brand_id=goodreads_mcp.brand_id, task=task, mcp_ctx=ctx)
+    return await run_agent_for_brand(task)

--- a/getgather/mcp/brand/hardcover.py
+++ b/getgather/mcp/brand/hardcover.py
@@ -9,4 +9,4 @@ hardcover_mcp = BrandMCPBase(brand_id="hardcover", name="Hardcover MCP")
 @hardcover_mcp.tool(tags={"private"})
 async def get_book_list() -> dict[str, Any]:
     """Get book list from Hardcover.app."""
-    return await extract(brand_id=hardcover_mcp.brand_id)
+    return await extract()

--- a/getgather/mcp/brand/kindle.py
+++ b/getgather/mcp/brand/kindle.py
@@ -9,4 +9,4 @@ kindle_mcp = BrandMCPBase(brand_id="kindle", name="Kindle MCP")
 @kindle_mcp.tool(tags={"private"})
 async def get_book_list() -> dict[str, Any]:
     """Get book list from Amazon Kindle."""
-    return await extract(brand_id=kindle_mcp.brand_id)
+    return await extract()

--- a/getgather/mcp/brand/shopee.py
+++ b/getgather/mcp/brand/shopee.py
@@ -15,7 +15,7 @@ shopee_mcp = BrandMCPBase(brand_id="shopee", name="Shopee MCP")
 @shopee_mcp.tool(tags={"private"})
 async def get_purchase_history() -> dict[str, Any]:
     """Get purchase history of a shopee."""
-    return await extract(brand_id=shopee_mcp.brand_id)
+    return await extract()
 
 
 @shopee_mcp.tool

--- a/getgather/mcp/brand/tokopedia.py
+++ b/getgather/mcp/brand/tokopedia.py
@@ -10,7 +10,7 @@ from getgather.connectors.spec_models import Schema as SpecSchema
 from getgather.database.repositories.brand_state_repository import BrandState
 from getgather.logs import logger
 from getgather.mcp.registry import BrandMCPBase
-from getgather.mcp.shared import start_browser_session
+from getgather.mcp.shared import get_mcp_browser_session, with_brand_browser_session
 from getgather.parse import parse_html
 
 tokopedia_mcp = BrandMCPBase(brand_id="tokopedia", name="Tokopedia MCP")
@@ -272,12 +272,14 @@ async def get_shop_details(
 
 
 @tokopedia_mcp.tool(tags={"private"})
+@with_brand_browser_session
 async def get_purchase_history(
+    *,
     page_number: int = 1,
 ) -> dict[str, Any]:
     """Get purchase history of a tokopedia."""
 
-    browser_session = await start_browser_session(brand_id=tokopedia_mcp.brand_id)
+    browser_session = get_mcp_browser_session()
     page = await browser_session.page()
     await page.goto(f"https://www.tokopedia.com/order-list?page={page_number}")
     raw_data = await handle_graphql_response(
@@ -320,10 +322,10 @@ async def get_purchase_history(
 
 
 @tokopedia_mcp.tool(tags={"private"})
+@with_brand_browser_session
 async def get_cart() -> dict[str, Any]:
     """Get cart of a tokopedia."""
-
-    browser_session = await start_browser_session(brand_id=tokopedia_mcp.brand_id)
+    browser_session = get_mcp_browser_session()
     page = await browser_session.page()
     await page.goto(f"https://www.tokopedia.com/cart")
     raw_data = await handle_graphql_response(
@@ -367,12 +369,10 @@ async def get_cart() -> dict[str, Any]:
 
 
 @tokopedia_mcp.tool(tags={"private"})
-async def get_wishlist(
-    page_number: int = 1,
-) -> dict[str, Any]:
+@with_brand_browser_session
+async def get_wishlist(page_number: int = 1) -> dict[str, Any]:
     """Get purchase history of a tokopedia."""
-
-    browser_session = await start_browser_session(brand_id=tokopedia_mcp.brand_id)
+    browser_session = get_mcp_browser_session()
     page = await browser_session.page()
     await page.goto(f"https://www.tokopedia.com/wishlist/all?page={page_number}")
     raw_data = await handle_graphql_response(

--- a/getgather/mcp/brand/ubereats.py
+++ b/getgather/mcp/brand/ubereats.py
@@ -9,4 +9,4 @@ ubereats_mcp = BrandMCPBase(brand_id="ubereats", name="UberEats MCP")
 @ubereats_mcp.tool(tags={"private"})
 async def get_orders() -> dict[str, Any]:
     """Get orders from UberEats.com."""
-    return await extract(brand_id=ubereats_mcp.brand_id)
+    return await extract()

--- a/getgather/mcp/brand/zillow.py
+++ b/getgather/mcp/brand/zillow.py
@@ -9,4 +9,4 @@ zillow_mcp = BrandMCPBase(brand_id="zillow", name="Zillow MCP")
 @zillow_mcp.tool(tags={"private"})
 async def get_favorites() -> dict[str, Any]:
     """Get favorites of zillow."""
-    return await extract(brand_id=zillow_mcp.brand_id)
+    return await extract()

--- a/getgather/mcp/main.py
+++ b/getgather/mcp/main.py
@@ -60,6 +60,8 @@ class AuthMiddleware(Middleware):
                 return await call_next(context)
 
         brand_id = context.message.name.split("_")[0]
+        context.fastmcp_context.set_state("brand_id", brand_id)
+
         if "private" not in tool.tags or BrandState.is_brand_connected(brand_id):
             async with activity(
                 brand_id=brand_id,

--- a/getgather/mcp/shared.py
+++ b/getgather/mcp/shared.py
@@ -1,9 +1,10 @@
 import asyncio
-from typing import Any
+import functools
+from typing import Any, Awaitable, Callable, ParamSpec, TypeVar
 
 import httpx
 from fastmcp import Context
-from fastmcp.server.dependencies import get_http_headers
+from fastmcp.server.dependencies import get_context, get_http_headers
 
 from getgather.api.routes.link.types import HostedLinkTokenRequest
 from getgather.auth_flow import ExtractResult
@@ -82,17 +83,67 @@ async def poll_status_hosted_link(context: Context, hosted_link_id: str) -> dict
         }
 
 
-async def extract(brand_id: BrandIdEnum) -> dict[str, Any]:
+def get_mcp_brand_id() -> BrandIdEnum:
+    """
+    Get the brand ID from the mcp context.
+    Raise an error if the tool doesn't belong to a brand.
+    """
+    brand_id = get_context().get_state("brand_id")
+    if not brand_id:
+        raise ValueError("Brand ID is not set")
+    return brand_id
+
+
+def get_mcp_browser_session() -> BrowserSession:
+    session = get_context().get_state("browser_session")
+    if not session:
+        raise ValueError("Browser session is not set")
+    return session
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def with_brand_browser_session(func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+    """Run a function with a browser session for the brand stored in the mcp context."""
+
+    @functools.wraps(func)
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        brand_id = get_mcp_brand_id()
+
+        profile_id = (
+            BrandState.get_browser_profile_id(brand_id)
+            if BrandState.is_brand_connected(brand_id)
+            else None
+        )
+        browser_profile = BrowserProfile(id=profile_id) if profile_id else BrowserProfile()
+        browser_session = BrowserSession.get(browser_profile)
+
+        mcp_ctx = get_context()
+        mcp_ctx.set_state("browser_session", browser_session)
+
+        await browser_session.start()
+        try:
+            return await func(*args, **kwargs)
+        finally:
+            await browser_session.stop()
+            mcp_ctx.set_state("browser_session", None)
+
+    return wrapper
+
+
+@with_brand_browser_session
+async def extract() -> dict[str, Any]:
     """Extract data from a brand."""
-    browser_session = await start_browser_session(brand_id=brand_id)
+    browser_session = get_mcp_browser_session()
 
     extract_orchestrator = ExtractOrchestrator(
-        brand_id=brand_id,
+        brand_id=get_mcp_brand_id(),
         browser_profile=browser_session.profile,
         nested_browser_session=True,
     )
     await extract_orchestrator.extract_flow()
-    await browser_session.stop()
     extract_result = ExtractResult(
         profile_id=browser_session.profile.id,
         state=extract_orchestrator.state,
@@ -103,31 +154,3 @@ async def extract(brand_id: BrandIdEnum) -> dict[str, Any]:
     return {
         "extract_result": parsed_bundles if parsed_bundles else extract_result.bundles,
     }
-
-
-async def start_browser_session(brand_id: BrandIdEnum) -> BrowserSession:
-    """Start a browser session and return the page object."""
-    profile_id: str | None = None
-    if BrandState.is_brand_connected(brand_id):
-        profile_id = BrandState.get_browser_profile_id(brand_id)
-
-    if profile_id:
-        browser_profile = BrowserProfile(id=profile_id)
-    else:
-        # For public tools or unauthenticated brands, launch a fresh browser
-        # profile without persisting anything to the store.
-        browser_profile = BrowserProfile()
-
-    browser_session = await BrowserSession.get(browser_profile)
-    await browser_session.start()
-    return browser_session
-
-
-async def stop_browser_session(brand_id: BrandIdEnum) -> None:
-    profile_id = BrandState.get_browser_profile_id(brand_id)
-    if not profile_id:
-        # Nothing to stop if a stored profile was never created for this brand.
-        return None
-    browser_profile = BrowserProfile(id=profile_id)
-    browser_session = await BrowserSession.get(browser_profile)
-    await browser_session.stop()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,10 @@ dependencies = [
   "uvicorn[standard]>=0.34.2",
   # Browser Automation: Locked to specific versions to avoid breaking changes.
   "patchright==1.52.5",
-  "fastmcp>=2.10.5",
   "requests>=2.32.4",
   "httpx>=0.28.1",
   "browser-use>=0.5.10",
+  "fastmcp>=2.11.3",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "3.22.3"
+version = "3.22.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -463,9 +463,9 @@ dependencies = [
     { name = "rich" },
     { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/05/9d5a0a8f4628f6a1230b43e0c34a7dc45c40a17045a09f4a5d7145da12e2/cyclopts-3.22.3.tar.gz", hash = "sha256:7df1d05e4b56b07079e13880b457b78522101531e2947af1a68f182e89742b34", size = 74837, upload-time = "2025-07-23T23:25:09.815Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/d5/24c6c894f3833bc93d4944c2064309dfd633c0becf93e16fc79d76edd388/cyclopts-3.22.5.tar.gz", hash = "sha256:fa2450b9840abc41c6aa37af5eaeafc7a1264e08054e3a2fe39d49aa154f592a", size = 74890, upload-time = "2025-07-31T18:18:37.336Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/1f/4b9f6986add9f6ff361c1bfffeb08fc2f2f6752f8adf8d4dcf0a988b6f28/cyclopts-3.22.3-py3-none-any.whl", hash = "sha256:771ae584868c8beeac74184a96e9fad3726c787b17e47a6f0d5f42cece1df57a", size = 84941, upload-time = "2025-07-23T23:25:08.527Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e5/a7b6db64f08cfe065e531ec6b508fa7dac704fab70d05adb5bc0c2c1d1b6/cyclopts-3.22.5-py3-none-any.whl", hash = "sha256:92efb4a094d9812718d7efe0bffa319a19cb661f230dbf24406c18cd8809fb82", size = 84994, upload-time = "2025-07-31T18:18:35.939Z" },
 ]
 
 [[package]]
@@ -512,11 +512,11 @@ wheels = [
 
 [[package]]
 name = "docutils"
-version = "0.21.2"
+version = "0.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/86/5b41c32ecedcfdb4c77b28b6cb14234f252075f8cdb254531727a35547dd/docutils-0.22.tar.gz", hash = "sha256:ba9d57750e92331ebe7c08a1bbf7a7f8143b86c476acd51528b042216a6aad0f", size = 2277984, upload-time = "2025-07-29T15:20:31.06Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
+    { url = "https://files.pythonhosted.org/packages/44/57/8db39bc5f98f042e0153b1de9fb88e1a409a33cda4dd7f723c2ed71e01f6/docutils-0.22-py3-none-any.whl", hash = "sha256:4ed966a0e96a0477d852f7af31bdcb3adc049fbb35ccba358c2ea8a03287615e", size = 630709, upload-time = "2025-07-29T15:20:28.335Z" },
 ]
 
 [[package]]
@@ -594,7 +594,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "2.10.6"
+version = "2.11.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -602,15 +602,16 @@ dependencies = [
     { name = "exceptiongroup" },
     { name = "httpx" },
     { name = "mcp" },
+    { name = "openapi-core" },
     { name = "openapi-pydantic" },
     { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
     { name = "python-dotenv" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/a0/eceb88277ef9e3a442e099377a9b9c29fb2fa724e234486e03a44ca1c677/fastmcp-2.10.6.tar.gz", hash = "sha256:5a7b3301f9f1b64610430caef743ac70175c4b812e1949f037e4db65b0a42c5a", size = 1640538, upload-time = "2025-07-19T20:02:12.543Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/80/13aec687ec21727b0fe6d26c6fe2febb33ae24e24c980929a706db3a8bc2/fastmcp-2.11.3.tar.gz", hash = "sha256:e8e3834a3e0b513712b8e63a6f0d4cbe19093459a1da3f7fbf8ef2810cfd34e3", size = 2692092, upload-time = "2025-08-11T21:38:46.493Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/05/4958cccbe862958d862b6a15f2d10d2f5ec3c411268dcb131a433e5e7a0d/fastmcp-2.10.6-py3-none-any.whl", hash = "sha256:9782416a8848cc0f4cfcc578e5c17834da620bef8ecf4d0daabf5dd1272411a2", size = 202613, upload-time = "2025-07-19T20:02:11.47Z" },
+    { url = "https://files.pythonhosted.org/packages/61/05/63f63ad5b6789a730d94b8cb3910679c5da1ed5b4e38c957140ac9edcf0e/fastmcp-2.11.3-py3-none-any.whl", hash = "sha256:28f22126c90fd36e5de9cc68b9c271b6d832dcf322256f23d220b68afb3352cc", size = 260231, upload-time = "2025-08-11T21:38:44.746Z" },
 ]
 
 [[package]]
@@ -655,7 +656,7 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "browser-use", specifier = ">=0.5.10" },
     { name = "fastapi", specifier = ">=0.115.12" },
-    { name = "fastmcp", specifier = ">=2.10.5" },
+    { name = "fastmcp", specifier = ">=2.11.3" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "nanoid", specifier = ">=2.0.0" },
@@ -952,6 +953,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1048,6 +1058,21 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema-path"
+version = "0.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/45/41ebc679c2a4fced6a722f624c18d658dee42612b83ea24c1caf7c0eb3a8/jsonschema_path-0.3.4.tar.gz", hash = "sha256:8365356039f16cc65fddffafda5f58766e34bebab7d6d105616ab52bc4297001", size = 11159, upload-time = "2025-01-24T14:33:16.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/58/3485da8cb93d2f393bce453adeef16896751f14ba3e2024bc21dc9597646/jsonschema_path-0.3.4-py3-none-any.whl", hash = "sha256:f502191fdc2b22050f9a81c9237be9d27145b9001c55842bece5e94e382e52f8", size = 14810, upload-time = "2025-01-24T14:33:14.652Z" },
+]
+
+[[package]]
 name = "jsonschema-specifications"
 version = "2025.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1057,6 +1082,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bf/ce/46fbd9c8119cfc3581ee5643ea49464d168028cfb5caff5fc0596d0cf914/jsonschema_specifications-2025.4.1.tar.gz", hash = "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608", size = 15513, upload-time = "2025-04-23T12:34:07.418Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl", hash = "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af", size = 18437, upload-time = "2025-04-23T12:34:05.422Z" },
+]
+
+[[package]]
+name = "lazy-object-proxy"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/f9/1f56571ed82fb324f293661690635cf42c41deb8a70a6c9e6edc3e9bb3c8/lazy_object_proxy-1.11.0.tar.gz", hash = "sha256:18874411864c9fbbbaa47f9fc1dd7aea754c86cfde21278ef427639d1dd78e9c", size = 44736, upload-time = "2025-04-16T16:53:48.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/f6/eb645ca1ff7408bb69e9b1fe692cce1d74394efdbb40d6207096c0cd8381/lazy_object_proxy-1.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:090935756cc041e191f22f4f9c7fd4fe9a454717067adf5b1bbd2ce3046b556e", size = 28047, upload-time = "2025-04-16T16:53:34.679Z" },
+    { url = "https://files.pythonhosted.org/packages/13/9c/aabbe1e8b99b8b0edb846b49a517edd636355ac97364419d9ba05b8fa19f/lazy_object_proxy-1.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:76ec715017f06410f57df442c1a8d66e6b5f7035077785b129817f5ae58810a4", size = 28440, upload-time = "2025-04-16T16:53:36.113Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/24/dae4759469e9cd318fef145f7cfac7318261b47b23a4701aa477b0c3b42c/lazy_object_proxy-1.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9a9f39098e93a63618a79eef2889ae3cf0605f676cd4797fdfd49fcd7ddc318b", size = 28142, upload-time = "2025-04-16T16:53:37.663Z" },
+    { url = "https://files.pythonhosted.org/packages/de/0c/645a881f5f27952a02f24584d96f9f326748be06ded2cee25f8f8d1cd196/lazy_object_proxy-1.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:ee13f67f4fcd044ef27bfccb1c93d39c100046fec1fad6e9a1fcdfd17492aeb3", size = 28380, upload-time = "2025-04-16T16:53:39.07Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0f/6e004f928f7ff5abae2b8e1f68835a3870252f886e006267702e1efc5c7b/lazy_object_proxy-1.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fd4c84eafd8dd15ea16f7d580758bc5c2ce1f752faec877bb2b1f9f827c329cd", size = 28149, upload-time = "2025-04-16T16:53:40.135Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cb/b8363110e32cc1fd82dc91296315f775d37a39df1c1cfa976ec1803dac89/lazy_object_proxy-1.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:d2503427bda552d3aefcac92f81d9e7ca631e680a2268cbe62cd6a58de6409b7", size = 28389, upload-time = "2025-04-16T16:53:43.612Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/89/68c50fcfd81e11480cd8ee7f654c9bd790a9053b9a0efe9983d46106f6a9/lazy_object_proxy-1.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:0613116156801ab3fccb9e2b05ed83b08ea08c2517fdc6c6bc0d4697a1a376e3", size = 28777, upload-time = "2025-04-16T16:53:41.371Z" },
+    { url = "https://files.pythonhosted.org/packages/39/d0/7e967689e24de8ea6368ec33295f9abc94b9f3f0cd4571bfe148dc432190/lazy_object_proxy-1.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:bb03c507d96b65f617a6337dedd604399d35face2cdf01526b913fb50c4cb6e8", size = 29598, upload-time = "2025-04-16T16:53:42.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/1e/fb441c07b6662ec1fc92b249225ba6e6e5221b05623cb0131d082f782edc/lazy_object_proxy-1.11.0-py3-none-any.whl", hash = "sha256:a56a5093d433341ff7da0e89f9b486031ccd222ec8e52ec84d0ec1cdc819674b", size = 16635, upload-time = "2025-04-16T16:53:47.198Z" },
 ]
 
 [[package]]
@@ -1160,7 +1202,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.12.2"
+version = "1.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1175,9 +1217,9 @@ dependencies = [
     { name = "starlette" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/85/f36d538b1286b7758f35c1b69d93f2719d2df90c01bd074eadd35f6afc35/mcp-1.12.2.tar.gz", hash = "sha256:a4b7c742c50ce6ed6d6a6c096cca0e3893f5aecc89a59ed06d47c4e6ba41edcc", size = 426202, upload-time = "2025-07-24T18:29:05.175Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/a8/564c094de5d6199f727f5d9f5672dbec3b00dfafd0f67bf52d995eaa5951/mcp-1.13.0.tar.gz", hash = "sha256:70452f56f74662a94eb72ac5feb93997b35995e389b3a3a574e078bed2aa9ab3", size = 434709, upload-time = "2025-08-14T15:03:58.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/cf/3fd38cfe43962452e4bfadc6966b2ea0afaf8e0286cb3991c247c8c33ebd/mcp-1.12.2-py3-none-any.whl", hash = "sha256:b86d584bb60193a42bd78aef01882c5c42d614e416cbf0480149839377ab5a5f", size = 158473, upload-time = "2025-07-24T18:29:03.419Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/6b/46b8bcefc2ee9e2d2e8d2bd25f1c2512f5a879fac4619d716b194d6e7ccc/mcp-1.13.0-py3-none-any.whl", hash = "sha256:8b1a002ebe6e17e894ec74d1943cc09aa9d23cb931bf58d49ab2e9fa6bb17e4b", size = 160226, upload-time = "2025-08-14T15:03:56.641Z" },
 ]
 
 [[package]]
@@ -1187,6 +1229,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/a0/834b0cebabbfc7e311f30b46c8188790a37f89fc8d756660346fe5abfd09/more_itertools-10.7.0.tar.gz", hash = "sha256:9fddd5403be01a94b204faadcff459ec3568cf110265d3c54323e1e866ad29d3", size = 127671, upload-time = "2025-04-22T14:17:41.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/9f/7ba6f94fc1e9ac3d2b853fdff3035fb2fa5afbed898c4a72b8a020610594/more_itertools-10.7.0-py3-none-any.whl", hash = "sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e", size = 65278, upload-time = "2025-04-22T14:17:40.49Z" },
 ]
 
 [[package]]
@@ -1249,6 +1300,26 @@ wheels = [
 ]
 
 [[package]]
+name = "openapi-core"
+version = "0.19.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "isodate" },
+    { name = "jsonschema" },
+    { name = "jsonschema-path" },
+    { name = "more-itertools" },
+    { name = "openapi-schema-validator" },
+    { name = "openapi-spec-validator" },
+    { name = "parse" },
+    { name = "typing-extensions" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/35/1acaa5f2fcc6e54eded34a2ec74b479439c4e469fc4e8d0e803fda0234db/openapi_core-0.19.5.tar.gz", hash = "sha256:421e753da56c391704454e66afe4803a290108590ac8fa6f4a4487f4ec11f2d3", size = 103264, upload-time = "2025-03-20T20:17:28.193Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/6f/83ead0e2e30a90445ee4fc0135f43741aebc30cca5b43f20968b603e30b6/openapi_core-0.19.5-py3-none-any.whl", hash = "sha256:ef7210e83a59394f46ce282639d8d26ad6fc8094aa904c9c16eb1bac8908911f", size = 106595, upload-time = "2025-03-20T20:17:26.77Z" },
+]
+
+[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1261,12 +1332,50 @@ wheels = [
 ]
 
 [[package]]
+name = "openapi-schema-validator"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-specifications" },
+    { name = "rfc3339-validator" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/f3/5507ad3325169347cd8ced61c232ff3df70e2b250c49f0fe140edb4973c6/openapi_schema_validator-0.6.3.tar.gz", hash = "sha256:f37bace4fc2a5d96692f4f8b31dc0f8d7400fd04f3a937798eaf880d425de6ee", size = 11550, upload-time = "2025-01-10T18:08:22.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/c6/ad0fba32775ae749016829dace42ed80f4407b171da41313d1a3a5f102e4/openapi_schema_validator-0.6.3-py3-none-any.whl", hash = "sha256:f3b9870f4e556b5a62a1c39da72a6b4b16f3ad9c73dc80084b1b11e74ba148a3", size = 8755, upload-time = "2025-01-10T18:08:19.758Z" },
+]
+
+[[package]]
+name = "openapi-spec-validator"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-path" },
+    { name = "lazy-object-proxy" },
+    { name = "openapi-schema-validator" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/af/fe2d7618d6eae6fb3a82766a44ed87cd8d6d82b4564ed1c7cfb0f6378e91/openapi_spec_validator-0.7.2.tar.gz", hash = "sha256:cc029309b5c5dbc7859df0372d55e9d1ff43e96d678b9ba087f7c56fc586f734", size = 36855, upload-time = "2025-06-07T14:48:56.299Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/dd/b3fd642260cb17532f66cc1e8250f3507d1e580483e209dc1e9d13bd980d/openapi_spec_validator-0.7.2-py3-none-any.whl", hash = "sha256:4bbdc0894ec85f1d1bea1d6d9c8b2c3c8d7ccaa13577ef40da9c006c9fd0eb60", size = 39713, upload-time = "2025-06-07T14:48:54.077Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "parse"
+version = "1.20.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/78/d9b09ba24bb36ef8b83b71be547e118d46214735b6dfb39e4bfde0e9b9dd/parse-1.20.2.tar.gz", hash = "sha256:b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce", size = 29391, upload-time = "2024-06-11T04:41:57.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/31/ba45bf0b2aa7898d81cbbfac0e88c267befb59ad91a19e36e1bc5578ddb1/parse-1.20.2-py2.py3-none-any.whl", hash = "sha256:967095588cb802add9177d0c0b6133b5ba33b1ea9007ca800e526f42a85af558", size = 20126, upload-time = "2024-06-11T04:41:55.057Z" },
 ]
 
 [[package]]
@@ -1286,6 +1395,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/58/7cb5211098f1665249af337843cfd1772ca3daa439cb77a042eefcb832b3/patchright-1.52.5-py3-none-win32.whl", hash = "sha256:127b70d12de28d6d70bf1033b386c7b787c58b5535750f915dfe0c6aec4a8bdf", size = 34820935, upload-time = "2025-06-05T21:54:17.143Z" },
     { url = "https://files.pythonhosted.org/packages/9e/3b/e30391b7e610a6e0b536cfb92a01a6af2ca1fc2f3b37e69ad5a3982b94dc/patchright-1.52.5-py3-none-win_amd64.whl", hash = "sha256:043e25cbb69e11db002770fde27eb14c59e5751f16969b4e3d4483e452537dc1", size = 34820943, upload-time = "2025-06-05T21:54:20.105Z" },
     { url = "https://files.pythonhosted.org/packages/9e/6a/b8f0fd8c513667b59b85d3969a5af65a5f2410ff41aff04d597ed5b872d0/patchright-1.52.5-py3-none-win_arm64.whl", hash = "sha256:f406911b5b3b21d70e3b1d1a2780b732575e31f2b012483622cc764166a31d78", size = 30670751, upload-time = "2025-06-05T21:54:23.336Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/93/8f2c2075b180c12c1e9f6a09d1a985bc2036906b13dff1d8917e395f2048/pathable-0.4.4.tar.gz", hash = "sha256:6905a3cd17804edfac7875b5f6c9142a218c7caef78693c2dbbbfbac186d88b2", size = 8124, upload-time = "2025-01-10T18:43:13.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/eb/b6260b31b1a96386c0a880edebe26f89669098acea8e0318bff6adb378fd/pathable-0.4.4-py3-none-any.whl", hash = "sha256:5ae9e94793b6ef5a4cbe0a7ce9dbbefc1eec38df253763fd0aeeacf2762dbbc2", size = 9592, upload-time = "2025-01-10T18:43:11.88Z" },
 ]
 
 [[package]]
@@ -4575,6 +4693,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5142,6 +5272,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/af/d4502dc713b4ccea7175d764718d5183caf8d0867a4f0190d5d4a45cea49/werkzeug-3.1.1.tar.gz", hash = "sha256:8cd39dfbdfc1e051965f156163e2974e52c210f130810e9ad36858f0fd3edad4", size = 806453, upload-time = "2024-11-01T16:40:45.462Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/ea/c67e1dee1ba208ed22c06d1d547ae5e293374bfc43e0eb0ef5e262b68561/werkzeug-3.1.1-py3-none-any.whl", hash = "sha256:a71124d1ef06008baafa3d266c02f56e1836a5984afd6dd6c9230669d60d9fb5", size = 224371, upload-time = "2024-11-01T16:40:43.994Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
the changes simplified tool definition to 4~5 lines and don't have to worry about fetching brand_id and browser_session, for example

example of simple extract
```
@goodreads_mcp.tool(tags={"private"})
async def get_book_list() -> dict[str, Any]:
    """Get the book list from a user's Goodreads account."""
    return await extract()
```

example of simple browser-use agent
```
@goodreads_mcp.tool(tags={"private"})
async def get_recommendation(ctx: Context) -> dict[str, Any]:
    """Get recommendation of a goodreads."""
    task = "Get recommendation of a goodreads"
    return await run_agent_for_brand(task)
```

example of more complex tool that needs access to browser_session
```
@tokopedia_mcp.tool(tags={"private"})
@with_brand_browser_session
async def get_cart() -> dict[str, Any]:
    """Get cart of a tokopedia."""
    browser_session = get_mcp_browser_session()
    page = await browser_session.page()
    ...
```

mcp has a convenient way to retrieve context with get_context, which can store brand_id and browser_session so we don't need to pass around
that made is easy to create a with_brand_browser_session decorator for brand mcp tools, which simplifies the code
it also made sure browser sessions are always closed properly, which is currently missed in a few places

Verified the tools definition still works with decorator

```
In [1]: from getgather.mcp.brand import tokopedia

In [2]: tokopedia.get_purchase_history.to_mcp_tool()
Out[2]: 

Tool(
    name='get_purchase_history',
    title=None,
    description='Get purchase history of a tokopedia.',
    inputSchema={
        'properties': {'page_number': {'default': 1, 'title': 'Page Number', 'type': 'integer'}},
        'type': 'object'
    },
    outputSchema={'additionalProperties': True, 'type': 'object'},
    annotations=None,
    meta={'_fastmcp': {'tags': ['private']}}
)
```