### PR TITLE
Manual distillation test via CLI

### DIFF
--- a/getgather.py
+++ b/getgather.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+
+import argparse
+import asyncio
+import os
+import sys
+import urllib.parse
+from typing import TypedDict, cast
+
+import nanoid
+import pwinput
+from bs4 import BeautifulSoup
+from bs4.element import Tag
+from patchright.async_api import BrowserContext, Page, async_playwright
+
+from getgather.distill import Pattern, distill
+
+NORMAL = "\033[0m"
+BOLD = "\033[1m"
+YELLOW = "\033[93m"
+MAGENTA = "\033[35m"
+RED = "\033[91m"
+GREEN = "\033[92m"
+CYAN = "\033[36m"
+
+ARROW = "⇢"
+CROSS = "✘"
+
+FRIENDLY_CHARS = "23456789abcdefghijkmnpqrstuvwxyz"
+
+
+async def sleep(seconds: float):
+    await asyncio.sleep(seconds)
+
+
+async def ask(message: str, mask: str | None = None) -> str:
+    if mask:
+        return pwinput.pwinput(f"{message}: ", mask=mask)
+    else:
+        return input(f"{message}: ")
+
+
+async def click(page: Page, selector: str, timeout: int = 3000) -> None:
+    LOCATOR_ALL_TIMEOUT = 100
+    locator = page.locator(selector)
+    try:
+        elements = await locator.all()
+        print(f'Found {len(elements)} elements for selector "{selector}"')
+        for element in elements:
+            print("Checking", element)
+            if await element.is_visible():
+                print("Clicking on", element)
+                try:
+                    await element.click()
+                    return
+                except Exception as err:
+                    print(f"Failed to click on {selector} {element}: {err}")
+    except Exception as e:
+        if timeout > 0 and "TimeoutError" in str(type(e)):
+            print(f"retrying click {selector} {timeout}")
+            await click(page, selector, timeout - LOCATOR_ALL_TIMEOUT)
+            return
+        raise e
+
+
+def search(directory: str) -> list[str]:
+    results: list[str] = []
+    for root, _, files in os.walk(directory):
+        for file in files:
+            results.append(os.path.join(root, file))
+    return results
+
+
+def parse(html: str):
+    return BeautifulSoup(html, "html.parser")
+
+
+class Handle(TypedDict):
+    id: str
+    hostname: str
+    location: str
+    context: BrowserContext
+    page: Page
+
+
+async def init(location: str = "", hostname: str = "") -> Handle:
+    global playwright_instance, browser_instance
+
+    id = nanoid.generate(FRIENDLY_CHARS, 6)
+    directory = f"data/profiles/{id}"
+
+    if not playwright_instance:
+        playwright_instance = await async_playwright().start()
+        browser_instance = await playwright_instance.chromium.launch(
+            headless=False, channel="chromium"
+        )
+
+    context = await playwright_instance.chromium.launch_persistent_context(  # type: ignore
+        directory, headless=False, viewport={"width": 1920, "height": 1080}
+    )
+
+    page = context.pages[0] if context.pages else await context.new_page()
+    return {"id": id, "hostname": hostname, "location": location, "context": context, "page": page}
+
+
+def load_patterns() -> list[Pattern]:
+    patterns: list[Pattern] = []
+    for name in [f for f in search("./getgather/connectors/brand_specs") if f.endswith(".html")]:
+        with open(name, "r", encoding="utf-8") as f:
+            content = f.read()
+        pattern = parse(content)
+        patterns.append({"name": name, "pattern": pattern})
+    return patterns
+
+
+async def autofill(page: Page, distilled: str, fields: list[str]):
+    document = parse(distilled)
+    root = document.find("html")
+    domain = None
+    if root:
+        domain = cast(Tag, root).get("gg-domain")
+
+    for field in fields:
+        element = document.find("input", {"type": field})
+        selector = None
+        if element:
+            selector = cast(Tag, element).get("gg-match")
+
+        if element and selector:
+            source = f"{domain}_{field}" if domain else field
+            key = source.upper()
+            value = os.getenv(key)
+
+            if value and len(value) > 0:
+                print(f"{CYAN}{ARROW} Using {BOLD}{key}{NORMAL} for {field}{NORMAL}")
+                await page.fill(str(selector), value)
+            else:
+                placeholder = cast(Tag, element).get("placeholder")
+                prompt = str(placeholder) if placeholder else f"Please enter {field}"
+                mask = "*" if field == "password" else None
+                await page.fill(str(selector), await ask(prompt, mask))
+            await sleep(0.25)
+
+
+async def autoclick(page: Page, distilled: str):
+    document = parse(distilled)
+    buttons = document.find_all(attrs={"gg-autoclick": True})
+
+    for button in buttons:
+        if isinstance(button, Tag):
+            selector = button.get("gg-match")
+            if selector:
+                print(f"{CYAN}{ARROW} Auto-clicking {NORMAL}{selector}")
+                await click(page, str(selector))
+
+
+async def terminate(page: Page, distilled: str) -> bool:
+    document = parse(distilled)
+    stops = document.find_all(attrs={"gg-stop": True})
+    if len(stops) > 0:
+        print("Found stop elements, terminating session...")
+        return True
+    return False
+
+
+playwright_instance = None
+browser_instance = None
+
+
+async def list_command():
+    spec_files = search("./getgather/connectors/brand_specs")
+    spec_files = [f for f in spec_files if f.endswith(".html")]
+
+    for name in spec_files:
+        print(name.replace("specs/", ""))
+
+
+async def distill_command(location: str, option: str | None = None):
+    patterns = load_patterns()
+
+    print(f"Distilling {location}")
+
+    async with async_playwright() as p:
+        if location.startswith("http"):
+            hostname = urllib.parse.urlparse(location).hostname
+            browser = await p.chromium.launch(headless=False, channel="chromium")
+            context = await browser.new_context()
+            page = await context.new_page()
+            await page.goto(location)
+        else:
+            hostname = option or ""
+            browser = await p.chromium.launch(headless=False, channel="chromium")
+            context = await browser.new_context()
+            page = await context.new_page()
+
+            with open(location, "r", encoding="utf-8") as f:
+                content = f.read()
+            await page.set_content(content)
+
+        match = await distill(hostname, page, patterns)
+
+        if match:
+            distilled = match["distilled"]
+            print()
+            print(distilled)
+            print()
+
+        await browser.close()
+
+
+async def run_command(location: str):
+    if not location.startswith("http"):
+        location = f"https://{location}"
+
+    hostname = urllib.parse.urlparse(location).hostname or ""
+    patterns = load_patterns()
+
+    browser_data = await init(location, hostname)
+    browser_id = browser_data["id"]
+    context = browser_data["context"]
+    page = browser_data["page"]
+
+    print(f"Starting browser {browser_id}")
+
+    print(f"{GREEN}{ARROW} Navigating to {NORMAL}{location}")
+    await page.goto(location)
+
+    TICK = 1  # seconds
+    TIMEOUT = 15  # seconds
+    max = TIMEOUT // TICK
+
+    current = {"name": None, "distilled": None}
+
+    try:
+        for iteration in range(max):
+            print()
+            print(f"{MAGENTA}Iteration {iteration + 1}{NORMAL} of {max}")
+            await sleep(TICK)
+
+            match = await distill(hostname, page, patterns)
+            if match:
+                name = match["name"]
+                distilled = match["distilled"]
+
+                if distilled == current["distilled"]:
+                    print(f"Still the same: {name}")
+                else:
+                    current = match
+                    print()
+                    print(distilled)
+                    await autofill(page, distilled, ["email", "password", "tel", "text"])
+                    await autoclick(page, distilled)
+
+                    if await terminate(page, distilled):
+                        break
+            else:
+                print(f"{CROSS}{RED} No matched pattern found{NORMAL}")
+
+        print()
+        print(f"Terminating browser {browser_id}")
+
+    finally:
+        await context.close()
+        print("Terminated.")
+
+
+async def inspect_command(id: str, option: str | None = None):
+    directory = f"data/profiles/{id}"
+
+    async with async_playwright() as p:
+        context = await p.chromium.launch_persistent_context(directory, headless=False)
+        page = context.pages[0] if context.pages else await context.new_page()
+
+        if option and len(option) > 0:
+            url = option if option.startswith("http") else f"https://{option}"
+            await page.goto(url)
+
+        await context.close()
+
+
+async def main():
+    if len(sys.argv) == 1:
+        return "server"
+
+    parser = argparse.ArgumentParser(description="MIDDLEMAN")
+    subparsers = parser.add_subparsers(dest="command", help="Commands")
+
+    subparsers.add_parser("list", help="List all patterns")
+
+    distill_parser = subparsers.add_parser("distill", help="Distill a webpage")
+    distill_parser.add_argument("parameter", help="URL or file path")
+    distill_parser.add_argument("option", nargs="?", help="Hostname for file distillation")
+
+    run_parser = subparsers.add_parser("run", help="Run automation")
+    run_parser.add_argument("parameter", help="URL or domain")
+
+    inspect_parser = subparsers.add_parser("inspect", help="Inspect browser session")
+    inspect_parser.add_argument("parameter", help="Browser ID")
+    inspect_parser.add_argument("option", nargs="?", help="URL to navigate to")
+
+    subparsers.add_parser("server", help="Start web server")
+
+    args = parser.parse_args()
+
+    if args.command == "list":
+        await list_command()
+    elif args.command == "distill":
+        await distill_command(args.parameter, args.option)
+    elif args.command == "run":
+        await run_command(args.parameter)
+    elif args.command == "inspect":
+        await inspect_command(args.parameter, args.option)
+    elif args.command == "server":
+        return "server"
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    result = asyncio.run(main())
+    if result == "server":
+        print("TODO: launch MCP server")

