### PR TITLE
Distillation Test with Sign In

### DIFF
--- a/.github/workflows/distill-tests.yml
+++ b/.github/workflows/distill-tests.yml
@@ -44,3 +44,6 @@ jobs:
 
       - name: Run the distillation tests
         run: uv run pytest -n 7 -m "distill" tests/distillation/test_distill.py
+        env:
+          ACME_EMAIL_AND_PASSWORD_EMAIL: joe@example.com
+          ACME_EMAIL_AND_PASSWORD_PASSWORD: trustno1

--- a/tests/distillation/patterns/acme_authentication_error.html
+++ b/tests/distillation/patterns/acme_authentication_error.html
@@ -1,0 +1,11 @@
+<html gg-domain="acme_universal_error_test">
+  <head>
+    <title>ACME Universal Error Test</title>
+  </head>
+
+  <body>
+    <p gg-stop gg-match="p:has-text('Error Code: ACME_AUTH_ERROR_001')">
+      Error Code: ACME_AUTH_ERROR_001
+    </p>
+  </body>
+</html>

--- a/tests/distillation/patterns/acme_email_and_password.html
+++ b/tests/distillation/patterns/acme_email_and_password.html
@@ -1,14 +1,18 @@
 <html gg-domain="acme_email_and_password">
+  <head>
+    <title>ACME Email and Password</title>
+  </head>
 
-<head>
-  <title>ACME Email and Password</title>
-</head>
-
-<body>
-  <h1 gg-match="h1">Login</h1>
-  <input name="email" type="email" placeholder="Email" gg-match="input[type=email]" />
-  <input gg-optional name="password" type="password" placeholder="Password" gg-match="input[type=password]" />
-  <button gg-autoclick gg-match="button[type=submit]">Log in</button>
-</body>
-
+  <body>
+    <h1 gg-match="h1">Login</h1>
+    <input name="email" type="email" placeholder="Email" gg-match="input[type=email]" />
+    <input
+      gg-optional
+      name="password"
+      type="password"
+      placeholder="Password"
+      gg-match="input[type=password]"
+    />
+    <button gg-autoclick gg-match="button[type=submit]">Log in</button>
+  </body>
 </html>

--- a/tests/distillation/patterns/acme_email_and_password.html
+++ b/tests/distillation/patterns/acme_email_and_password.html
@@ -1,12 +1,14 @@
-<html>
-  <head>
-    <title>ACME Email and Password</title>
-  </head>
+<html gg-domain="acme_email_and_password">
 
-  <body>
-    <h1 gg-optional gg-match="h1">Login</h1>
-    <input name="email" type="email" placeholder="Email" gg-match="input[type=email]" />
-    <input name="password" type="password" placeholder="Password" gg-match="input[type=password]" />
-    <button gg-autoclick gg-match="button[type=submit]">Log in</button>
-  </body>
+<head>
+  <title>ACME Email and Password</title>
+</head>
+
+<body>
+  <h1 gg-match="h1">Login</h1>
+  <input name="email" type="email" placeholder="Email" gg-match="input[type=email]" />
+  <input gg-optional name="password" type="password" placeholder="Password" gg-match="input[type=password]" />
+  <button gg-autoclick gg-match="button[type=submit]">Log in</button>
+</body>
+
 </html>

--- a/tests/distillation/patterns/acme_home_page.html
+++ b/tests/distillation/patterns/acme_home_page.html
@@ -1,13 +1,11 @@
 <html gg-domain="acme_homepage">
-
-<head>
+  <head>
     <title>ACME Home Page</title>
-</head>
+  </head>
 
-<body>
+  <body>
     <h1 gg-match="h1">ACME Corp</h1>
     <a gg-match="a[href='/auth/email-and-password']">Email and Password</a>
     <a gg-match="a[href='/auth/email-then-password']">Email then Password</a>
-</body>
-
+  </body>
 </html>

