### PR TITLE
feat: replace extraction with distillation for amazon purchases

### DIFF
--- a/getgather/mcp/brand/amazon.py
+++ b/getgather/mcp/brand/amazon.py
@@ -1,11 +1,18 @@
+import os
+from datetime import datetime
 from typing import Any
 
 from fastmcp import Context
 
 from getgather.connectors.spec_models import Schema as SpecSchema
+from getgather.distill import load_distillation_patterns, run_distillation_loop
 from getgather.mcp.agent import run_agent_for_brand
 from getgather.mcp.registry import BrandMCPBase
-from getgather.mcp.shared import extract, get_mcp_browser_session, with_brand_browser_session
+from getgather.mcp.shared import (
+    get_mcp_browser_profile,
+    get_mcp_browser_session,
+    with_brand_browser_session,
+)
 from getgather.parse import parse_html
 
 amazon_mcp = BrandMCPBase(brand_id="amazon", name="Amazon MCP")
@@ -14,7 +21,17 @@ amazon_mcp = BrandMCPBase(brand_id="amazon", name="Amazon MCP")
 @amazon_mcp.tool(tags={"private"})
 async def get_purchase_history() -> dict[str, Any]:
     """Get purchase/order history of a amazon."""
-    return await extract()
+
+    browser_profile = get_mcp_browser_profile()
+    path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
+    patterns = load_distillation_patterns(path)
+    current_year = datetime.now().year
+    purchases = await run_distillation_loop(
+        f"https://www.amazon.com/your-orders/orders?timeFilter=year-{current_year}",
+        patterns,
+        browser_profile=browser_profile,
+    )
+    return {"purchases": purchases}
 
 
 @amazon_mcp.tool

--- a/getgather/mcp/brand/amazonca.py
+++ b/getgather/mcp/brand/amazonca.py
@@ -23,7 +23,7 @@ async def get_purchase_history() -> dict[str, Any]:
     """Get purchase/order history of a amazon ca."""
 
     browser_profile = get_mcp_browser_profile()
-    path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")  # pyright: ignore[reportUnknownMemberType]
+    path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
     current_year = datetime.now().year
     purchases = await run_distillation_loop(


### PR DESCRIPTION
Enhanced the Amazon MCP purchase history retrieval to use the distillation loop pattern with dynamic year filtering instead of the generic extract method. This provides more targeted data extraction for the current year's Amazon orders.


https://github.com/user-attachments/assets/a1845890-4500-4144-88c7-fe9dd0395f77

