### PR TITLE
fix: backwards compatible dpage

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -374,7 +374,8 @@ async def run_distillation_loop(
     browser_profile: BrowserProfile | None = None,
     timeout: int = 15,
     interactive: bool = True,
-) -> dict[str, str | ConversionResult | None | bool]:
+    with_terminate_flag: bool = False,
+) -> dict[str, str | ConversionResult | None | bool] | str | ConversionResult:
     if len(patterns) == 0:
         logger.error("No distillation patterns provided")
         raise ValueError("No distillation patterns provided")
@@ -418,9 +419,18 @@ async def run_distillation_loop(
                         await autoclick(page, distilled)
                     if await terminate(page, distilled):
                         converted = await convert(distilled)
-                        return {"terminated": True, "result": converted if converted else distilled}
+                        if with_terminate_flag:
+                            return {
+                                "terminated": True,
+                                "result": converted if converted else distilled,
+                            }
+                        else:
+                            return converted if converted else distilled
 
             else:
                 logger.debug(f"No matched pattern found")
 
-        return {"terminated": False, "result": current.distilled}
+        if with_terminate_flag:
+            return {"terminated": False, "result": current.distilled}
+        else:
+            return current.distilled

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -341,9 +341,14 @@ async def dpage_mcp_tool(initial_url: str, result_key: str, timeout: int = 2) ->
 
     # First, try without any interaction as this will work if the user signed in previously
     distillation_result = await run_distillation_loop(
-        initial_url, patterns, browser_profile=browser_profile, interactive=False, timeout=timeout
+        initial_url,
+        patterns,
+        browser_profile=browser_profile,
+        interactive=False,
+        timeout=timeout,
+        with_terminate_flag=True,
     )
-    if distillation_result["terminated"]:
+    if isinstance(distillation_result, dict) and distillation_result["terminated"]:
         return {result_key: distillation_result["result"]}
 
     # If that didn't work, try signing in via distillation


### PR DESCRIPTION
Unfortunately, the changes in #411 are breaking demo apps because of the extra response (e.g., `{terminate: Bool, result ...}`). This update ensures backward compatibility so that demo apps can continue working