### PR TITLE
feat: bypass CSP

### DIFF
--- a/getgather/browser/profile.py
+++ b/getgather/browser/profile.py
@@ -56,6 +56,7 @@ class BrowserProfile(FreezableModel):
             headless=settings.HEADLESS,
             viewport=viewport_config,
             proxy=proxy,  # type: ignore[arg-type]
+            bypass_csp=True,
         )
 
     def cleanup(self, profile_id: str):

--- a/getgather/browser/session.py
+++ b/getgather/browser/session.py
@@ -71,11 +71,8 @@ class BrowserSession:
             )
 
             page = await self.page()
-            if rrweb_injector.should_inject_for_page(page):
-                await self._context.expose_function("saveEvent", rrweb_injector.save_event)  # type: ignore
-                page.on(
-                    "load", lambda page: asyncio.create_task(rrweb_injector.inject_into_page(page))
-                )
+            await self._context.expose_function("saveEvent", rrweb_injector.save_event)  # type: ignore
+            page.on("load", lambda page: asyncio.create_task(rrweb_injector.inject_into_page(page)))
 
         except Exception as e:
             logger.error(f"Error starting browser: {e}")

--- a/getgather/browser/session.py
+++ b/getgather/browser/session.py
@@ -71,8 +71,10 @@ class BrowserSession:
             )
 
             page = await self.page()
-            await self._context.expose_function("saveEvent", rrweb_injector.save_event)  # type: ignore
-            page.on("load", lambda page: asyncio.create_task(rrweb_injector.inject_into_page(page)))
+            page.on(
+                "load",
+                lambda page: asyncio.create_task(rrweb_injector.setup_rrweb(self.context, page)),
+            )
 
         except Exception as e:
             logger.error(f"Error starting browser: {e}")

--- a/getgather/config.py
+++ b/getgather/config.py
@@ -38,7 +38,7 @@ class Settings(BaseSettings):
     BROWSER_HTTP_PROXY_PASSWORD: str = ""
 
     # Websites with Content Security Policy
-    CSP_WEBSITES: list[str] = ["*.bbc.com"]
+    CSP_WEBSITES: list[str] = []
 
     # RRWeb Recording Settings
     ENABLE_RRWEB_RECORDING: bool = True

--- a/getgather/config.py
+++ b/getgather/config.py
@@ -38,7 +38,7 @@ class Settings(BaseSettings):
     BROWSER_HTTP_PROXY_PASSWORD: str = ""
 
     # RRWeb Recording Settings
-    ENABLE_RRWEB_RECORDING: bool = True
+    ENABLE_RRWEB_RECORDING: bool = False
     RRWEB_SCRIPT_URL: str = (
         "https://cdn.jsdelivr.net/npm/rrweb@2.0.0-alpha.14/dist/record/rrweb-record.min.js"
     )

--- a/getgather/config.py
+++ b/getgather/config.py
@@ -37,9 +37,6 @@ class Settings(BaseSettings):
     BROWSER_HTTP_PROXY: str = ""
     BROWSER_HTTP_PROXY_PASSWORD: str = ""
 
-    # Websites with Content Security Policy
-    CSP_WEBSITES: list[str] = []
-
     # RRWeb Recording Settings
     ENABLE_RRWEB_RECORDING: bool = True
     RRWEB_SCRIPT_URL: str = (

--- a/getgather/rrweb.py
+++ b/getgather/rrweb.py
@@ -38,7 +38,10 @@ class RRWebInjector:
             "() => { rrwebRecord({ emit(event) { window.saveEvent(event); }, maskAllInputs: true }); }",
             isolated_context=False,
         )
-        await context.expose_function("saveEvent", rrweb_injector.save_event)  # type: ignore
+
+        if context not in self.injected_contexts:
+            await context.expose_function("saveEvent", rrweb_injector.save_event)  # type: ignore
+            self.injected_contexts.add(context)
 
 
 class Recording(BaseModel):

--- a/getgather/rrweb.py
+++ b/getgather/rrweb.py
@@ -1,28 +1,11 @@
 import json
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
 from patchright.async_api import BrowserContext, Page
 from pydantic import BaseModel
 
 from getgather.config import settings
-from getgather.logs import logger
-
-
-def _is_csp_domain(domain: str) -> bool:
-    """Check if domain matches any CSP website patterns."""
-    for pattern in settings.CSP_WEBSITES:
-        if pattern.startswith("*."):
-            # Wildcard pattern: *.example.com matches subdomain.example.com
-            base_domain = pattern[2:]
-            if domain.endswith(base_domain):
-                return True
-        else:
-            # Exact or substring match
-            if pattern in domain:
-                return True
-    return False
 
 
 class RRWebInjector:
@@ -46,31 +29,16 @@ class RRWebInjector:
         finally:
             self.events = []
 
-    async def inject_into_page(self, page: Page):
+    async def setup_rrweb(self, context: BrowserContext, page: Page):
+        if not self.enabled:
+            return
+
         await page.add_script_tag(url=self.script_url)
         await page.evaluate(
             "() => { rrwebRecord({ emit(event) { window.saveEvent(event); }, maskAllInputs: true }); }",
             isolated_context=False,
         )
-
-    def should_inject_for_page(self, page: Page) -> bool:
-        """Determine if RRWeb should be injected for this page."""
-        if not self.enabled:
-            return False
-
-        url = page.url
-        if not url or url == "about:blank":
-            return False
-
-        domain = urlparse(url).hostname
-        if not domain:
-            return False
-
-        if _is_csp_domain(domain):
-            logger.info(f"Skipping RRWeb injection for CSP domain: {domain}")
-            return False
-
-        return True
+        await context.expose_function("saveEvent", rrweb_injector.save_event)  # type: ignore
 
 
 class Recording(BaseModel):


### PR DESCRIPTION
## Summary
It turns out Playwright has API to bypass CSP, so I used it's built-in parameter. CSP setting are no longer needed.

## Tests
- The tests for BBC are still green after the code was removed