### PR TITLE
MCP tool to get NPR headlines

### DIFF
--- a/getgather/mcp/main.py
+++ b/getgather/mcp/main.py
@@ -85,7 +85,7 @@ CATEGORY_BUNDLES: dict[str, list[str]] = {
 
 # For MCP tools based on distillation
 MCP_BUNDLES: dict[str, list[str]] = {
-    "media": ["bbc", "espn", "nytimes"],
+    "media": ["bbc", "espn", "npr", "nytimes"],
 }
 
 

--- a/getgather/mcp/npr.py
+++ b/getgather/mcp/npr.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from fastmcp import Context
+
+from getgather.mcp.dpage import dpage_mcp_tool
+from getgather.mcp.registry import GatherMCP
+
+npr_mcp = GatherMCP(brand_id="npr", name="NPR MCP")
+
+
+@npr_mcp.tool
+async def get_headlines(ctx: Context) -> dict[str, Any]:
+    """Get the current news headlines from NPR."""
+    return await dpage_mcp_tool("https://text.npr.org", "headlines")

--- a/getgather/mcp/patterns/npr-headlines.html
+++ b/getgather/mcp/patterns/npr-headlines.html
@@ -1,0 +1,17 @@
+<html gg-domain="npr">
+  <head>
+    <title>NPR Headlines</title>
+  </head>
+  <body>
+    <ul gg-stop gg-match-html="main ul"></ul>
+    <script type="application/json" id="headlines">
+      {
+        "rows": "ul li",
+        "columns": [
+          { "name": "title", "selector": "li a" },
+          { "name": "link", "selector": "li a", "attribute": "href" }
+        ]
+      }
+    </script>
+  </body>
+</html>

--- a/tests/mcp/test_npr.py
+++ b/tests/mcp/test_npr.py
@@ -1,0 +1,28 @@
+"""Tests for NPR Tools: get_headlines."""
+
+import json
+import os
+
+import pytest
+from fastmcp import Client
+from mcp.types import TextContent
+
+config = {
+    "mcpServers": {"getgather": {"url": f"{os.environ.get('HOST', 'http://localhost:23456')}/mcp"}}
+}
+
+
+@pytest.mark.mcp
+@pytest.mark.asyncio
+async def test_npr_get_headlines():
+    """Test get headlines from NPR."""
+    client = Client(config)
+    async with client:
+        mcp_call_result = await client.call_tool("npr_get_headlines")
+        assert isinstance(mcp_call_result.content[0], TextContent), (
+            f"Expected TextContent, got {type(mcp_call_result.content[0])}"
+        )
+        parsed_mcp_call_result = json.loads(mcp_call_result.content[0].text)
+        headlines = parsed_mcp_call_result.get("headlines")
+        assert headlines, "Expected 'headlines' to be non-empty"
+        assert isinstance(headlines, list), f"Expected list, got {type(headlines)}"


### PR DESCRIPTION
This is using the bandwidth-friendly text.npr.org which does not load any extra resources like ads etc.

To verify: `npm run dev`, connect MCP inspector, and invoke the tool `npr_get_headlines`.

<img width="1852" height="1385" alt="2025-09-24 npr mcp tool" src="https://github.com/user-attachments/assets/eab68163-6ad3-414e-9efb-3e95d46ac34d" />
