### PR TITLE
Use TigerVNC to replace the combination of Xvfb and x11vnc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,8 +76,7 @@ RUN npm run build:ci
 FROM mirror.gcr.io/library/python:3.13-slim-bookworm
 
 RUN apt-get update && apt-get install -y \
-    xvfb \
-    xauth \
+    tigervnc-standalone-server \
     libnss3 \
     libatk-bridge2.0-0 \
     libgtk-3-0 \


### PR DESCRIPTION
For the purpose of live desktop view, VNC is needed anyway, thus might as well use one tool that does both X server and VNC server.

To verify, build the container image as usual, run it, and then connect MCP Inspector to the running MCP server. Open the live view while invoking an MCP tool.

<img width="1584" height="1374" alt="2025-09-29 tigervnc" src="https://github.com/user-attachments/assets/43fb4fa0-de3a-4687-bf4c-30a9dbd3afa9" />
