### PR TITLE
Fix: simplify RRWeb recording for whole page

### DIFF
--- a/getgather/browser/session.py
+++ b/getgather/browser/session.py
@@ -67,11 +67,8 @@ class BrowserSession:
                 profile_id=self.profile.id, browser_type=self.playwright.chromium
             )
 
-            # Set up page navigation handler for conditional RRWeb injection
-            async def handle_page(page: Page):
-                await rrweb_injector.inject_into_page(page)
-
-            self._context.on("page", handle_page)
+            await self._context.expose_function("saveEvent", rrweb_injector.save_event)
+            await rrweb_injector.inject_into_context(self._context)
         except Exception as e:
             logger.error(f"Error starting browser: {e}")
             raise BrowserStartupError(f"Failed to start browser: {e}") from e


### PR DESCRIPTION
Simplified RRWeb injection script to record whole page instead of individual iframes. Updated configuration to use standard rrweb options with canvas and font recording enabled.