### PR TITLE
fix: hosted-link not found

### DIFF
--- a/getgather/mcp/shared.py
+++ b/getgather/mcp/shared.py
@@ -136,6 +136,13 @@ async def poll_status_hosted_link(context: Context, hosted_link_id: str) -> dict
                 "[poll_status_hosted_link] Response status",
                 extra={"status_code": response.status_code, "url": response.request.url},
             )
+
+            if response.status_code == 404:
+                return {
+                    "status": "ERROR",
+                    "message": f"Link '{hosted_link_id}' not found or expired",
+                }
+
             response_json = response.json()
 
             logger.info(
@@ -148,6 +155,7 @@ async def poll_status_hosted_link(context: Context, hosted_link_id: str) -> dict
                 },
             )
 
+            # missing this
             if response_json["status"] == "completed":
                 processing = False
                 brand_state = brand_state_manager.get(


### PR DESCRIPTION
## Summary
  - Fixed KeyError crash when polling auth status for non-existent/expired links

## Root Cause
The poll_status_hosted_link function assumed all API responses would contain a status field, but HTTP 404 responses from FastAPI have a different structure ({"detail": "error message"}) without this field, causing KeyError: 'status'.

## Error log when server crash
```
/25 06:33:13] ERROR    Error calling tool 'poll_auth'  tool_manager.py:233
2025-09-09T06:33:13.802657661Z app[web.1]:                              ╭─ Traceback (most recent cal─╮
2025-09-09T06:33:13.802664432Z app[web.1]:                              │ /opt/venv/lib/python3.13/si │
2025-09-09T06:33:13.802669608Z app[web.1]:                              │ te-packages/fastmcp/tools/t │
2025-09-09T06:33:13.802674498Z app[web.1]:                              │ ool_manager.py:224 in       │
2025-09-09T06:33:13.802680264Z app[web.1]:                              │ call_tool                   │
2025-09-09T06:33:13.802685402Z app[web.1]:                              │                             │
2025-09-09T06:33:13.802707001Z app[web.1]:                              │   221 │   │   │   │   raise │
2025-09-09T06:33:13.802712025Z app[web.1]:                              │   222 │   │   │             │
2025-09-09T06:33:13.802716744Z app[web.1]:                              │   223 │   │   │   try:      │
2025-09-09T06:33:13.802721284Z app[web.1]:                              │ ❱ 224 │   │   │   │   retur │
2025-09-09T06:33:13.802726135Z app[web.1]:                              │   225 │   │   │             │
2025-09-09T06:33:13.802731408Z app[web.1]:                              │   226 │   │   │   # raise T │
2025-09-09T06:33:13.802736666Z app[web.1]:                              │   227 │   │   │   except To │
2025-09-09T06:33:13.802742061Z app[web.1]:                              │                             │
2025-09-09T06:33:13.802747591Z app[web.1]:                              │ /opt/venv/lib/python3.13/si │
2025-09-09T06:33:13.802752784Z app[web.1]:                              │ te-packages/fastmcp/tools/t │
2025-09-09T06:33:13.802757435Z app[web.1]:                              │ ool.py:311 in run           │
2025-09-09T06:33:13.802763257Z app[web.1]:                              │                             │
2025-09-09T06:33:13.802768260Z app[web.1]:                              │   308 │   │   result = type │
2025-09-09T06:33:13.802774251Z app[web.1]:                              │   309 │   │                 │
2025-09-09T06:33:13.802779954Z app[web.1]:                              │   310 │   │   if inspect.is │
2025-09-09T06:33:13.802785180Z app[web.1]:                              │ ❱ 311 │   │   │   result =  │
2025-09-09T06:33:13.802792391Z app[web.1]:                              │   312 │   │                 │
2025-09-09T06:33:13.802797625Z app[web.1]:                              │   313 │   │   if isinstance │
2025-09-09T06:33:13.802802525Z app[web.1]:                              │   314 │   │   │   return re │
2025-09-09T06:33:13.802807431Z app[web.1]:                              │                             │
2025-09-09T06:33:13.802812328Z app[web.1]:                              │ /app/getgather/mcp/main.py: │
2025-09-09T06:33:13.802817120Z app[web.1]:                              │ 151 in poll_auth            │
2025-09-09T06:33:13.802822791Z app[web.1]:                              │                             │
2025-09-09T06:33:13.802827917Z app[web.1]:                              │   148 │   @mcp.tool(tags={" │
2025-09-09T06:33:13.802833246Z app[web.1]:                              │   149 │   async def poll_au │
2025-09-09T06:33:13.802838496Z app[web.1]:                              │       ignore[reportUnusedFu │
2025-09-09T06:33:13.802850711Z app[web.1]:                              │   150 │   │   """Poll auth  │
2025-09-09T06:33:13.802856363Z app[web.1]:                              │ ❱ 151 │   │   return await  │
2025-09-09T06:33:13.802861497Z app[web.1]:                              │   152 │                     │
2025-09-09T06:33:13.802877885Z app[web.1]:                              │   153 │   for brand_id in b │
2025-09-09T06:33:13.802884221Z app[web.1]:                              │   154 │   │   brand_mcp = B │
2025-09-09T06:33:13.802889506Z app[web.1]:                              │                             │
2025-09-09T06:33:13.802894877Z app[web.1]:                              │ /app/getgather/mcp/shared.p │
2025-09-09T06:33:13.802900534Z app[web.1]:                              │ y:151 in                    │
2025-09-09T06:33:13.802905828Z app[web.1]:                              │ poll_status_hosted_link     │
2025-09-09T06:33:13.802910967Z app[web.1]:                              │                             │
2025-09-09T06:33:13.802915684Z app[web.1]:                              │   148 │   │   │   │   },    │
2025-09-09T06:33:13.802921049Z app[web.1]:                              │   149 │   │   │   )         │
2025-09-09T06:33:13.802926266Z app[web.1]:                              │   150 │   │   │             │
2025-09-09T06:33:13.802932350Z app[web.1]:                              │ ❱ 151 │   │   │   if respon │
2025-09-09T06:33:13.802937357Z app[web.1]:                              │   152 │   │   │   │   proce │
2025-09-09T06:33:13.802942120Z app[web.1]:                              │   153 │   │   │   │   brand │
2025-09-09T06:33:13.802947194Z app[web.1]:                              │   154 │   │   │   │   │   B │
2025-09-09T06:33:13.802952628Z app[web.1]:                              ╰─────────────────────────────╯
2025-09-09T06:33:13.802957778Z app[web.1]:                              KeyError: 'status'
```