### PR TITLE
add prefix "__" to frontend asset path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -499,6 +499,7 @@ getgather/api/frontend/index.html
 getgather/api/frontend/assets
 getgather/frontend/index.html
 getgather/frontend/assets
+getgather/frontend/__assets
 
 !frontend/src/lib
 

--- a/frontend/src/components/BrandForm.tsx
+++ b/frontend/src/components/BrandForm.tsx
@@ -131,7 +131,7 @@ const BrandForm = forwardRef<BrandFormHandle, BrandFormProps>(
         img.src = img.src.replace(/\.svg$/, ".png");
         img.dataset.fallback = "png";
       } else {
-        img.src = "/static/assets/logos/default.svg";
+        img.src = "/__static/assets/logos/default.svg";
         img.onerror = null;
       }
     };
@@ -378,7 +378,7 @@ const BrandForm = forwardRef<BrandFormHandle, BrandFormProps>(
               {brandId && (
                 <img
                   className="w-12 h-12 object-contain mx-auto rounded-lg bg-slate-100 p-2"
-                  src={`/static/assets/logos/${brandId}.svg`}
+                  src={`/__static/assets/logos/${brandId}.svg`}
                   alt={brandId}
                   onError={onImageError}
                   data-fallback="svg"

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -47,7 +47,7 @@ export default function Home() {
       img.src = img.src.replace(/\.svg$/, ".png");
       img.dataset.fallback = "png";
     } else {
-      img.src = "/static/assets/logos/default.svg";
+      img.src = "/__static/assets/logos/default.svg";
       img.onerror = null;
     }
   };
@@ -102,7 +102,7 @@ export default function Home() {
               >
                 <img
                   className="w-12 h-12 object-contain mb-4 rounded-md bg-white"
-                  src={`/static/assets/logos/${brand.id}.svg`}
+                  src={`/__static/assets/logos/${brand.id}.svg`}
                   alt={brand.name}
                   onError={onImageError}
                   data-fallback="svg"

--- a/getgather/main.py
+++ b/getgather/main.py
@@ -58,12 +58,12 @@ app = FastAPI(
 
 
 STATIC_ASSETS_DIR = Path(__file__).parent / "static" / "assets"
-BUILD_ASSETS_DIR = Path(__file__).parent / "frontend" / "assets"
+BUILD_ASSETS_DIR = Path(__file__).parent / "frontend" / "__assets"
 FRONTEND_DIR = Path(__file__).parent / "frontend"
 
 
-app.mount("/static/assets", StaticFiles(directory=STATIC_ASSETS_DIR), name="assets")
-app.mount("/assets", StaticFiles(directory=BUILD_ASSETS_DIR), name="assets")
+app.mount("/__static/assets", StaticFiles(directory=STATIC_ASSETS_DIR), name="assets")
+app.mount("/__assets", StaticFiles(directory=BUILD_ASSETS_DIR), name="__assets")
 
 
 @app.get("/live")

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,11 +9,12 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   build: {
     outDir: path.resolve(__dirname, "getgather", "frontend"),
+    assetsDir: "__assets",
   },
   server: {
     host: "0.0.0.0",
     proxy: {
-      "^/(api|brands|link/create|link/status|parse|auth|replay|static|live|mcp|inspector)":
+      "^/(api|brands|link/create|link/status|parse|auth|replay|__static|live|mcp|inspector)":
         {
           target: "http://127.0.0.1:23456/",
           changeOrigin: false,


### PR DESCRIPTION
"assets" and "static" are usually used by the frontend ([example](https://github.com/gather-engineering/circuit-shack/pull/12/files)). To prevent conflicts with the frontend that uses `mcp-getgather` via proxy, we want to change "assets" and "static" to "__assets" and "__static"