--- a/getgather/connectors/brand_specs/goodreads/goodreads-books.html
+++ b/getgather/connectors/brand_specs/goodreads/goodreads-books.html
@@ -1,0 +1,10 @@
+<html gg-domain="goodreads">
+  <head>
+    <title>Goodreads Bookshelf</title>
+  </head>
+  <body>
+    <table>
+      <tbody gg-stop gg-match-html="tbody#booksBody"></tbody>
+    </table>
+  </body>
+</html>

--- a/getgather/connectors/brand_specs/goodreads/goodreads-overlay.html
+++ b/getgather/connectors/brand_specs/goodreads/goodreads-overlay.html
@@ -1,0 +1,8 @@
+<html gg-domain="goodreads" gg-priority="0">
+  <body>
+    <h1>Discover</h1>
+    <button gg-autoclick gg-match='div.loginModal a:has-text("Sign in")'>
+      Sign-in
+    </button>
+  </body>
+</html>

--- a/getgather/connectors/brand_specs/goodreads/goodreads-select-signin.html
+++ b/getgather/connectors/brand_specs/goodreads/goodreads-select-signin.html
@@ -1,0 +1,10 @@
+<html gg-domain="goodreads">
+  <body>
+    <button gg-match=".thirdPartyConnectButton">Third Party</button>
+    <button gg-match=".appleConnectButton">Apple</button>
+    <button gg-match=".amazonSignInButton">Amazon</button>
+    <button gg-autoclick gg-match="button.authPortalSignInButton">
+      Email sign-in
+    </button>
+  </body>
+</html>

