### PR TITLE
Ground News MCP tool, to get the latest stories

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -307,7 +307,7 @@ def is_local_address(host: str) -> bool:
         return hostname in ("localhost", "127.0.0.1")
 
 
-async def dpage_mcp_tool(initial_url: str, result_key: str) -> dict[str, Any]:
+async def dpage_mcp_tool(initial_url: str, result_key: str, timeout: int = 2) -> dict[str, Any]:
     """Generic MCP tool based on distillation"""
 
     path = os.path.join(os.path.dirname(__file__), "patterns", "**/*.html")
@@ -341,7 +341,7 @@ async def dpage_mcp_tool(initial_url: str, result_key: str) -> dict[str, Any]:
 
     # First, try without any interaction as this will work if the user signed in previously
     distillation_result = await run_distillation_loop(
-        initial_url, patterns, browser_profile=browser_profile, interactive=False, timeout=2
+        initial_url, patterns, browser_profile=browser_profile, interactive=False, timeout=timeout
     )
     if distillation_result["terminated"]:
         return {result_key: distillation_result["result"]}

--- a/getgather/mcp/groundnews.py
+++ b/getgather/mcp/groundnews.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from fastmcp import Context
+
+from getgather.mcp.dpage import dpage_mcp_tool
+from getgather.mcp.registry import GatherMCP
+
+groundnews_mcp = GatherMCP(brand_id="groundnews", name="Ground News MCP")
+
+
+@groundnews_mcp.tool
+async def get_stories(ctx: Context) -> dict[str, Any]:
+    """Get the latest news stories from Ground News."""
+    return await dpage_mcp_tool("https://ground.news", "stories", timeout=10)

--- a/getgather/mcp/main.py
+++ b/getgather/mcp/main.py
@@ -97,7 +97,7 @@ CATEGORY_BUNDLES: dict[str, list[str]] = {
 
 # For MCP tools based on distillation
 MCP_BUNDLES: dict[str, list[str]] = {
-    "media": ["bbc", "espn", "npr", "nytimes"],
+    "media": ["bbc", "espn", "groundnews", "npr", "nytimes"],
 }
 
 

--- a/getgather/mcp/patterns/groundnews-latest-stories.html
+++ b/getgather/mcp/patterns/groundnews-latest-stories.html
@@ -1,0 +1,17 @@
+<html gg-domain="ground.news">
+  <head>
+    <title>Ground News</title>
+  </head>
+  <body>
+    <div gg-stop gg-match-html="[data-testid=latest-stories-homepage]"></div>
+    <script type="application/json" id="news">
+      {
+        "rows": "[data-testid=story-item]",
+        "columns": [
+          { "name": "title", "selector": "h4" },
+          { "name": "link", "selector": "a", "attribute": "href" }
+        ]
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This also introduces the override for the timeout on the initial distillation, as Ground News usually displays an interstitial page for about 2-3 seconds.

To verify, run `npm run dev`, connect MCP Inspector, and launch the tool named `groundnews_get_stories`.

<img width="1624" height="963" alt="Screenshot 2025-09-27 at 10 39 51 AM" src="https://github.com/user-attachments/assets/ef2eb9cc-53e1-4cc1-b4c4-ccb3ab9988cd" />
