### PR TITLE
CNN tool to grab the latest stories without sign in

### DIFF
--- a/getgather/mcp/cnn.py
+++ b/getgather/mcp/cnn.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from fastmcp import Context
+
+from getgather.mcp.dpage import dpage_mcp_tool
+from getgather.mcp.registry import GatherMCP
+
+cnn_mcp = GatherMCP(brand_id="cnn", name="CNN MCP")
+
+
+@cnn_mcp.tool
+async def get_latest_stories(ctx: Context) -> dict[str, Any]:
+    """Get the latest stories from CNN."""
+    return await dpage_mcp_tool("https://lite.cnn.com", "stories")

--- a/getgather/mcp/main.py
+++ b/getgather/mcp/main.py
@@ -92,12 +92,12 @@ CATEGORY_BUNDLES: dict[str, list[str]] = {
     "food": ["doordash", "ubereats"],
     "books": ["audible", "goodreads", "kindle", "hardcover"],
     "shopping": ["amazon", "shopee", "tokopedia"],
-    "media": [],
+    "media": ["cnn"],
 }
 
 # For MCP tools based on distillation
 MCP_BUNDLES: dict[str, list[str]] = {
-    "media": ["bbc", "espn", "groundnews", "npr", "nytimes"],
+    "media": ["bbc", "cnn", "espn", "groundnews", "npr", "nytimes"],
 }
 
 

--- a/getgather/mcp/patterns/cnn-latest-stories.html
+++ b/getgather/mcp/patterns/cnn-latest-stories.html
@@ -1,0 +1,17 @@
+<html gg-domain="cnn">
+  <head>
+    <title>CNN Latest Stories</title>
+  </head>
+  <body>
+    <div gg-stop gg-match-html="div[data-uri^=cms]"></div>
+    <script type="application/json" id="stories">
+      {
+        "rows": "section.active ul li",
+        "columns": [
+          { "name": "title", "selector": "a" },
+          { "name": "link", "selector": "a", "attribute": "href" }
+        ]
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This is using lite.cnn.com. To verify, launch as usual, connect MCP Inspector, and invoke the tool `cnn_get_latest_stories`. In a few seconds, the latest stores in JSON should be retrieved.

<img width="2560" height="1382" alt="2025-09-30 cnn stories" src="https://github.com/user-attachments/assets/35b0b365-844c-4b7b-a3d7-17fe384d060f" />
