### PR TITLE
Update tests with signin language

### DIFF
--- a/.github/workflows/api-signin-tests.yml
+++ b/.github/workflows/api-signin-tests.yml
@@ -1,4 +1,4 @@
-name: API Authentication Tests
+name: API Signin Tests
 
 on:
   push:
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  api-auth-tests:
-    name: API Authentication Tests
+  api-signin-tests:
+    name: API Signin Tests
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -39,7 +39,7 @@ jobs:
         run: while ! curl -s 'http://localhost:23456/health' | grep 'OK'; do sleep 1; done
         timeout-minutes: 3
 
-      - name: Install Chromium for API authentication tests
+      - name: Install Chromium for API signin tests
         run: uv run playwright install chromium
 
       - name: Run the ACME Corp test server
@@ -50,8 +50,8 @@ jobs:
         run: while ! curl -s 'http://localhost:5001' | grep 'ACME'; do sleep 1; done
         timeout-minutes: 3
 
-      - name: Run the API authentication tests
-        run: uv run pytest -n 7 -m "api" tests/api/test_auth_api.py
+      - name: Run the API signin tests
+        run: uv run pytest -n 7 -m "api" tests/api/test_signin_api.py
         env:
           DISPLAY: :1
           HOST: http://localhost:23456

--- a/.github/workflows/webui-tests.yml
+++ b/.github/workflows/webui-tests.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install Chromium for Playwright tests
         run: uv run playwright install chromium
 
-      - run: uv run pytest -n 8 -s tests/api/test_webui_auth.py
+      - run: uv run pytest -n 8 -s tests/api/test_webui_signin.py
         env:
           ACME_EMAIL: joe@example.com
           ACME_PASSWORD: trustno1

--- a/tests/api/test_signin_api.py
+++ b/tests/api/test_signin_api.py
@@ -75,13 +75,13 @@ def get_test_id(test_case: dict[str, str]):
 
 @pytest.mark.api
 @pytest.mark.parametrize("test_case", TEST_CASES, ids=[get_test_id(tc) for tc in TEST_CASES])
-def test_auth_api_flow(test_case: dict[str, str]):
+def test_signin_api_flow(test_case: dict[str, str]):
     brand_id = test_case["test"]
     headers: dict[str, str] = {}
     if API_KEY:
         headers["Authorization"] = f"Bearer {API_KEY}"
 
-    # 1. Start the auth flow
+    # 1. Start the signin flow
     initial_payload = {"extract": True}
     res = requests.post(
         f"{HOST}/api/auth/{brand_id}", json=initial_payload, headers=headers, timeout=120
@@ -177,4 +177,4 @@ def test_auth_api_flow(test_case: dict[str, str]):
 
 
 if __name__ == "__main__":
-    test_auth_api_flow({"test": "acme-email-password-checkbox"})
+    test_signin_api_flow({"test": "acme-email-password-checkbox"})

--- a/tests/api/test_webui_signin.py
+++ b/tests/api/test_webui_signin.py
@@ -22,14 +22,14 @@ SPECS_WITHOUT_CHOICE = sorted(
 
 @pytest.mark.webui
 @pytest.mark.parametrize("brand_id", SPECS_WITHOUT_CHOICE)
-def test_auth(page: Page, site_url: str, brand_id: str):
+def test_signin(page: Page, site_url: str, brand_id: str):
     _run_signin(page, site_url, brand_id)
 
 
 @pytest.mark.webui
 @pytest.mark.parametrize("brand_id", SPECS_WITH_CHOICE)
 @pytest.mark.parametrize("verification_choice", ["password", "otp"])
-def test_auth_with_choice(page: Page, site_url: str, brand_id: str, verification_choice: str):
+def test_signin_with_choice(page: Page, site_url: str, brand_id: str, verification_choice: str):
     _run_signin(page, site_url, brand_id, verification_choice=verification_choice)
 
 
@@ -62,7 +62,7 @@ def _run_signin(
             if "Connection successful" in content:
                 success = True
                 break
-            elif "Error during authentication" in content:
+            elif "Error during sign in" in content:
                 break
 
         email_input = page.get_by_test_id("input-email")
@@ -109,6 +109,6 @@ def _run_signin(
 
 
 @pytest.mark.webui
-def test_auth_with_wrong_password(page: Page, site_url: str):
+def test_signin_with_wrong_password(page: Page, site_url: str):
     brand_id = "acme-email-then-password"
     _run_signin(page, site_url, brand_id, passwords=["wrongpassword", VALID_PASSWORD])

--- a/tests/api/test_webui_signin.py
+++ b/tests/api/test_webui_signin.py
@@ -23,17 +23,17 @@ SPECS_WITHOUT_CHOICE = sorted(
 @pytest.mark.webui
 @pytest.mark.parametrize("brand_id", SPECS_WITHOUT_CHOICE)
 def test_auth(page: Page, site_url: str, brand_id: str):
-    _run_auth(page, site_url, brand_id)
+    _run_signin(page, site_url, brand_id)
 
 
 @pytest.mark.webui
 @pytest.mark.parametrize("brand_id", SPECS_WITH_CHOICE)
 @pytest.mark.parametrize("verification_choice", ["password", "otp"])
 def test_auth_with_choice(page: Page, site_url: str, brand_id: str, verification_choice: str):
-    _run_auth(page, site_url, brand_id, verification_choice=verification_choice)
+    _run_signin(page, site_url, brand_id, verification_choice=verification_choice)
 
 
-def _run_auth(
+def _run_signin(
     page: Page,
     site_url: str,
     brand_id: str,
@@ -111,4 +111,4 @@ def _run_auth(
 @pytest.mark.webui
 def test_auth_with_wrong_password(page: Page, site_url: str):
     brand_id = "acme-email-then-password"
-    _run_auth(page, site_url, brand_id, passwords=["wrongpassword", VALID_PASSWORD])
+    _run_signin(page, site_url, brand_id, passwords=["wrongpassword", VALID_PASSWORD])

--- a/tests/connectors/brand_specs/acme-email-and-password-navigate-action.yml
+++ b/tests/connectors/brand_specs/acme-email-and-password-navigate-action.yml
@@ -1,5 +1,5 @@
-# This is to test the specific case where we need to navigate to a different page after authenticating to verify
-# the authentication was successful.
+# This is to test the specific case where we need to navigate to a different page after signing in to verify
+# the signin was successful.
 
 name: ACME
 

--- a/tests/connectors/brand_specs/acme-email-and-password-then-mfa.yml
+++ b/tests/connectors/brand_specs/acme-email-and-password-then-mfa.yml
@@ -1,5 +1,5 @@
-# This is to test the specific case where we need to navigate to a different page after authenticating to verify
-# the authentication was successful.
+# This is to test the specific case where we need to navigate to a different page after signing in to verify
+# the signin was successful.
 
 name: ACME
 


### PR DESCRIPTION
Update our previously termed "authentication" tests to "signin" tests to reflect the new verbiage that authentication is for the MCP server and signin is for individual brands.