### PR TITLE
Handle raw html dpage result

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -337,11 +337,11 @@ async def dpage_mcp_tool(initial_url: str, result_key: str) -> dict[str, Any]:
         browser_profile = global_browser_profile
 
     # First, try without any interaction as this will work if the user signed in previously
-    result = await run_distillation_loop(
+    distillation_result = await run_distillation_loop(
         initial_url, patterns, browser_profile=browser_profile, interactive=False, timeout=2
     )
-    if isinstance(result, list):
-        return {result_key: result}
+    if distillation_result["terminated"]:
+        return {result_key: distillation_result["result"]}
 
     # If that didn't work, try signing in via distillation
     id = await dpage_add(browser_profile=browser_profile, location=initial_url)

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -39,7 +39,7 @@ def block_unwanted_resources(route: Route) -> Task[None]:
 
 
 active_pages: dict[str, Page] = {}
-distillation_results: dict[str, list[dict[str, str | list[str]]]] = {}
+distillation_results: dict[str, str | list[dict[str, str | list[str]]]] = {}
 global_browser_profile: BrowserProfile | None = None
 
 
@@ -275,6 +275,9 @@ async def post_dpage(id: str, request: Request) -> HTMLResponse:
                 if converted:
                     print(converted)
                     distillation_results[id] = converted
+                else:
+                    logger.info("No conversion found")
+                    distillation_results[id] = distilled
                 return HTMLResponse(render(FINISHED_MSG, options))
 
             logger.info("All form fields are filled")


### PR DESCRIPTION
Currently, when we use dpage in mcp-tool, if the parse schema is not defined inside the .html pattern, it will ask us to sign in again.

This changes allow us to send the raw HTML result to the MCP client (for cases like empty message orders, etc.).

Testing result:

<details>
  <summary>From signin, no schema parse</summary>

<img width="1237" height="908" alt="Screenshot 2025-09-26 at 16 15 49" src="https://github.com/user-attachments/assets/f8851907-bb9d-40f7-9390-f2e7f22bd56c" />


</details>

<details>
  <summary>Already signin, no schema parse</summary>

<img width="1140" height="783" alt="Screenshot 2025-09-26 at 16 09 10" src="https://github.com/user-attachments/assets/c84143ae-180b-4465-9864-ea71c435bf6d" />


</details>

<details>
  <summary>Already signin, with schema parse</summary>


<img width="945" height="736" alt="Screenshot 2025-09-26 at 16 08 41" src="https://github.com/user-attachments/assets/7dcdadf5-65fd-47a3-889d-6ba90840b91a" />

</details>