### PR TITLE
Base MCP for distillation-based tools

### DIFF
--- a/getgather/mcp/auto_import.py
+++ b/getgather/mcp/auto_import.py
@@ -1,8 +1,28 @@
 import importlib
+import inspect
 import pkgutil
+import sys
+from typing import Any
+
+from getgather.mcp.registry import BrandMCPBase, GatherMCP
+
+
+def has_mcp_class(module: Any) -> bool:
+    """Check if a module contains a class that inherits from BrandMCPBase or GatherMCP."""
+    for _, obj in inspect.getmembers(module):
+        if inspect.isclass(obj) and (issubclass(obj, BrandMCPBase) or issubclass(obj, GatherMCP)):
+            # Exclude the base classes themselves
+            if obj is not BrandMCPBase and obj is not GatherMCP:
+                return True
+    return False
 
 
 def auto_import(package_name: str):
     package = __import__(package_name, fromlist=["dummy"])
     for _, module_name, _ in pkgutil.iter_modules(package.__path__):
-        importlib.import_module(f"{package_name}.{module_name}")
+        full_module_name = f"{package_name}.{module_name}"
+        module = importlib.import_module(full_module_name)
+
+        # Remove non-MCP modules
+        if not has_mcp_class(module) and full_module_name in sys.modules:
+            del sys.modules[full_module_name]

--- a/getgather/mcp/bbc.py
+++ b/getgather/mcp/bbc.py
@@ -1,10 +1,11 @@
 from typing import Any
 
-from fastmcp import Context, FastMCP
+from fastmcp import Context
 
 from getgather.mcp.dpage import dpage_mcp_tool
+from getgather.mcp.registry import GatherMCP
 
-bbc_mcp = FastMCP[Context](name="BBC MCP")
+bbc_mcp = GatherMCP(brand_id="bbc", name="BBC MCP")
 
 
 @bbc_mcp.tool

--- a/getgather/mcp/espn.py
+++ b/getgather/mcp/espn.py
@@ -1,10 +1,11 @@
 from typing import Any
 
-from fastmcp import Context, FastMCP
+from fastmcp import Context
 
 from getgather.mcp.dpage import dpage_mcp_tool
+from getgather.mcp.registry import GatherMCP
 
-espn_mcp = FastMCP[Context](name="ESPN MCP")
+espn_mcp = GatherMCP(brand_id="espn", name="ESPN MCP")
 
 
 @espn_mcp.tool

--- a/getgather/mcp/main.py
+++ b/getgather/mcp/main.py
@@ -13,13 +13,10 @@ from getgather.connectors.spec_loader import BrandIdEnum
 from getgather.logs import logger
 from getgather.mcp.activity import activity
 from getgather.mcp.auto_import import auto_import
-from getgather.mcp.bbc import bbc_mcp
 from getgather.mcp.brand_state import BrandState, brand_state_manager
 from getgather.mcp.calendar_utils import calendar_mcp
 from getgather.mcp.dpage import dpage_check
-from getgather.mcp.espn import espn_mcp
-from getgather.mcp.nytimes import nytimes_mcp
-from getgather.mcp.registry import BrandMCPBase
+from getgather.mcp.registry import BrandMCPBase, GatherMCP
 from getgather.mcp.shared import poll_status_hosted_link, signin_hosted_link
 
 # Ensure calendar MCP is registered by importing its module
@@ -83,6 +80,12 @@ CATEGORY_BUNDLES: dict[str, list[str]] = {
     "food": ["doordash", "ubereats"],
     "books": ["audible", "goodreads", "kindle", "hardcover"],
     "shopping": ["amazon", "shopee", "tokopedia"],
+    "media": ["bbc"],
+}
+
+# For MCP tools based on distillation
+MCP_BUNDLES: dict[str, list[str]] = {
+    "media": ["bbc", "espn", "nytimes"],
 }
 
 
@@ -91,7 +94,7 @@ class MCPApp:
     name: str
     type: Literal["brand", "category", "all"]
     route: str
-    brand_ids: list[BrandIdEnum]
+    brand_ids: list[BrandIdEnum | str]
 
     @cached_property
     def app(self) -> StarletteWithLifespan:
@@ -103,15 +106,23 @@ def create_mcp_apps() -> list[MCPApp]:
     # Discover and import all brand MCP modules (registers into BrandMCPBase.registry)
     auto_import("getgather.mcp.brand")
 
+    auto_import("getgather.mcp")  # Import distillation-based MCPs
+
     apps: list[MCPApp] = []
     apps.append(
         MCPApp(
             name="all",
             type="all",
             route="/mcp",
-            brand_ids=list(BrandMCPBase.registry.keys()),
+            brand_ids=list(BrandMCPBase.registry.keys())
+            + [
+                brand_id
+                for brand_id in GatherMCP.registry.keys()
+                if brand_id not in [b.value for b in BrandMCPBase.registry.keys()]
+            ],
         )
     )
+    # Add individual brand MCPs from BrandMCPBase registry
     apps.extend([
         MCPApp(
             name=brand_id.value,
@@ -121,12 +132,24 @@ def create_mcp_apps() -> list[MCPApp]:
         )
         for brand_id in BrandMCPBase.registry.keys()
     ])