--- a/getgather/connectors/brand_specs/goodreads/goodreads-signin.html
+++ b/getgather/connectors/brand_specs/goodreads/goodreads-signin.html
@@ -1,0 +1,30 @@
+<html gg-domain="goodreads">
+  <head>
+    <title>Goodreads Sign In</title>
+  </head>
+  <body>
+    <h4 gg-optional gg-match=".a-alert-heading"></h4>
+    <p gg-optional gg-match=".a-alert-content"></p>
+    <input
+      autofocus
+      name="email"
+      type="email"
+      placeholder="Email"
+      gg-match="input[type=email]"
+    />
+    <input
+      name="password"
+      type="password"
+      placeholder="Password"
+      gg-match="input[type=password]"
+    />
+    <input
+      gg-autoclick
+      name="remember"
+      type="checkbox"
+      gg-match="input[name=rememberMe]"
+      style="display: none"
+    />
+    <button gg-autoclick gg-match="input[type=submit]">Sign in</button>
+  </body>
+</html>

--- a/getgather/connectors/brand_specs/goodreads/goodreads-signup.html
+++ b/getgather/connectors/brand_specs/goodreads/goodreads-signup.html
@@ -1,0 +1,6 @@
+<html gg-domain="goodreads" gg-priority="4">
+  <body>
+    <h1 gg-match='h1:has-text("Sign up")'>Sign up</h1>
+    <button gg-autoclick gg-match="a[href*=sign_in]">Sign in</button>
+  </body>
+</html>

--- a/getgather/connectors/brand_specs/goodreads/goodreads-siteheader.html
+++ b/getgather/connectors/brand_specs/goodreads/goodreads-siteheader.html
@@ -1,0 +1,7 @@
+<html gg-domain="goodreads" gg-priority="1">
+  <body>
+    <ul>
+      <li gg-autoclick gg-match='nav li a:has-text("My Books")'>My Books</li>
+    </ul>
+  </body>
+</html>

