### PR TITLE
fix: search product on amazon

### DIFF
--- a/getgather/mcp/brand/amazon.py
+++ b/getgather/mcp/brand/amazon.py
@@ -51,6 +51,7 @@ async def search_product(
                 {"name": "currency", "selector": "span.a-price-symbol"},
                 {"name": "rating", "selector": "span.a-icon-alt"},
                 {"name": "image_url", "selector": "img.s-image", "attribute": "src"},
+                {"name": "reviews", "selector": "div[data-cy='reviews-block']"},
             ],
         })
 

--- a/getgather/mcp/brand/amazon.py
+++ b/getgather/mcp/brand/amazon.py
@@ -30,28 +30,35 @@ async def search_product(
 
     async with browser_session(profile) as session:
         page = await session.page()
-        await page.goto(f"https://www.amazon.com/s?k={keyword}")
-        await page.wait_for_selector("div[role='listitem]")
-        await page.wait_for_timeout(1000)
-        html = await page.locator("div.s-search-results").inner_html()
-    spec_schema = SpecSchema.model_validate({
-        "bundle": "",
-        "format": "html",
-        "output": "",
-        "row_selector": "div[role='listitem']",
-        "columns": [
-            {"name": "product_name", "selector": "div[data-cy='title-recipe'] > a"},
-            {
-                "name": "product_url",
-                "selector": "div[data-cy='title-recipe'] > a",
-                "attribute": "href",
-            },
-            {"name": "price", "selector": "div[data-cy='price-recipe']"},
-            {"name": "reviews", "selector": "div[data-cy='reviews-block']"},
-        ],
-    })
-    result = await parse_html(brand_id=amazon_mcp.brand_id, html_content=html, schema=spec_schema)
-    return {"product_list": result.content}
+        await page.goto(f"https://www.amazon.com/s?k={keyword}", wait_until="commit")
+        await page.wait_for_selector("div[data-component-type='s-search-result']")
+        await page.wait_for_timeout(500)
+
+        spec_schema = SpecSchema.model_validate({
+            "bundle": "search_results.html",
+            "format": "html",
+            "output": "search_results.json",
+            "row_selector": "div[data-component-type='s-search-result']",
+            "columns": [
+                {"name": "product_name", "selector": "h2 span"},
+                {
+                    "name": "product_url",
+                    "selector": "div[data-cy='title-recipe'] a",
+                    "attribute": "href",
+                },
+                {"name": "price", "selector": "span.a-price-whole"},
+                {"name": "price_fraction", "selector": "span.a-price-fraction"},
+                {"name": "currency", "selector": "span.a-price-symbol"},
+                {"name": "rating", "selector": "span.a-icon-alt"},
+                {"name": "image_url", "selector": "img.s-image", "attribute": "src"},
+            ],
+        })
+
+        bundle_result = await parse_html(
+            brand_id=amazon_mcp.brand_id, schema=spec_schema, page=page
+        )
+
+        return {"product_list": bundle_result.content or []}
 
 
 @amazon_mcp.tool


### PR DESCRIPTION
Background 

The parse function took too long when we give the html directly, because it tries to create a new headless instance based on the html given. When using the parse, we already have the page and can use that to find what we need. 

This PR is part of #129. We're solving too many problems with undecided solution in that PR, so I'm creating a new PR to tackle each one to make it clearer. 

Can search product with no problem:
<img width="1198" height="1272" alt="CleanShot 2025-08-20 at 12 43 53@2x" src="https://github.com/user-attachments/assets/03f28a60-505d-4359-a0fd-cb003f1ef322" />
