### PR TITLE
Distilled page, to prepare for sign-in flow processing

### DIFF
--- a/getgather/main.py
+++ b/getgather/main.py
@@ -23,6 +23,7 @@ from getgather.browser.session import BrowserSession
 from getgather.config import disabled_if_multi_user, settings
 from getgather.logs import logger
 from getgather.mcp.auth import setup_mcp_auth
+from getgather.mcp.dpage import router as dpage_router
 from getgather.mcp.main import create_mcp_apps
 from getgather.startup import startup
 
@@ -251,6 +252,7 @@ async def proxy_inspector(file_path: str):
             return Response(status_code=500, content=f"Internal Server Error: {str(e)}")
 
 
+app.include_router(dpage_router)
 app.mount("/api", api_app)
 
 if settings.MULTI_USER_ENABLED:

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -1,0 +1,242 @@
+import asyncio
+import os
+
+from bs4 import BeautifulSoup, Tag
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from nanoid import generate
+from patchright.async_api import Page
+
+from getgather.browser.profile import BrowserProfile
+from getgather.browser.session import BrowserSession
+from getgather.distill import (
+    Match,
+    autoclick,
+    convert,
+    distill,
+    get_selector,
+    load_distillation_patterns,
+    terminate,
+)
+from getgather.logs import logger
+
+router = APIRouter(prefix="/dpage", tags=["dpage"])
+
+active_pages: dict[str, Page] = {}
+distillation_results: dict[str, list[dict[str, str]]] = {}
+
+
+async def dpage_add(
+    id: str | None = None,
+    location: str | None = None,
+):
+    if id is None:
+        FRIENDLY_CHARS: str = "23456789abcdefghijkmnpqrstuvwxyz"
+        id = generate(FRIENDLY_CHARS, 8)
+
+    profile = BrowserProfile()
+    session = BrowserSession(profile.id)
+    await session.start()
+    page = await session.page()
+
+    if location:
+        if not location.startswith("http"):
+            location = f"https://{location}"
+        await page.goto(location)
+
+    active_pages[id] = page
+    return id
+
+
+async def dpage_close(id: str) -> None:
+    if id in active_pages:
+        await active_pages[id].close()
+        del active_pages[id]
+
+
+async def dpage_check(id: str):
+    TICK = 1  # seconds
+    TIMEOUT = 120  # seconds
+    max = TIMEOUT // TICK
+
+    for iteration in range(max):
+        logger.debug(f"Checking dpage {id}: {iteration + 1} of {max}")
+        await asyncio.sleep(TICK)
+        if id in distillation_results:
+            return distillation_results[id]
+
+    return None
+
+
+def render(content: str, options: dict[str, str] | None = None) -> str:
+    if options is None:
+        options = {}
+
+    title = options.get("title", "GetGather")
+    action = options.get("action", "")
+
+    return f"""<!doctype html>
+<html data-theme=light>
+  <head>
+    <title>{title}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+  </head>
+  <body>
+    <main class="container">
+      <section>
+        <h2>{title}</h2>
+        <articles>
+        <form method="POST" action="{action}">
+        {content}
+        </form>
+        </articles>
+      </section>
+    </main>
+  </body>
+</html>"""
+
+
+# Since the browser can't redirect from GET to POST,
+# we'll use an auto-submit form to do that.
+def redirect(id: str) -> HTMLResponse:
+    return HTMLResponse(f"""
+    <!DOCTYPE html>
+    <html>
+    <body>
+      <form id="redirect" action="/dpage/{id}" method="post">
+      </form>
+      <script>document.getElementById('redirect').submit();</script>
+    </body>
+    </html>
+    """)
+
+
+@router.get("", response_class=HTMLResponse)
+@router.get("/{id}", response_class=HTMLResponse)
+async def get_dpage(location: str | None = None, id: str | None = None) -> HTMLResponse:
+    if id:
+        if id in active_pages:
+            return redirect(id)
+        raise HTTPException(status_code=404, detail="Invalid page id")
+
+    if not location:
+        raise HTTPException(status_code=400, detail="Missing location parameter")
+
+    logger.info(f"Starting distillation at {location}...")
+    id = await dpage_add(location=location)
+    return redirect(id)
+
+
+FINISHED_MSG = "Finished! You can close this window now."
+
+
+@router.post("/{id}", response_class=HTMLResponse)
+async def post_dpage(id: str, request: Request) -> HTMLResponse:
+    if id not in active_pages:
+        raise HTTPException(status_code=404, detail="Page not found")
+
+    page = active_pages[id]
+
+    form_data = await request.form()
+    fields: dict[str, str] = {k: str(v) for k, v in form_data.items()}
+
+    path = os.path.join(os.path.dirname(__file__), "patterns", "**/*.html")
+    patterns = load_distillation_patterns(path)
+
+    logger.info(f"Continuing distillation for page {id}...")
+    logger.debug(f"Available distillation patterns: {len(patterns)}")
+
+    TICK = 1  # seconds
+    TIMEOUT = 15  # seconds
+    max = TIMEOUT // TICK
+
+    current = Match(name="", priority=-1, distilled="", matches=[])
+
+    for iteration in range(max):
+        logger.debug(f"Iteration {iteration + 1} of {max}")
+        await asyncio.sleep(TICK)
+
+        match = await distill(None, page, patterns)
+        if not match:
+            logger.info("No matched pattern found")
+            continue
+
+        if match.distilled == current.distilled:
+            logger.info(f"Still the same: {match.name}")
+            continue
+
+        current = match
+        distilled = match.distilled
+
+        print(distilled)
+
+        names: list[str] = []
+        document = BeautifulSoup(distilled, "html.parser")
+        inputs = document.find_all("input")
+
+        for input in inputs:
+            if isinstance(input, Tag):
+                gg_match = input.get("gg-match")
+                selector, frame_selector = get_selector(
+                    str(gg_match) if gg_match is not None else ""
+                )
+                name = input.get("name")
+                input_type = input.get("type")
+
+                if selector:
+                    if input_type == "checkbox":
+                        names.append(str(name) if name is not None else "checkbox")
+                        logger.info(f"Handling {selector} using autoclick")
+                    elif name is not None:
+                        name_str = str(name)
+                        value = fields.get(name_str)
+                        if value and len(value) > 0:
+                            logger.info(f"Using form data {name}")
+                            names.append(name_str)
+                            input["value"] = value
+                            if frame_selector:
+                                await (
+                                    page.frame_locator(str(frame_selector))
+                                    .locator(str(selector))
+                                    .fill(value)
+                                )
+                            else:
+                                await page.fill(str(selector), value)
+                            del fields[name_str]
+                            await asyncio.sleep(0.25)
+                        else:
+                            logger.info(f"No form data found for {name}")
+
+        title_element = document.find("title")
+        title = title_element.get_text() if title_element is not None else "GetGather"
+        action = f"/dpage/{id}"
+        options = {"title": title, "action": action}
+
+        if len(inputs) == len(names):
+            await autoclick(page, distilled)
+            if await terminate(page, distilled):
+                logger.info("Finished!")
+                converted = await convert(distilled)
+                await dpage_close(id)
+                if converted:
+                    print(converted)
+                    distillation_results[id] = converted
+                return HTMLResponse(render(FINISHED_MSG, options))
+
+            logger.info("All form fields are filled")
+            continue
+
+        if await terminate(page, distilled):
+            converted = await convert(distilled)
+            await dpage_close(id)
+            if converted:
+                print(converted)
+                distillation_results[id] = converted
+            return HTMLResponse(render(FINISHED_MSG, options))
+        else:
+            logger.info("Not all form fields are filled")
+
+        return HTMLResponse(render(str(document.find("body")), options))
+
+    raise HTTPException(status_code=503, detail="Timeout reached")

