### PR TITLE
Fix autoimport by checking for the MCP class in the module source

### DIFF
--- a/getgather/mcp/auto_import.py
+++ b/getgather/mcp/auto_import.py
@@ -1,4 +1,5 @@
 import importlib
+import importlib.util
 import inspect
 import pkgutil
 import sys
@@ -10,19 +11,44 @@ from getgather.mcp.registry import BrandMCPBase, GatherMCP
 def has_mcp_class(module: Any) -> bool:
     """Check if a module contains a class that inherits from BrandMCPBase or GatherMCP."""
     for _, obj in inspect.getmembers(module):
-        if inspect.isclass(obj) and (issubclass(obj, BrandMCPBase) or issubclass(obj, GatherMCP)):
-            # Exclude the base classes themselves
-            if obj is not BrandMCPBase and obj is not GatherMCP:
-                return True
+        if inspect.isclass(obj):
+            try:
+                if issubclass(obj, BrandMCPBase) or issubclass(obj, GatherMCP):
+                    return True
+            except TypeError:
+                # Skip if obj cannot be used with issubclass
+                continue
     return False
+
+
+def check_module_source_for_mcp(module_name: str) -> bool:
+    """
+    Check heuristically if a module might contain MCP classes by examining its source.
+    """
+    try:
+        module_spec = importlib.util.find_spec(module_name)
+        if not module_spec or not module_spec.origin:
+            return False
+        if not module_spec.origin.endswith(".py"):
+            return False
+
+        # Check for imports in the source file
+        with open(module_spec.origin, "r") as f:
+            source = f.read()
+        return "import BrandMCPBase" in source or "import GatherMCP" in source
+
+    except Exception:
+        # If we can't check the source, assume it might have an MCP class
+        return True
 
 
 def auto_import(package_name: str):
     package = __import__(package_name, fromlist=["dummy"])
     for _, module_name, _ in pkgutil.iter_modules(package.__path__):
         full_module_name = f"{package_name}.{module_name}"
-        module = importlib.import_module(full_module_name)
 
-        # Remove non-MCP modules
-        if not has_mcp_class(module) and full_module_name in sys.modules:
-            del sys.modules[full_module_name]
+        if check_module_source_for_mcp(full_module_name):
+            module = importlib.import_module(full_module_name)
+            if not has_mcp_class(module):
+                if full_module_name in sys.modules:
+                    del sys.modules[full_module_name]


### PR DESCRIPTION
Eventually when everything is migrated to distillation, we may not need this. But for now, avoid blind module import by checking first heuristically if the module is a legimate MCP class.

To verify, run the MCP server, connect MCP inspector, list some tools. All the available tools should be still enumerated correctly.