### PR TITLE
Distilled page: handle radio buttons

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -199,6 +199,34 @@ async def post_dpage(id: str, request: Request) -> HTMLResponse:
                     if input_type == "checkbox":
                         names.append(str(name) if name is not None else "checkbox")
                         logger.info(f"Handling {selector} using autoclick")
+                    elif input_type == "radio":
+                        if name is not None:
+                            name_str = str(name)
+                            value = fields.get(name_str)
+                            if not value or len(value) == 0:
+                                logger.warning(f"No form data found for radio button group {name}")
+                                continue
+                            radio = document.find("input", {"type": "radio", "id": str(value)})
+                            if not radio or not isinstance(radio, Tag):
+                                logger.warning(f"No radio button found with id {value}")
+                                continue
+                            logger.info(f"Handling radio button group {name}")
+                            logger.info(f"Using form data {name}={value}")
+                            radio_selector, radio_frame_selector = get_selector(
+                                str(radio.get("gg-match"))
+                            )
+                            if radio_frame_selector:
+                                await (
+                                    page.frame_locator(str(radio_frame_selector))
+                                    .locator(str(radio_selector))
+                                    .check()
+                                )
+                            else:
+                                await page.check(str(radio_selector))
+                            radio["checked"] = "checked"
+                            current.distilled = str(document)
+                            names.append(str(input.get("id")) if input.get("id") else "radio")
+                            await asyncio.sleep(0.25)
                     elif name is not None:
                         name_str = str(name)
                         value = fields.get(name_str)

--- a/getgather/mcp/patterns/bestbuy-mfa-choices.html
+++ b/getgather/mcp/patterns/bestbuy-mfa-choices.html
@@ -1,0 +1,47 @@
+<html gg-domain="bestbuy" gg-priority="5">
+  <head>
+    <title>Best Buy Verification Code</title>
+  </head>
+  <body>
+    <p gg-optional gg-match="h1"></p>
+
+    <div class="vertical-radios">
+      <div class="radio-wrapper">
+        <input
+          type="radio"
+          name="signin-option-radio"
+          id="password-radio"
+          gg-match="input#password-radio"
+          value="password-radio"
+          checked
+        />
+        <label for="password-radio" gg-match="label[for=password-radio]">Use password</label>
+      </div>
+      <div class="radio-wrapper">
+        <input
+          gg-optional
+          type="radio"
+          name="signin-option-radio"
+          id="email-code-radio"
+          gg-match="input#email-code-radio"
+          value="email-code-radio"
+        />
+        <label gg-optional for="email-code-radio" gg-match="label[for=email-code-radio]"
+          >Use email code</label
+        >
+      </div>
+      <div class="radio-wrapper">
+        <input
+          gg-optional
+          type="radio"
+          name="signin-option-radio"
+          id="sms-radio"
+          gg-match="input#sms-radio"
+          value="sms-radio"
+        />
+        <label gg-optional for="sms-radio" gg-match="label[for=sms-radio]">Use email link</label>
+      </div>
+    </div>
+    <button gg-autoclick gg-match="button[type=submit]">Continue</button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/bestbuy-signin-email.html
+++ b/getgather/mcp/patterns/bestbuy-signin-email.html
@@ -1,0 +1,9 @@
+<html gg-domain="bestbuy">
+  <head>
+    <title>Best Buy Sign In</title>
+  </head>
+  <body>
+    <input autofocus name="email" type="email" placeholder="Email" gg-match="input[type=email]" />
+    <button gg-autoclick gg-match="button[type=submit]">Continue</button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/bestbuy-signin-password.html
+++ b/getgather/mcp/patterns/bestbuy-signin-password.html
@@ -1,0 +1,17 @@
+<html gg-domain="bestbuy" gg-priority="1">
+  <head>
+    <title>Best Buy Sign In</title>
+  </head>
+  <body>
+    <p gg-optional gg-match=".tb-validation"></p>
+    <p gg-optional gg-match="div[role=alert]"></p>
+    <input
+      autofocus
+      name="password"
+      type="password"
+      placeholder="Password"
+      gg-match="input[type=password]"
+    />
+    <button gg-autoclick gg-match="form[novalidate] [type=submit]">Sign in</button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/bestbuy-verification-code.html
+++ b/getgather/mcp/patterns/bestbuy-verification-code.html
@@ -1,0 +1,19 @@
+<html gg-domain="bestbuy">
+  <head>
+    <title>Best Buy Verification Code</title>
+  </head>
+  <body>
+    <p gg-optional gg-match="h1"></p>
+    <p gg-optional gg-match="div[role=alert]"></p>
+    <p gg-optional gg-match="form div.text-center"></p>
+    <input
+      autofocus
+      name="verificationCode"
+      type="text"
+      inputmode="numeric"
+      placeholder="Verification Code"
+      gg-match="input#verificationCode"
+    />
+    <button gg-autoclick gg-match="button[type=submit]">Confirm</button>
+  </body>
+</html>


### PR DESCRIPTION
This is a port of the same feature tested in Middleman already: https://github.com/mcp-getgather/middleman/pull/31

To verify, run the distillation loop via the CLI:

```
./getgather.py run bestbuy.com/profile/ss/orderlookup
```

<img width="1698" height="1020" alt="2025-09-17 distill radio buttons" src="https://github.com/user-attachments/assets/e1365680-fe27-4c46-b318-ec1a64c63a5d" />

<img width="1698" height="1020" alt="2025-09-17 distill otp" src="https://github.com/user-attachments/assets/3654bf88-0f97-4f88-b42a-886e00c55efb" />


There is no Best Buy MCP tool yet, but I've tested it locally with its distilled page and the radio button appears just fine.