### PR TITLE
fix: dpage mismatch detected pattern

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import urllib.parse
 
 from bs4 import BeautifulSoup, Tag
 from fastapi import APIRouter, HTTPException, Request
@@ -157,7 +158,9 @@ async def post_dpage(id: str, request: Request) -> HTMLResponse:
         logger.debug(f"Iteration {iteration + 1} of {max}")
         await asyncio.sleep(TICK)
 
-        match = await distill(page.url, page, patterns)
+        hostname = urllib.parse.urlparse(page.url).hostname
+
+        match = await distill(hostname, page, patterns)
         if not match:
             logger.info("No matched pattern found")
             continue


### PR DESCRIPTION
If we go to [this branch](https://github.com/mcp-getgather/mcp-getgather/pull/266), then run http://localhost:5173/dpage?location=www.linkedin.com/feed/ . It will detect "BBC Password" because the pattern is same. This happen because there's no domain/hostname matching.

<img width="1800" height="982" alt="Screenshot 2025-09-12 at 16 10 30" src="https://github.com/user-attachments/assets/ef4178da-bc8a-4eaf-a32d-808e43c1cc6a" />
