### PR TITLE
Refactor the distillation by moving functions to the shared logic

### DIFF
--- a/getgather.py
+++ b/getgather.py
@@ -6,146 +6,25 @@ import os
 import sys
 import urllib.parse
 from glob import glob
-from typing import cast
-
-import pwinput
-from bs4 import BeautifulSoup
-from bs4.element import Tag
-from patchright.async_api import Page
 
 from getgather.browser.profile import BrowserProfile
 from getgather.browser.session import browser_session
 from getgather.config import settings
-from getgather.distill import Pattern, distill
+from getgather.distill import (
+    distill,
+    load_distillation_patterns,
+    run_distillation_loop,
+)
 from getgather.logs import logger
 
 _ = settings.LOG_LEVEL
 
 
-async def sleep(seconds: float):
-    await asyncio.sleep(seconds)
-
-
-async def ask(message: str, mask: str | None = None) -> str:
-    if mask:
-        return pwinput.pwinput(f"{message}: ", mask=mask)
-    else:
-        return input(f"{message}: ")
-
-
-async def click(
-    page: Page, selector: str, timeout: int = 3000, frame_selector: str | None = None
-) -> None:
-    LOCATOR_ALL_TIMEOUT = 100
-    if frame_selector:
-        locator = page.frame_locator(str(frame_selector)).locator(str(selector))
-    else:
-        locator = page.locator(str(selector))
-    try:
-        elements = await locator.all()
-        logger.debug(f'Found {len(elements)} elements for selector "{selector}"')
-        for element in elements:
-            logger.debug(f"Checking {element}")
-            if await element.is_visible():
-                logger.debug(f"Clicking on {element}")
-                try:
-                    await element.click()
-                    return
-                except Exception as err:
-                    logger.warning(f"Failed to click on {selector} {element}: {err}")
-    except Exception as e:
-        if timeout > 0 and "TimeoutError" in str(type(e)):
-            logger.warning(f"retrying click {selector} {timeout}")
-            await click(page, selector, timeout - LOCATOR_ALL_TIMEOUT, frame_selector)
-            return
-        logger.error(f"Failed to click on {selector}: {e}")
-        raise e
-
-
-def parse(html: str):
-    return BeautifulSoup(html, "html.parser")
-
-
-def load_patterns() -> list[Pattern]:
-    patterns: list[Pattern] = []
-    for name in glob("./getgather/connectors/brand_specs/**/*.html", recursive=True):
-        with open(name, "r", encoding="utf-8") as f:
-            content = f.read()
-        patterns.append(Pattern(name=name, pattern=parse(content)))
-    return patterns
-
-
-async def autofill(page: Page, distilled: str, fields: list[str]):
-    document = parse(distilled)
-    root = document.find("html")
-    domain = None
-    if root:
-        domain = cast(Tag, root).get("gg-domain")
-
-    for field in fields:
-        element = document.find("input", {"type": field})
-        selector = None
-        frame_selector = None
-
-        if element:
-            selector = cast(Tag, element).get("gg-match")
-            frame_selector = cast(Tag, element).get("gg-frame")
-
-        if selector:
-            source = f"{domain}_{field}" if domain else field
-            key = source.upper()
-            value = os.getenv(key)
-
-            if value and len(value) > 0:
-                logger.info(f"Using {key} for {field}")
-
-                if frame_selector:
-                    await page.frame_locator(str(frame_selector)).locator(str(selector)).fill(value)
-                else:
-                    await page.fill(str(selector), value)
-            else:
-                placeholder = cast(Tag, element).get("placeholder")
-                prompt = str(placeholder) if placeholder else f"Please enter {field}"
-                mask = "*" if field == "password" else None
-
-                if frame_selector:
-                    await (
-                        page.frame_locator(str(frame_selector))
-                        .locator(str(selector))
-                        .fill(await ask(prompt, mask))
-                    )
-
-                else:
-                    await page.fill(str(selector), await ask(prompt, mask))
-            await sleep(0.25)
-
-
-async def autoclick(page: Page, distilled: str):
-    document = parse(distilled)
-    buttons = document.find_all(attrs={"gg-autoclick": True})
-
-    for button in buttons:
-        if isinstance(button, Tag):
-            selector = button.get("gg-match")
-            if selector:
-                logger.info(f"Auto-clicking {selector}")
-                frame_selector = button.get("gg-frame")
-                if isinstance(frame_selector, list):
-                    frame_selector = frame_selector[0] if frame_selector else None
-                await click(page, str(selector), frame_selector=frame_selector)
-
-
-async def terminate(page: Page, distilled: str) -> bool:
-    document = parse(distilled)
-    stops = document.find_all(attrs={"gg-stop": True})
-    if len(stops) > 0:
-        logger.info("Found stop elements, terminating session...")
-        return True
-    return False
+PATTERNS_LOCATION = "./getgather/connectors/brand_specs/**/*.html"
 
 
 async def list_command():
