### PR TITLE
add the ability to use oxylabs proxy directly

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -9,8 +9,7 @@ SENTRY_DSN=
 OPENAI_API_KEY=
 BROWSER_USE_MODEL=
 # Proxy Settings (Optional)
-# BROWSER_HTTP_PROXY=http://your-proxy-server:port
-# BROWSER_HTTP_PROXY_PASSWORD=your-proxy-password
+# BROWSER_PROXY=http://username:password@your-proxy-server:port
 
 HOSTNAME=
 

--- a/getgather/config.py
+++ b/getgather/config.py
@@ -33,8 +33,7 @@ class Settings(BaseSettings):
     BROWSER_TIMEOUT: int = 30_000
 
     # Proxy Settings
-    BROWSER_HTTP_PROXY: str = ""
-    BROWSER_HTTP_PROXY_PASSWORD: str = ""
+    BROWSER_PROXY: str = ""
 
     # RRWeb Recording Settings
     ENABLE_RRWEB_RECORDING: bool = False


### PR DESCRIPTION
we can use `http://:1234@localhost:8889` for our own proxy service, where username is dynamic
or `https://username:password@pr.oxylabs.io:7777` for oxylabs directly
or any other proxy services