### PR TITLE
Adopt the input value when it is being filled

### DIFF
--- a/getgather.py
+++ b/getgather.py
@@ -59,12 +59,11 @@ async def distill_command(location: str, option: str | None = None):
 
 async def run_command(location: str):
     patterns = load_distillation_patterns(PATTERNS_LOCATION)
-    fields = ["email", "tel", "text", "password"]
 
     if not location.startswith("http"):
         location = f"https://{location}"
 
-    result = await run_distillation_loop(location, patterns=patterns, fields=fields)
+    result = await run_distillation_loop(location, patterns=patterns)
     print(result)
 
     logger.info("Terminated.")

--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -100,48 +100,60 @@ async def ask(message: str, mask: str | None = None) -> str:
         return input(f"{message}: ")
 
 
-async def autofill(page: Page, distilled: str, fields: list[str]):
+async def autofill(page: Page, distilled: str):
     document = BeautifulSoup(distilled, "html.parser")
     root = document.find("html")
     domain = None
     if root:
         domain = cast(Tag, root).get("gg-domain")
 
-    for field in fields:
-        element = document.find("input", {"type": field})
-        selector = None
-        frame_selector = None
+    for element in document.find_all("input", {"type": True}):
+        if not isinstance(element, Tag):
+            continue
 
-        if element:
-            selector, frame_selector = get_selector(str(cast(Tag, element).get("gg-match")))
+        input_type = element.get("type")
+        name = element.get("name")
 
-        if selector:
+        if not name or (isinstance(name, str) and len(name) == 0):
+            logger.warning(f"There is an input (of type {input_type}) without a name!")
+
+        selector, frame_selector = get_selector(str(element.get("gg-match", "")))
+        if not selector:
+            logger.warning(f"There is an input (of type {input_type}) without a selector!")
+            continue
+
+        if input_type in ["email", "tel", "text", "password"]:
+            field = name or input_type
+            logger.debug(f"Autofilling type={input_type} name={name}...")
+
             source = f"{domain}_{field}" if domain else field
-            key = source.upper()
+            key = str(source).upper()
             value = os.getenv(key)
 
             if value and len(value) > 0:
                 logger.info(f"Using {key} for {field}")
-
                 if frame_selector:
                     await page.frame_locator(str(frame_selector)).locator(str(selector)).fill(value)
                 else:
                     await page.fill(str(selector), value)
+                element["value"] = value
             else:
-                placeholder = cast(Tag, element).get("placeholder")
+                placeholder = element.get("placeholder")
                 prompt = str(placeholder) if placeholder else f"Please enter {field}"
-                mask = "*" if field == "password" else None
-
+                mask = "*" if input_type == "password" else None
+                user_input = await ask(prompt, mask)
                 if frame_selector:
                     await (
                         page.frame_locator(str(frame_selector))
                         .locator(str(selector))
-                        .fill(await ask(prompt, mask))
+                        .fill(user_input)
                     )
-
                 else:
-                    await page.fill(str(selector), await ask(prompt, mask))
+                    await page.fill(str(selector), user_input)
+                element["value"] = user_input
             await asyncio.sleep(0.25)
+
+    return str(document)
 
 
 async def locate(locator: Locator) -> Locator | None:
@@ -309,7 +321,6 @@ async def distill(hostname: str | None, page: Page, patterns: list[Pattern]) -> 
 async def run_distillation_loop(
     location: str,
     patterns: list[Pattern],
-    fields: list[str] = [],
     browser_profile: BrowserProfile | None = None,
     timeout: int = 15,
     interactive: bool = True,
@@ -345,14 +356,18 @@ async def run_distillation_loop(
                 if match.distilled == current.distilled:
                     logger.debug(f"Still the same: {match.name}")
                 else:
-                    current = match
-                    print()
-                    print(current.distilled)
+                    distilled = match.distilled
                     if interactive:
-                        await autofill(page, current.distilled, fields)
-                        await autoclick(page, current.distilled)
-                    if await terminate(page, current.distilled):
-                        converted = await convert(current.distilled)
+                        distilled = await autofill(page, distilled)
+
+                    current = match
+                    current.distilled = distilled
+                    print()
+                    print(distilled)
+                    if interactive:
+                        await autoclick(page, distilled)
+                    if await terminate(page, distilled):
+                        converted = await convert(distilled)
                         if converted:
                             return converted
                         break

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -206,6 +206,7 @@ async def post_dpage(id: str, request: Request) -> HTMLResponse:
                             logger.info(f"Using form data {name}")
                             names.append(name_str)
                             input["value"] = value
+                            current.distilled = str(document)
                             if frame_selector:
                                 await (
                                     page.frame_locator(str(frame_selector))


### PR DESCRIPTION
This is necessary to avoid the potential infinite loop, e.g. in the case of repeated incorrect credentials. It is a port of the same mechanism in Middleman (https://github.com/mcp-getgather/middleman/pull/30).

The idea is that when an input field is filled, either on the CLI or from the distilled page, the value for that field also changes the distilled version of the page. This way, when that page is submitted (via form) to the upstream server and the server comes back with another sign-in form, it will not be considered the same thing (they are not).

To verify, run the usual CLI: `./getgather.py run goodreads.com/review`.

Before this change, the distillation loop never considers that the second incorrect passsword alert as a different once.

After this change, everything works as expected. Everytime Goodreads detect the incorrect password, the distilled version continues to be delivered to the user.

To try it on the MCP server itself, use BBC since it's the one fully migrated to distillation already.

<img width="1922" height="1192" alt="2025-09-15 distil adopt value" src="https://github.com/user-attachments/assets/90ebba7e-559c-4d51-84ad-ccc79e976b59" />
