### PR TITLE
add link_id to auth endpoints

### DIFF
--- a/frontend/src/components/BrandForm.tsx
+++ b/frontend/src/components/BrandForm.tsx
@@ -63,6 +63,7 @@ export type BrandFormHandle = {
 
 type BrandFormProps = {
   brandId?: string;
+  linkId?: string;
   profileId?: string;
   extract?: boolean;
   successMessage?: string;
@@ -89,6 +90,7 @@ const BrandForm = forwardRef<BrandFormHandle, BrandFormProps>(function BrandForm
   {
     onUpdateStatus,
     brandId,
+    linkId,
     onSuccess,
     profileId: profileIdProps,
     extract = false,
@@ -195,7 +197,7 @@ const BrandForm = forwardRef<BrandFormHandle, BrandFormProps>(function BrandForm
 
   async function authenticateNext(actionState?: StatePayload) {
     try {
-      const response = await fetch(`/api/auth/v1/${brandId}`, {
+      const response = await fetch(`/api/auth/v1/${brandId}/${linkId}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/frontend/src/pages/Link.tsx
+++ b/frontend/src/pages/Link.tsx
@@ -85,6 +85,7 @@ export default function Link() {
           }
         }
       } catch (error) {
+        console.log("error", error);
         brandFormRef?.current?.setView("error");
         brandFormRef?.current?.setMessage("Link not found. Please check the URL and try again.");
         console.error("Error fetching link status:", error);
@@ -97,6 +98,7 @@ export default function Link() {
   return (
     <BrandForm
       brandId={linkData?.brand_id}
+      linkId={linkId}
       profileId={linkData?.profile_id}
       onUpdateStatus={handleUpdateLinkStatus}
       ref={brandFormRef}

--- a/getgather/api/routes/auth/endpoints.py
+++ b/getgather/api/routes/auth/endpoints.py
@@ -11,18 +11,24 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 
 
 @router.post("/{brand_id}")
-async def auth_flow_redirect(brand_id: BrandIdEnum) -> RedirectResponse:
+@router.post("/{brand_id}/{link_id}")
+async def auth_flow_redirect(brand_id: BrandIdEnum, link_id: str | None = None) -> RedirectResponse:
     """Redirect old auth flow endpoint to versioned endpoint."""
-    return RedirectResponse(url=f"/api/auth/v1/{brand_id}", status_code=307)
+    url = f"/api/auth/v1/{brand_id}"
+    if link_id:
+        url += f"/{link_id}"
+    return RedirectResponse(url=url, status_code=307)
 
 
 @router.post("/v1/{brand_id}")
+@router.post("/v1/{brand_id}/{link_id}")
 async def auth(
     brand_id: BrandIdEnum,
     auth_request: Annotated[AuthFlowRequest, "Request data for an auth flow."],
+    link_id: str | None = None,
 ) -> AuthFlowResponse:
     """Start or continue an authentication flow for a connector."""
     if auth_request.location:
         request_info.set(auth_request.location)
 
-    return await auth_flow(brand_id, auth_request)
+    return await auth_flow(brand_id, auth_request, link_id)

--- a/getgather/auth_flow.py
+++ b/getgather/auth_flow.py
@@ -8,6 +8,7 @@ from getgather.browser.session import BrowserSession, BrowserStartupError
 from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.extract_orchestrator import ExtractOrchestrator, ExtractState
 from getgather.flow_state import FlowState
+from getgather.hosted_link_manager import HostedLinkManager
 from getgather.logs import logger
 from getgather.parse import BundleOutput
 
@@ -56,9 +57,14 @@ class AuthFlowResponse(BaseModel):
 async def auth_flow(
     brand_id: BrandIdEnum,
     auth_request: AuthFlowRequest,
+    link_id: str | None = None,
 ) -> AuthFlowResponse:
     """Start or continue an authentication flow for a connector."""
-    # Validate connector against the enum
+    if link_id:
+        link_data = HostedLinkManager.get_link_data(link_id)
+        if not link_data:
+            raise HTTPException(status_code=404, detail="Link not found")
+
     try:
         # Initialize the auth manager
         if auth_request.profile_id:


### PR DESCRIPTION
so gateway can use the `link_id` to track all link and auth requests associated with the same `link_id`