--- a/getgather/mcp/patterns/bbc-pre-signin.html
+++ b/getgather/mcp/patterns/bbc-pre-signin.html
@@ -1,0 +1,6 @@
+<html gg-domain="bbc" gg-priority="2">
+  <body>
+    <button gg-match='button:has-text("Subscribe")'></button>
+    <button gg-autoclick gg-match='button:has-text("Sign in")'></button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/bbc-saved-not-login.html
+++ b/getgather/mcp/patterns/bbc-saved-not-login.html
@@ -1,0 +1,6 @@
+<html gg-domain="bbc" gg-priority="2">
+  <body>
+    <span gg-match='span:has-text("Register for a BBC account")'></span>
+    <button gg-autoclick gg-match='button:has-text("Sign in")'></button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/bbc-signin-email.html
+++ b/getgather/mcp/patterns/bbc-signin-email.html
@@ -1,0 +1,11 @@
+<html gg-domain="bbc">
+  <head>
+    <title>BBC Sign In</title>
+  </head>
+  <body>
+    <p gg-optional gg-match="p.sb-form-message__content__text"></p>
+    <label gg-optional gg-match="label#username-label">Email</label>
+    <input autofocus name="email" type="email" placeholder="Email" gg-match="input#username" />
+    <button gg-autoclick gg-match="button[type=submit]">Sign in</button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/bbc-signin-password.html
+++ b/getgather/mcp/patterns/bbc-signin-password.html
@@ -1,0 +1,18 @@
+<html gg-domain="bbc">
+  <head>
+    <title>BBC Sign In</title>
+  </head>
+  <body>
+    <p gg-optional gg-match="[data-bbc-metadata*=error] p"></p>
+    <p gg-optional gg-match="p.sb-form-message__content__text"></p>
+    <label gg-optional gg-match="label#password-label">Password</label>
+    <input
+      autofocus
+      name="password"
+      type="password"
+      placeholder="Password"
+      gg-match="input[type=password]"
+    />
+    <button gg-autoclick gg-match="form[novalidate] [type=submit]">Sign in</button>
+  </body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,10 +19,11 @@ export default defineConfig(({ mode }) => {
     server: {
       host: "0.0.0.0",
       proxy: {
-        "^/(api|brands|link/create|link/status|parse|auth|replay|__static|live|mcp|inspector)": {
-          target: "http://127.0.0.1:23456/",
-          changeOrigin: false,
-        },
+        "^/(api|brands|link/create|link/status|parse|auth|replay|__static|live|mcp|inspector|dpage)":
+          {
+            target: "http://127.0.0.1:23456/",
+            changeOrigin: false,
+          },
       },
     },
     resolve: {


### PR DESCRIPTION
This is not yet fully completed nor connected to the MCP tool. It is merely the port of the Middleman's implementation of the concept.

To verify the initial functionality, launch with `npm run dev` and then open the following `localhost:5173/dpage?location=bbc.com/saved`.

This will trigger the distillation loop and that dpage ("distilled page") will start with the BBC sign in (email, and then password), and the finally end up with message to close the window.

While this happens, expect Patchright/Chromium to launch and to navigate the BBC website, according to the progression of the distillation.

<img width="1570" height="1059" alt="2025-08-10 dpage bbc" src="https://github.com/user-attachments/assets/b86e78ec-75b8-4681-b45d-7fa695dc170e" />
