### PR TITLE
fix: update product selector in amazon orders

### DIFF
--- a/getgather/mcp/patterns/amazon-orders.html
+++ b/getgather/mcp/patterns/amazon-orders.html
@@ -25,7 +25,7 @@
           },
           {
             "name": "product_names",
-            "selector": "div.yohtmlc-product-title, a.a-link-normal[href*='/gp/product/'], a.a-link-normal[href*='/gp/video/'], .a-fixed-left-grid-col a.a-link-normal",
+            "selector": "div.yohtmlc-product-title a",
             "kind": "list"
           },
           {


### PR DESCRIPTION
Fix duplicated items on amazon product_names

<img width="1128" height="451" alt="Firefox Developer Edition 2025-09-24 09 10 53" src="https://github.com/user-attachments/assets/ff38d307-6a7b-4d98-8721-be70d9d26916" />
<img width="2692" height="2040" alt="Firefox Developer Edition 2025-09-24 09 14 34" src="https://github.com/user-attachments/assets/3731fd28-fb2b-45a8-ac3e-f876e8dd0ba5" />