--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -1,0 +1,118 @@
+from typing import TypedDict
+
+from bs4 import BeautifulSoup
+from bs4.element import Tag
+from patchright.async_api import Locator, Page
+
+NORMAL = "\033[0m"
+BOLD = "\033[1m"
+YELLOW = "\033[93m"
+GRAY = "\033[90m"
+CHECK = "✓"
+
+
+class Pattern(TypedDict):
+    name: str
+    pattern: BeautifulSoup
+
+
+class Match(TypedDict):
+    name: str
+    priority: int
+    distilled: str
+    matches: list[Locator]
+
+
+async def locate(locator: Locator) -> Locator | None:
+    count = await locator.count()
+    if count > 0:
+        for i in range(count):
+            el = locator.nth(i)
+            if await el.is_visible():
+                return el
+    return None
+
+
+async def distill(hostname: str | None, page: Page, patterns: list[Pattern]) -> Match | None:
+    result: list[Match] = []
+
+    for item in patterns:
+        name = item["name"]
+        pattern = item["pattern"]
+
+        root = pattern.find("html")
+        gg_priority = root.get("gg-priority", "-1") if isinstance(root, Tag) else "-1"
+        try:
+            priority = int(str(gg_priority).lstrip("= "))
+        except ValueError:
+            priority = -1
+        domain = root.get("gg-domain") if isinstance(root, Tag) else None
+
+        if domain and hostname:
+            if isinstance(domain, str) and domain.lower() not in hostname.lower():
+                print(f"{GRAY}Skipping {name} due to mismatched domain {domain}{NORMAL}")
+                continue
+
+        print(f"Checking {name} with priority {priority}")
+
+        found = True
+        matches: list[Locator] = []
+        targets = pattern.find_all(attrs={"gg-match": True}) + pattern.find_all(
+            attrs={"gg-match-html": True}
+        )
+
+        for target in targets:
+            if not isinstance(target, Tag):
+                continue
+
+            html = target.get("gg-match-html")
+            selector = html if html else target.get("gg-match")
+
+            if not selector or not isinstance(selector, str):
+                continue
+
+            source = await locate(page.locator(selector))
+
+            if source:
+                if html:
+                    target.clear()
+                    fragment = BeautifulSoup(
+                        "<div>" + await source.inner_html() + "</div>", "html.parser"
+                    )
+                    if fragment.div:
+                        for child in list(fragment.div.children):
+                            child.extract()
+                            target.append(child)
+                else:
+                    raw_text = await source.text_content()
+                    if raw_text:
+                        target.string = raw_text.strip()
+                matches.append(source)
+            else:
+                optional = target.get("gg-optional") is not None
+                print(f"{GRAY}Optional {selector} has no match{NORMAL}")
+                if not optional:
+                    found = False
+
+        if found and len(matches) > 0:
+            distilled = str(pattern)
+            result.append({
+                "name": name,
+                "priority": priority,
+                "distilled": distilled,
+                "matches": matches,
+            })
+
+    result = sorted(result, key=lambda x: x["priority"])
+
+    if len(result) == 0:
+        print("No matches found")
+        return None
+    else:
+        print(f"Number of matches: {len(result)}")
+        for item in result:
+            print(f" - {item['name']} with priority {item['priority']}")
+
+        match = result[0]
+        print(f"{YELLOW}{CHECK} Best match: {BOLD}{match['name']}{NORMAL}")
+        return match

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
   "fastmcp>=2.11.3",
   "beautifulsoup4>=4.13.4",
   "lxml>=6.0.0",
+  "python-multipart>=0.0.20",
+  "pwinput>=1.0.3",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -629,8 +629,10 @@ dependencies = [
     { name = "lxml" },
     { name = "nanoid" },
     { name = "patchright" },
+    { name = "pwinput" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
@@ -665,8 +667,10 @@ requires-dist = [
     { name = "lxml", specifier = ">=6.0.0" },
     { name = "nanoid", specifier = ">=2.0.0" },
     { name = "patchright", specifier = "==1.52.5" },
+    { name = "pwinput", specifier = ">=1.0.3" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "pydantic-settings", specifier = ">=2.9.1" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "rich", specifier = ">=14.0.0" },
@@ -1561,6 +1565,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/50/e6/eecf58810b9d12e6427369784efe814a1eec0f492084ce8eb8f4d89d6d61/psutil-7.0.0-cp37-abi3-win32.whl", hash = "sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99", size = 241053, upload-time = "2025-02-13T21:54:34.31Z" },
     { url = "https://files.pythonhosted.org/packages/50/1b/6921afe68c74868b4c9fa424dad3be35b095e16687989ebbb50ce4fceb7c/psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553", size = 244885, upload-time = "2025-02-13T21:54:37.486Z" },
 ]
+
+[[package]]
+name = "pwinput"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/c9/f6d03c2214c282251baa38c6be08f5b9f81f1ea488716cd2335e7e190b58/pwinput-1.0.3.tar.gz", hash = "sha256:ca1a8bd06e28872d751dbd4132d8637127c25b408ea3a349377314a5491426f3", size = 4433, upload-time = "2023-02-16T17:04:14.592Z" }
 
 [[package]]
 name = "pyasn1"


### PR DESCRIPTION
This is mainly copied from Middleman with very little modification. I plan to have a follow-up which will do the following:

* Use a proper and richer logging
* Avoid custom browser code and reuse the existing abstraction
* Switch to idiomatic Pydantic

For now, try this by running:

```bash
./getgather.py run goodreads.com/review
```

and you'll be prompted for email and password. If nothing goes wrong, the list of books will be printed out in its original HTML table.

And to run a simple distillation:

```bash
./getgather.py distill https://www.goodreads.com/user/sign_in
```