### PR TITLE
Fix autoclick during distillation

### DIFF
--- a/getgather.py
+++ b/getgather.py
@@ -164,7 +164,9 @@ async def autoclick(page: Page, distilled: str):
             if selector:
                 logger.info(f"Auto-clicking {selector}")
                 frame_selector = button.get("gg-frame")
-                await click(page, str(selector), frame_selector=str(frame_selector))
+                if isinstance(frame_selector, list):
+                    frame_selector = frame_selector[0] if frame_selector else None
+                await click(page, str(selector), frame_selector=frame_selector)
 
 
 async def terminate(page: Page, distilled: str) -> bool:


### PR DESCRIPTION
This is done by avoiding typecasting frame_selector to string too early. Otherwise, None will be turned into a literal string "None" and it won't match correctly in the click() function.

In case there are (mistakenly) multiple gg-frame attributes, just pick the first one.

To verify, run `./getgather.py run goodreads.com/review` and the distillation should work correctly now.