--- a/tests/distillation/patterns/acme_home_page.html
+++ b/tests/distillation/patterns/acme_home_page.html
@@ -1,0 +1,13 @@
+<html gg-domain="acme_homepage">
+
+<head>
+    <title>ACME Home Page</title>
+</head>
+
+<body>
+    <h1 gg-match="h1">ACME Corp</h1>
+    <a gg-match="a[href='/auth/email-and-password']">Email and Password</a>
+    <a gg-match="a[href='/auth/email-then-password']">Email then Password</a>
+</body>
+
+</html>

--- a/tests/distillation/patterns/acme_login_success.html
+++ b/tests/distillation/patterns/acme_login_success.html
@@ -1,0 +1,11 @@
+<html>
+
+<head>
+    <title>ACME Login Success</title>
+</head>
+
+<body>
+    <h1 gg-stop gg-match-html="h1:has-text('Login successful!')"></h1>
+</body>
+
+</html>

--- a/tests/distillation/patterns/acme_login_success.html
+++ b/tests/distillation/patterns/acme_login_success.html
@@ -1,11 +1,9 @@
 <html>
-
-<head>
+  <head>
     <title>ACME Login Success</title>
-</head>
+  </head>
 
-<body>
+  <body>
     <h1 gg-stop gg-match-html="h1:has-text('Login successful!')"></h1>
-</body>
-
+  </body>
 </html>

--- a/tests/distillation/patterns/acme_universal_error_test.html
+++ b/tests/distillation/patterns/acme_universal_error_test.html
@@ -1,11 +1,9 @@
 <html gg-domain="acme_universal_error_test">
-
-<head>
+  <head>
     <title>ACME Universal Error Test</title>
-</head>
+  </head>
 
-<body>
+  <body>
     <p gg-match="p:has-text('Click \'Sign in\' to continue')">Click 'Sign in' to continue</p>
-</body>
-
+  </body>
 </html>

--- a/tests/distillation/patterns/acme_universal_error_test.html
+++ b/tests/distillation/patterns/acme_universal_error_test.html
@@ -5,5 +5,6 @@
 
   <body>
     <p gg-match="p:has-text('Click \'Sign in\' to continue')">Click 'Sign in' to continue</p>
+    <button gg-autoclick gg-match="button[type=submit]">Sign in</button>
   </body>
 </html>

--- a/tests/distillation/patterns/acme_universal_error_test.html
+++ b/tests/distillation/patterns/acme_universal_error_test.html
@@ -1,0 +1,11 @@
+<html gg-domain="acme_universal_error_test">
+
+<head>
+    <title>ACME Universal Error Test</title>
+</head>
+
+<body>
+    <p gg-match="p:has-text('Click \'Sign in\' to continue')">Click 'Sign in' to continue</p>
+</body>
+
+</html>

--- a/tests/distillation/test_distill.py
+++ b/tests/distillation/test_distill.py
@@ -15,6 +15,7 @@ PATTERN_LOCATIONS = {
     "http://localhost:5001": "acme_home_page.html",
     "http://localhost:5001/auth/email-and-password": "acme_email_and_password.html",
     "http://localhost:5001/auth/email-then-password": "acme_email_and_password.html",
+    "http://localhost:5001/universal-error-test": "acme_universal_error_test.html",
 }
 
 


### PR DESCRIPTION
Adds a new distillation test for the `run_distillation_loop` function with the ACME email and password page. This tests the actual ability of the distill framework to autofill email and password and click submit. The only thing needed is to add the email and password to the .env file with the proper names.

You can test it out by running `uv run pytest tests/distillation/test_distill.py -v -s` in the terminal. Be sure to first set 

```
ACME_EMAIL_AND_PASSWORD_EMAIL=joe@example.com
ACME_EMAIL_AND_PASSWORD_PASSWORD=trustno1
```
in your .env file first and run `source .env` to reset env vars before running the above command.

<img width="660" height="195" alt="Screenshot 2025-09-15 at 4 08 52 PM" src="https://github.com/user-attachments/assets/5090ee99-96b1-4799-8996-8e8257ae63d1" />
