### PR TITLE
feat: include digital items in purchase history

### DIFF
--- a/getgather/connectors/brand_specs/amazon/specs.yml
+++ b/getgather/connectors/brand_specs/amazon/specs.yml
@@ -187,23 +187,30 @@ parse:
   - bundle: orders.html
     format: html
     output: orders.json
-    row_selector: li.order-card__list
+    row_selector: li.order-card__list, div.order-card.js-order-card
     columns:
       - name: order_date
-        selector: div.a-box-inner h5 div.a-span3 div:nth-child(2)
+        selector: div.a-box-inner h5 div.a-span3 div:nth-child(2), div.a-box-inner div.a-span3 div:nth-child(2)
       - name: order_total
-        selector: div.a-box-inner h5 div.a-span2 div:nth-child(2)
+        selector: div.a-box-inner h5 div.a-span2 div:nth-child(2), div.a-box-inner div.a-span2 div:nth-child(2)
       - name: ship_to
         selector: div.yohtmlc-recipient div:nth-child(2) div.a-popover-preload
       - name: order_id
         selector: div.yohtmlc-order-id span:nth-child(2)
       - name: product_names
-        selector: div.yohtmlc-product-title
+        selector: div.yohtmlc-product-title, a.a-link-normal[href*="/gp/product/"], a.a-link-normal[href*="/gp/video/"], .a-fixed-left-grid-col
+          a.a-link-normal
         multiple: true
       - name: image_urls
-        selector: div.product-image img
+        selector: div.product-image img, .item-view-left-col-inner img
         multiple: true
         attribute: src
       - name: return_window_dates
         selector: span[class="a-size-small"]
+        multiple: true
+      - name: product_type
+        selector: span.a-size-small.a-color-secondary.a-text-bold, .a-size-small.a-color-secondary.a-text-bold
+        multiple: true
+      - name: author_or_creator
+        selector: span.a-size-small:not(.a-color-secondary), .a-size-small:not(.a-color-secondary)
         multiple: true


### PR DESCRIPTION
The element for the digital and regular item is different, thus we need to add this element for digital purchases, such as books.

(tested with amazon japan)
<img width="1368" height="846" alt="CleanShot 2025-08-25 at 09 32 10@2x" src="https://github.com/user-attachments/assets/0d5e7806-484c-48d6-94af-18d0566887e4" />
