### PR TITLE
Add proxy to MCP tests

### DIFF
--- a/.github/workflows/mcp-tests.yml
+++ b/.github/workflows/mcp-tests.yml
@@ -47,3 +47,5 @@ jobs:
           HOST: http://localhost:23456
           BBC_EMAIL: ${{ secrets.BBC_EMAIL }}
           BBC_PASSWORD: ${{ secrets.BBC_PASSWORD }}
+          BROWSER_HTTP_PROXY: ${{ secrets.BROWSER_HTTP_PROXY }}
+          BROWSER_HTTP_PROXY_PASSWORD: ${{ secrets.BROWSER_HTTP_PROXY_PASSWORD }}

--- a/.github/workflows/mcp-tests.yml
+++ b/.github/workflows/mcp-tests.yml
@@ -35,6 +35,8 @@ jobs:
         run: uv run -m uvicorn getgather.main:app --host 127.0.0.1 --port 23456 &
         env:
           DISPLAY: :1
+          BROWSER_HTTP_PROXY: ${{ secrets.BROWSER_HTTP_PROXY }}
+          BROWSER_HTTP_PROXY_PASSWORD: ${{ secrets.BROWSER_HTTP_PROXY_PASSWORD }}
 
       - name: Wait for the API server to start
         run: while ! curl -s 'http://localhost:23456/health' | grep 'OK'; do sleep 1; done
@@ -47,5 +49,3 @@ jobs:
           HOST: http://localhost:23456
           BBC_EMAIL: ${{ secrets.BBC_EMAIL }}
           BBC_PASSWORD: ${{ secrets.BBC_PASSWORD }}
-          BROWSER_HTTP_PROXY: ${{ secrets.BROWSER_HTTP_PROXY }}
-          BROWSER_HTTP_PROXY_PASSWORD: ${{ secrets.BROWSER_HTTP_PROXY_PASSWORD }}


### PR DESCRIPTION
Adds the proxy endpoint and password to the MCP tests so that certain MCP tests don't flake out due to the CI using its own (probably detectable) IP address. Should make the NYT bestsellers test less flaky if it works properly. However, if this runs on every PR then we might want to think about cost. I'm not sure how expensive it is to run the proxy but it might not be worth it to run for every MCP test.