-    spec_files = glob("./getgather/connectors/brand_specs/**/*", recursive=True)
+    spec_files = glob(PATTERNS_LOCATION, recursive=True)
     spec_files = [f for f in spec_files if f.endswith(".html")]
 
     for name in spec_files:
@@ -153,9 +32,9 @@ async def list_command():
 
 
 async def distill_command(location: str, option: str | None = None):
-    patterns = load_patterns()
+    patterns = load_distillation_patterns(PATTERNS_LOCATION)
 
-    logger.info(f"Distilling {location}")
+    logger.info(f"Distilling {location} using {len(patterns)} patterns")
 
     profile = BrowserProfile()
     async with browser_session(profile) as session:
@@ -179,53 +58,15 @@ async def distill_command(location: str, option: str | None = None):
 
 
 async def run_command(location: str):
+    patterns = load_distillation_patterns(PATTERNS_LOCATION)
+    fields = ["email", "password", "tel", "text"]
+
     if not location.startswith("http"):
         location = f"https://{location}"
 
-    hostname = urllib.parse.urlparse(location).hostname or ""
-    patterns = load_patterns()
+    await run_distillation_loop(location, patterns=patterns, fields=fields)
 
-    profile = BrowserProfile()
-    async with browser_session(profile) as session:
-        page = await session.page()
-
-        logger.info(f"Starting browser {profile.id}")
-        logger.info(f"Navigating to {location}")
-        await page.goto(location)
-
-        TICK = 1  # seconds
-        TIMEOUT = 15  # seconds
-        max = TIMEOUT // TICK
-
-        current = {"name": None, "distilled": None}
-
-        for iteration in range(max):
-            logger.info("")
-            logger.info(f"Iteration {iteration + 1} of {max}")
-            await sleep(TICK)
-
-            match = await distill(hostname, page, patterns)
-            if match:
-                name = match.name
-                distilled = match.distilled
-
-                if distilled == current.get("distilled"):
-                    logger.debug(f"Still the same: {name}")
-                else:
-                    current = {"name": name, "distilled": distilled}
-                    print()
-                    print(distilled)
-                    await autofill(page, distilled, ["email", "password", "tel", "text"])
-                    await autoclick(page, distilled)
-
-                    if await terminate(page, distilled):
-                        break
-            else:
-                logger.debug(f"No matched pattern found")
-
-        logger.info("")
-        logger.info(f"Terminating browser {profile.id}")
-        logger.info("Terminated.")
+    logger.info("Terminated.")
 
 
 async def inspect_command(id: str, option: str | None = None):
@@ -239,7 +80,7 @@ async def inspect_command(id: str, option: str | None = None):
         else:
             await page.goto("https://google.com")
 
-        await ask("Press Enter to terminate session")
+        input("Press Enter to terminate session...")
 
 
 async def main():

--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -1,8 +1,17 @@
+import asyncio
+import os
+import urllib.parse
+from glob import glob
+from typing import cast
+
+import pwinput
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 from patchright.async_api import Locator, Page
 from pydantic import BaseModel
 
+from getgather.browser.profile import BrowserProfile
+from getgather.browser.session import browser_session
 from getgather.logs import logger
 
 
@@ -24,6 +33,58 @@ class Match(BaseModel):
         arbitrary_types_allowed = True
 
 
+async def ask(message: str, mask: str | None = None) -> str:
+    if mask:
+        return pwinput.pwinput(f"{message}: ", mask=mask)
+    else:
+        return input(f"{message}: ")
+
+
+async def autofill(page: Page, distilled: str, fields: list[str]):
+    document = BeautifulSoup(distilled, "html.parser")
+    root = document.find("html")
+    domain = None
+    if root:
+        domain = cast(Tag, root).get("gg-domain")
+
+    for field in fields:
+        element = document.find("input", {"type": field})
+        selector = None
+        frame_selector = None
+
+        if element:
+            selector = cast(Tag, element).get("gg-match")
+            frame_selector = cast(Tag, element).get("gg-frame")
+
+        if selector:
+            source = f"{domain}_{field}" if domain else field
+            key = source.upper()
+            value = os.getenv(key)
+
+            if value and len(value) > 0:
+                logger.info(f"Using {key} for {field}")
+
+                if frame_selector:
+                    await page.frame_locator(str(frame_selector)).locator(str(selector)).fill(value)
+                else:
+                    await page.fill(str(selector), value)
+            else:
+                placeholder = cast(Tag, element).get("placeholder")
+                prompt = str(placeholder) if placeholder else f"Please enter {field}"
+                mask = "*" if field == "password" else None
+
+                if frame_selector:
+                    await (
+                        page.frame_locator(str(frame_selector))
+                        .locator(str(selector))
+                        .fill(await ask(prompt, mask))
+                    )
+
+                else:
+                    await page.fill(str(selector), await ask(prompt, mask))
+            await asyncio.sleep(0.25)
+
+
 async def locate(locator: Locator) -> Locator | None:
     count = await locator.count()
     if count > 0:
