### PR TITLE
Add some Tailscale debugging for Dokku deployment

### DIFF
--- a/.github/workflows/deploy-dokku.yml
+++ b/.github/workflows/deploy-dokku.yml
@@ -31,6 +31,15 @@ jobs:
           tags: tag:ci
           use-cache: true
 
+      - name: Show Tailnet IP address
+        run: tailscale ip
+
+      - name: Check the reachability of the app server
+        env:
+          APP_URL: ${{ secrets.TAILSCALE_APP_URL }}
+        run: curl -s "${APP_URL}/health"
+        continue-on-error: true
+
       - name: Deploy to GCE via dokku
         uses: dokku/github-action@master
         with:


### PR DESCRIPTION
Consider the intermittent Tailscale issues, we need to have more information if the deployment fails.
This commit thus adds the following useful steps:

<img width="822" height="238" alt="Screenshot 2025-09-29 at 5 40 51 PM" src="https://github.com/user-attachments/assets/47930dd3-fe65-44f5-a968-59fac3581307" />