+    # Add individual brand MCPs from GatherMCP registry
+    apps.extend([
+        MCPApp(
+            name=brand_id,
+            type="brand",
+            route=f"/mcp-{brand_id}",
+            brand_ids=[brand_id],
+        )
+        for brand_id in GatherMCP.registry.keys()
+        if brand_id not in [b.value for b in BrandMCPBase.registry.keys()]
+    ])
     apps.extend([
         MCPApp(
             name=category,
             type="category",
             route=f"/mcp-{category}",
-            brand_ids=[BrandIdEnum(brand_id) for brand_id in brand_ids],
+            brand_ids=[BrandIdEnum(brand_id) for brand_id in brand_ids]
+            + MCP_BUNDLES.get(category, []),
         )
         for category, brand_ids in CATEGORY_BUNDLES.items()
     ])
@@ -134,7 +157,7 @@ def create_mcp_apps() -> list[MCPApp]:
     return apps
 
 
-def _create_mcp_app(bundle_name: str, brand_ids: list[BrandIdEnum]):
+def _create_mcp_app(bundle_name: str, brand_ids: list[BrandIdEnum | str]):
     """Create and return the MCP ASGI app.
 
     This performs plugin discovery/registration and mounts brand MCPs.
@@ -162,15 +185,23 @@ def _create_mcp_app(bundle_name: str, brand_ids: list[BrandIdEnum]):
         }
 
     for brand_id in brand_ids:
-        brand_mcp = BrandMCPBase.registry[brand_id]
-        logger.info(f"Mounting {brand_mcp.name} to MCP bundle {bundle_name}")
-        mcp.mount(server=brand_mcp, prefix=brand_mcp.brand_id)
+        brand_id_str = brand_id.value if isinstance(brand_id, BrandIdEnum) else brand_id
+        brand_id_enum = brand_id if isinstance(brand_id, BrandIdEnum) else None
+
+        # Try BrandMCPBase registry first (if it's a BrandIdEnum)
+        if brand_id_enum and brand_id_enum in BrandMCPBase.registry:
+            brand_mcp = BrandMCPBase.registry[brand_id_enum]
+            logger.info(f"Mounting {brand_mcp.name} to MCP bundle {bundle_name}")
+            mcp.mount(server=brand_mcp, prefix=brand_mcp.brand_id)
+        # Try GatherMCP registry (for string brand IDs)
+        elif brand_id_str in GatherMCP.registry:
+            gather_mcp = GatherMCP.registry[brand_id_str]
+            logger.info(
+                f"Mounting {gather_mcp.name} (distillation-based) to MCP bundle {bundle_name}"
+            )
+            mcp.mount(server=gather_mcp, prefix=gather_mcp.brand_id)
 
     mcp.mount(server=calendar_mcp, prefix="calendar")
-    mcp.mount(server=nytimes_mcp, prefix="nytimes")
-    mcp.mount(server=espn_mcp, prefix="espn")
-
-    mcp.mount(server=bbc_mcp, prefix="bbc")
 
     return mcp.http_app(path="/")
 

--- a/getgather/mcp/nytimes.py
+++ b/getgather/mcp/nytimes.py
@@ -1,10 +1,11 @@
 from typing import Any
 
-from fastmcp import Context, FastMCP
+from fastmcp import Context
 
 from getgather.mcp.dpage import dpage_mcp_tool
+from getgather.mcp.registry import GatherMCP
 
-nytimes_mcp = FastMCP[Context](name="NYTimes MCP")
+nytimes_mcp = GatherMCP(brand_id="nytimes", name="NYTimes MCP")
 
 
 @nytimes_mcp.tool

--- a/getgather/mcp/registry.py
+++ b/getgather/mcp/registry.py
@@ -14,3 +14,13 @@ class BrandMCPBase(FastMCP[Context]):
         self.brand_id = BrandIdEnum(brand_id)
         BrandMCPBase.registry[self.brand_id] = self
         logger.debug(f"Registered MCP with brand_id '{brand_id}' and name '{name}'")
+
+
+class GatherMCP(FastMCP[Context]):
+    registry: ClassVar[dict[str, "GatherMCP"]] = {}
+
+    def __init__(self, *, brand_id: str, name: str) -> None:
+        super().__init__(name=name)
+        self.brand_id = brand_id
+        GatherMCP.registry[self.brand_id] = self
+        logger.debug(f"Registered GatherMCP with brand_id '{brand_id}' and name '{name}'")


### PR DESCRIPTION
This is mainly to assist gradual migration from orchestrator to distilation. Until every tool is completely migrated, expect some rough edges such as two category bundles, awkward/inconsistent typing, etc.

To verify, launch as usual with `npm run dev` and connect the MCP inspector to e.g. `localhost:23456/mcp-media`. A bunch of tools related to BBC, ESPN, and NYTimes should be available and accessible.

<img width="1570" height="1126" alt="2025-09-21 gather mcp distillation" src="https://github.com/user-attachments/assets/5f3dc76f-1c2d-4c15-9b16-9a3738e6d1ab" />
