### PR TITLE
Mark the NYTimes test as flaky

### DIFF
--- a/tests/mcp/test_nytimes.py
+++ b/tests/mcp/test_nytimes.py
@@ -14,6 +14,7 @@ config = {
 
 @pytest.mark.mcp
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="Flaky test")
 async def test_nytimes_get_bestsellers_list():
     """Test get bestsellers list from NY Times."""
     client = Client(config)


### PR DESCRIPTION
Temporary band-aid. The long term is likely to route the traffic to a proxy.