### PR TITLE
Speculative robustification of DISLAY env for Xvfb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,7 @@ ENV PYTHONUNBUFFERED=1 \
 # Set Playwright-specific environment variables only for full deployment
 ENV PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+ENV DISPLAY=:99
 
 ARG PORT=23456
 ENV PORT=${PORT}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,17 +2,18 @@
 set -e
 
 # Start Xvfb display server
-export DISPLAY=:99
 export XAUTHORITY=/tmp/xauth99
 rm -f "$XAUTHORITY"; touch "$XAUTHORITY"
 xauth -f "$XAUTHORITY" add :99 . "$(mcookie)"
 echo "Starting Xvfb on DISPLAY=$DISPLAY..."
-Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp -auth "$XAUTHORITY" >/dev/null 2>&1 &
-# Wait for Xvfb socket to appear
+Xvfb $DISPLAY -screen 0 1920x1080x24 -nolisten tcp -auth "$XAUTHORITY" >/dev/null 2>&1 &
+
+echo "Waiting for Xvfb socket to appear..."
 while [ ! -e /tmp/.X11-unix/X99 ]; do
   sleep 0.1
 done
-# wait until the server really answers (not just the socket exists)
+
+echo "Checking if Xvfb is ready with xpyinfo..."
 for i in $(seq 1 100); do xdpyinfo >/dev/null 2>&1 && break; sleep 0.1; done
 echo "Xvfb running on DISPLAY=$DISPLAY"
 
@@ -24,7 +25,7 @@ x11vnc \
   -forever \
   -nopw \
   -rfbport 5900 \
-  -display :99 \
+  -display $DISPLAY \
   -listen 0.0.0.0 \
   -quiet \
   -no6 >/dev/null 2>&1 &


### PR DESCRIPTION
Since it's always needed, might as well set it in Dockerfile. In addition, turn more script comments into "echo" logging for stdout.

To verify, build and run the container, try it with MCP Inspector while checking its live view.