### PR TITLE
The base URL for the distilled page can use a custom host and proto

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -322,13 +322,12 @@ async def dpage_mcp_tool(initial_url: str, result_key: str) -> dict[str, Any]:
     # If that didn't work, try signing in via distillation
     id = await dpage_add(browser_profile=browser_profile, location=initial_url)
 
-    host = headers.get("host")
+    host = headers.get("x-forwarded-host") or headers.get("host")
     if host is None:
         logger.warning("Missing Host header; defaulting to localhost")
         base_url = "http://localhost:23456"
     else:
-        is_local = "localhost" in host or "127.0.0.1" in host
-        scheme = headers.get("x-forwarded-proto", "http" if is_local else "https")
+        scheme = headers.get("x-forwarded-proto", "https")
         base_url = f"{scheme}://{host}"
 
     url = f"{base_url}/dpage/{id}"


### PR DESCRIPTION
This is the same behavior as the hosted link. Two HTTP headers (potentially set by mcp-gateway or any reverse proxy for that matter) to customize the base URL are `x-forwarded-host` and `x-forwarded-proto`.