### PR TITLE
fix: auto generate types before run frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN mkdir -p frontend/__generated__ && \
 COPY frontend/ ./frontend/
 
 # Build frontend
-RUN npm run build
+RUN npm run build:ci
 
 # Stage 3: Final image
 FROM mirror.gcr.io/library/python:3.13-slim-bookworm

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "inspector": "ALLOWED_ORIGINS=http://localhost:5173,http://localhost:6274 npx @modelcontextprotocol/inspector",
     "dev:frontend": "concurrently --raw \"npm run watch:schema:api\" \"vite\"",
     "build": "npm run generate:schema && tsc -b && vite build",
+    "build:ci": "tsc -b && vite build",
     "preview": "vite preview",
     "frontend:check:format": "prettier --check \"**/*.{html,js,jsx,ts,tsx,css,json,md}\"",
     "frontend:format": "prettier --write \"**/*.{html,js,jsx,ts,tsx,css,json,md}\"",


### PR DESCRIPTION
After #253, `__generated__/api.d.ts` is no longer generated automatically when we run `npm run dev`, which causes type errors.
Now we need to run the `getgather.generate_openapi` script to generate `openapi.json`, and then convert that into `api.d.ts`.

This is causing the frontend build to fail.
<img width="1110" height="878" alt="Screenshot 2025-09-16 at 14 06 03" src="https://github.com/user-attachments/assets/e04a3796-4035-49ae-85f0-7dca133baf65" />

After fix:
<img width="917" height="922" alt="Screenshot 2025-09-16 at 14 07 53" src="https://github.com/user-attachments/assets/490109f7-b9e4-4661-9970-a336563b2655" />
