### PR TITLE
Use pydantic for classes

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -1,8 +1,7 @@
-from typing import TypedDict
-
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 from patchright.async_api import Locator, Page
+from pydantic import BaseModel, Field
 
 NORMAL = "\033[0m"
 BOLD = "\033[1m"
@@ -11,16 +10,22 @@ GRAY = "\033[90m"
 CHECK = "✓"
 
 
-class Pattern(TypedDict):
+class Pattern(BaseModel):
     name: str
     pattern: BeautifulSoup
 
+    class Config:
+        arbitrary_types_allowed = True
 
-class Match(TypedDict):
+
+class Match(BaseModel):
     name: str
-    priority: int
+    priority: int = Field(ge=-1, description="Priority level for matching")
     distilled: str
     matches: list[Locator]
+
+    class Config:
+        arbitrary_types_allowed = True
 
 
 async def locate(locator: Locator) -> Locator | None:
@@ -37,8 +42,8 @@ async def distill(hostname: str | None, page: Page, patterns: list[Pattern]) -> 
     result: list[Match] = []
 
     for item in patterns:
-        name = item["name"]
-        pattern = item["pattern"]
+        name = item.name
+        pattern = item.pattern
 
         root = pattern.find("html")
         gg_priority = root.get("gg-priority", "-1") if isinstance(root, Tag) else "-1"
@@ -96,14 +101,16 @@ async def distill(hostname: str | None, page: Page, patterns: list[Pattern]) -> 
 
         if found and len(matches) > 0:
             distilled = str(pattern)
-            result.append({
-                "name": name,
-                "priority": priority,
-                "distilled": distilled,
-                "matches": matches,
-            })
+            result.append(
+                Match(
+                    name=name,
+                    priority=priority,
+                    distilled=distilled,
+                    matches=matches,
+                )
+            )
 
-    result = sorted(result, key=lambda x: x["priority"])
+    result = sorted(result, key=lambda x: x.priority)
 
     if len(result) == 0:
         print("No matches found")
@@ -111,8 +118,8 @@ async def distill(hostname: str | None, page: Page, patterns: list[Pattern]) -> 
     else:
         print(f"Number of matches: {len(result)}")
         for item in result:
-            print(f" - {item['name']} with priority {item['priority']}")
+            print(f" - {item.name} with priority {item.priority}")
 
         match = result[0]
-        print(f"{YELLOW}{CHECK} Best match: {BOLD}{match['name']}{NORMAL}")
+        print(f"{YELLOW}{CHECK} Best match: {BOLD}{match.name}{NORMAL}")
         return match

--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -1,7 +1,7 @@
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 from patchright.async_api import Locator, Page
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 NORMAL = "\033[0m"
 BOLD = "\033[1m"
@@ -20,7 +20,7 @@ class Pattern(BaseModel):
 
 class Match(BaseModel):
     name: str
-    priority: int = Field(ge=-1, description="Priority level for matching")
+    priority: int
     distilled: str
     matches: list[Locator]
 


### PR DESCRIPTION
Adds idiomatic pydantic to classes which inherit from BaseModel now.

Update dictionary calls to use the `.parameter` calling method instead of `["parameter"]`