### PR TITLE
minor changes in gateway mode

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -12,7 +12,7 @@ BROWSER_USE_MODEL=
 # BROWSER_HTTP_PROXY=http://your-proxy-server:port
 # BROWSER_HTTP_PROXY_PASSWORD=your-proxy-password
 
-SERVER_NAME=
+HOSTNAME=
 
 # where persisted data is stored
 DATA_DIR=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # Stage 1: Backend Builder
 FROM mirror.gcr.io/library/python:3.13-slim-bookworm AS backend-builder
 
-ARG MULTI_USER_ENABLED=false
-ENV MULTI_USER_ENABLED=${MULTI_USER_ENABLED}
-
 COPY --from=ghcr.io/astral-sh/uv:0.8.4 /uv /uvx /bin/
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -116,8 +113,11 @@ ENV PYTHONUNBUFFERED=1 \
 ENV PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 
+ARG PORT=23456
+ENV PORT=${PORT}
+
 # port for FastAPI server
-EXPOSE 23456
+EXPOSE ${PORT}
 # port for VNC server
 EXPOSE 5900
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,4 +42,4 @@ dbus-daemon --system --fork
 echo "D-BUS daemon started with pid: $(cat /run/dbus/pid)"
 
 # Start FastAPI server
-/opt/venv/bin/python -m uvicorn getgather.main:app --host 0.0.0.0 --port 23456 --proxy-headers --forwarded-allow-ips="*"
+/opt/venv/bin/python -m uvicorn getgather.main:app --host 0.0.0.0 --port $PORT --proxy-headers --forwarded-allow-ips="*"

--- a/getgather/config.py
+++ b/getgather/config.py
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
     )
     RRWEB_MASK_ALL_INPUTS: bool = True
 
-    SERVER_NAME: str = ""
+    HOSTNAME: str = ""
 
     @property
     def brand_spec_dir(self) -> Path:

--- a/getgather/hosted_link_manager.py
+++ b/getgather/hosted_link_manager.py
@@ -45,7 +45,7 @@ class HostedLinkManager:
     def _generate_link_id(cls) -> str:
         """Generate a unique link id. If server name is set, it will be encoded in the id."""
         id = generate(FRIENDLY_CHARS, 6)
-        return f"{settings.SERVER_NAME}-{id}" if settings.SERVER_NAME else id
+        return f"{settings.HOSTNAME}-{id}" if settings.HOSTNAME else id
 
     @classmethod
     def create_link(


### PR DESCRIPTION
rename SERVER_NAME to HOSTNAME to be consistent with gateway naming

make the fastapi port configurable so we can use 80 and gateway can reach the server just by hostname

