### PR TITLE
Distillation: skip loading images, videos, and fonts

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -307,6 +307,15 @@ async def dpage_mcp_tool(initial_url: str, result_key: str) -> dict[str, Any]:
             await debug_page.goto("https://ifconfig.me")
 
             init_page = await session.context.new_page()
+            await init_page.route(
+                "**/*",
+                lambda route: asyncio.create_task(
+                    route.abort()
+                    if route.request.resource_type in ["image", "media", "font"]
+                    else route.continue_()
+                ),
+            )
+
             await init_page.goto(initial_url)
             await asyncio.sleep(1)
 


### PR DESCRIPTION
On part with the orchestrator, any resources (decided based on its type) unrelated to the actual content should not be loaded by Chromium. This will speed up the loading process.

To verify, launch as usual with `npm run dev`, connect the MCP Inspector to `localhost:23456/mcp-media`, invoke the tool to grab the NYTimes Best-sellers list. Patchright/Chromium will load NYTimes page without the images (e.g. the book covers).

Before this PR, all those images take some time to load.

<img width="2410" height="1514" alt="2025-09-22 distillation block media" src="https://github.com/user-attachments/assets/6266b793-1211-45b5-acb1-8dbf2cb22ed3" />