@@ -32,6 +93,68 @@ async def locate(locator: Locator) -> Locator | None:
             if await el.is_visible():
                 return el
     return None
+
+
+async def click(
+    page: Page, selector: str, timeout: int = 3000, frame_selector: str | None = None
+) -> None:
+    LOCATOR_ALL_TIMEOUT = 100
+    if frame_selector:
+        locator = page.frame_locator(str(frame_selector)).locator(str(selector))
+    else:
+        locator = page.locator(str(selector))
+    try:
+        elements = await locator.all()
+        logger.debug(f'Found {len(elements)} elements for selector "{selector}"')
+        for element in elements:
+            logger.debug(f"Checking {element}")
+            if await element.is_visible():
+                logger.debug(f"Clicking on {element}")
+                try:
+                    await element.click()
+                    return
+                except Exception as err:
+                    logger.warning(f"Failed to click on {selector} {element}: {err}")
+    except Exception as e:
+        if timeout > 0 and "TimeoutError" in str(type(e)):
+            logger.warning(f"retrying click {selector} {timeout}")
+            await click(page, selector, timeout - LOCATOR_ALL_TIMEOUT, frame_selector)
+            return
+        logger.error(f"Failed to click on {selector}: {e}")
+        raise e
+
+
+async def autoclick(page: Page, distilled: str):
+    document = BeautifulSoup(distilled, "html.parser")
+    buttons = document.find_all(attrs={"gg-autoclick": True})
+
+    for button in buttons:
+        if isinstance(button, Tag):
+            selector = button.get("gg-match")
+            if selector:
+                logger.info(f"Auto-clicking {selector}")
+                frame_selector = button.get("gg-frame")
+                if isinstance(frame_selector, list):
+                    frame_selector = frame_selector[0] if frame_selector else None
+                await click(page, str(selector), frame_selector=frame_selector)
+
+
+async def terminate(page: Page, distilled: str) -> bool:
+    document = BeautifulSoup(distilled, "html.parser")
+    stops = document.find_all(attrs={"gg-stop": True})
+    if len(stops) > 0:
+        logger.info("Found stop elements, terminating session...")
+        return True
+    return False
+
+
+def load_distillation_patterns(path: str) -> list[Pattern]:
+    patterns: list[Pattern] = []
+    for name in glob(path, recursive=True):
+        with open(name, "r", encoding="utf-8") as f:
+            content = f.read()
+        patterns.append(Pattern(name=name, pattern=BeautifulSoup(content, "html.parser")))
+    return patterns
 
 
 async def distill(hostname: str | None, page: Page, patterns: list[Pattern]) -> Match | None:
@@ -124,3 +247,48 @@ async def distill(hostname: str | None, page: Page, patterns: list[Pattern]) -> 
         match = result[0]
         logger.info(f"✓ Best match: {match.name}")
         return match
+
+
+async def run_distillation_loop(location: str, patterns: list[Pattern], fields: list[str] = []):
+    if len(patterns) == 0:
+        logger.error("No distillation patterns provided")
+        raise ValueError("No distillation patterns provided")
+
+    hostname = urllib.parse.urlparse(location).hostname or ""
+
+    profile = BrowserProfile()
+    async with browser_session(profile) as session:
+        page = await session.page()
+
+        logger.info(f"Starting browser {profile.id}")
+        logger.info(f"Navigating to {location}")
+        await page.goto(location)
+
+        TICK = 1  # seconds
+        TIMEOUT = 15  # seconds
+        max = TIMEOUT // TICK
+
+        current = Match(name="", priority=-1, distilled="", matches=[])
+
+        for iteration in range(max):
+            logger.info("")
+            logger.info(f"Iteration {iteration + 1} of {max}")
+            await asyncio.sleep(TICK)
+
+            match = await distill(hostname, page, patterns)
+            if match:
+                if match.distilled == current.distilled:
+                    logger.debug(f"Still the same: {match.name}")
+                else:
+                    current = match
+                    print()
+                    print(current.distilled)
+                    await autofill(page, current.distilled, fields)
+                    await autoclick(page, current.distilled)
+                    if await terminate(page, current.distilled):
+                        break
+
+            else:
+                logger.debug(f"No matched pattern found")
+
+        return current.distilled


### PR DESCRIPTION
This is important for the upcoming distillation-based MCP tools.

To verify, as usual just run it with the example, e.g.:

```
./getgather.py run https://goodreads.com/review
```

and then supply the credentials until the loop terminates with the HTML version of the bookshelf.