### PR TITLE
typos: fix basic typos

### DIFF
--- a/getgather/mcp/stagehand_agent.py
+++ b/getgather/mcp/stagehand_agent.py
@@ -98,7 +98,7 @@ async def _get_user_data_dir() -> str | None:
     """Get browser profile directory for session persistence."""
     try:
         # the implementation is similar to with_brand_browser_session in shared.py
-        # howerver, it doesn't use the browser session directly, but rather uses stagehand's browser session
+        # however, it doesn't use the browser session directly, but rather uses stagehand's browser session
         brand_id = get_mcp_brand_id()
         if not brand_id:
             raise ValueError("Brand ID is not set")

--- a/getgather/mcp/tools.md
+++ b/getgather/mcp/tools.md
@@ -6,7 +6,7 @@ This list is non-exhaustive and only includes a sampling of the full set of MCP 
 
 ## Brand Specific Tools
 
-Each brand added to the unified MCP runns as its own **individual FastMCP server instance**. Each brand has its own server instance defined in the spec file under the `/mcp/brand/` directory. For example, in `goodreads.py` the Goodreads MCP is initialized as such:
+Each brand added to the unified MCP runs as its own **individual FastMCP server instance**. Each brand has its own server instance defined in the spec file under the `/mcp/brand/` directory. For example, in `goodreads.py` the Goodreads MCP is initialized as such:
 
 `goodreads_mcp = FastMCP[Any](name="Goodreads MCP")`
 


### PR DESCRIPTION
## Context

Ran `codespell`. 