### PR TITLE
Allow sharing of VNC sessions to enable multiple VNC connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,8 +76,7 @@ RUN npm run build:ci
 FROM mirror.gcr.io/library/python:3.13-slim-bookworm
 
 RUN apt-get update && apt-get install -y \
-    xvfb \
-    xauth \
+    tigervnc-standalone-server \
     libnss3 \
     libatk-bridge2.0-0 \
     libgtk-3-0 \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ export DBUS_SESSION_BUS_ADDRESS=""
 export USER=root
 
 echo "Starting TigerVNC server on DISPLAY=$DISPLAY..."
-Xvnc ${DISPLAY} -geometry 1920x1080 -depth 24 -rfbport 5900 -SecurityTypes None &
+Xvnc -alwaysshared ${DISPLAY} -geometry 1920x1080 -depth 24 -rfbport 5900 -SecurityTypes None &
 sleep 2
 echo "TigerVNC server running on DISPLAY=$DISPLAY"
 


### PR DESCRIPTION
Before this PR, if one person is opening the `/live` desktop view, nobody else can connect to that, since by default the VNC server limits to a single connection.

After this PR, by enabling the shared connection, multiple persons can go to the `/live` view and interact with the desktop all at the same time.

Note: this depends on PR #419.