### PR TITLE
Style JWM to look slightly more modern

### DIFF
--- a/.jwmrc
+++ b/.jwmrc
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+
+<JWM>
+
+   <!-- Window style -->
+   <WindowStyle>
+      <Font>Sans-10</Font>
+      <Width>2</Width>
+      <Height>24</Height>
+      <Active>
+         <Text>white</Text>
+         <Title>#2d7dff</Title>
+         <Outline>#2d7dff</Outline>
+         <Background>#0078d7</Background>
+      </Active>
+      <Inactive>
+         <Text>#aaaaaa</Text>
+         <Title>#333333</Title>
+         <Outline>#444444</Outline>
+         <Background>#222222</Background>
+      </Inactive>
+   </WindowStyle>
+
+   <!-- Menu style (Start menu look) -->
+   <MenuStyle>
+      <Font>Sans-10</Font>
+      <Foreground>white</Foreground>
+      <Background>#2b2b2b</Background>
+      <ActiveForeground>white</ActiveForeground>
+      <ActiveBackground>#0078d7</ActiveBackground> 
+      <Outline>#444444</Outline>
+   </MenuStyle>
+
+   <!-- Taskbar / Tray -->
+   <TrayStyle>
+      <Font>Sans-10</Font>
+      <Background>#1c1c1c</Background>
+      <Foreground>white</Foreground>
+   </TrayStyle>
+
+   <TaskListStyle>
+      <Font>Sans-10</Font>
+      <ActiveForeground>white</ActiveForeground>
+      <ActiveBackground>#0078d7</ActiveBackground>
+      <Foreground>#cccccc</Foreground>
+      <Background>#2b2b2b</Background>
+   </TaskListStyle>
+
+   <ClockStyle>
+      <Font>Sans-10</Font>
+      <Foreground>white</Foreground>
+      <Background>#1c1c1c</Background>
+   </ClockStyle>
+
+   <!-- Start menu -->
+   <RootMenu onroot="1" labeled="true" label="Start">
+      <Program label="Chromium">/opt/ms-playwright/chromium-1169/chrome-linux/chrome --no-sandbox</Program>
+      <Program label="Terminal">xterm</Program>
+      <Exit label="Shut Down"/>
+   </RootMenu>
+
+   <!-- Taskbar -->
+   <Tray x="0" y="-1" height="32" autohide="false">
+      <TrayButton label="   Start ">root:1</TrayButton>
+      <TaskList maxwidth="256"/>
+      <Dock/>
+      <Clock format="%H:%M"/>
+   </Tray>
+
+</JWM>

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN $VENV_PATH/bin/patchright install --with-deps chromium
 COPY getgather /app/getgather
 COPY tests /app/tests
 COPY entrypoint.sh /app/entrypoint.sh
+COPY .jwmrc /app/.jwmrc
 
 # Install the workspace package
 RUN uv sync --no-dev
@@ -89,6 +90,7 @@ RUN apt-get update && apt-get install -y \
     libvulkan1 \
     x11vnc \
     jwm \
+    xterm \
     x11-apps \
     dbus \
     dbus-x11 \
@@ -101,6 +103,7 @@ COPY --from=backend-builder /app/.venv /opt/venv
 COPY --from=backend-builder /app/getgather /app/getgather
 COPY --from=backend-builder /app/tests /app/tests
 COPY --from=backend-builder /app/entrypoint.sh /app/entrypoint.sh
+COPY --from=backend-builder /app/.jwmrc /app/.jwmrc
 COPY --from=backend-builder /opt/ms-playwright /opt/ms-playwright
 COPY --from=frontend-builder /app/getgather/frontend /app/getgather/frontend
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,11 +17,11 @@ eval $(dbus-launch --sh-syntax)
 export SESSION_MANAGER=""
 
 echo "Starting JWM (Joe's Window Manager)"
+cp /app/.jwmrc $HOME
 jwm >/dev/null 2>&1 &
 
 # So that the desktop is not completely empty
 xeyes &
-xclock &
 
 # Start FastAPI server
 /opt/venv/bin/python -m uvicorn getgather.main:app --host 0.0.0.0 --port $PORT --proxy-headers --forwarded-allow-ips="*"


### PR DESCRIPTION
Useful menu items such as Terminal and Chromium are useful to assist troubleshooting as well.

Before:

<img width="1784" height="1029" alt="2025-09-30 desktop jwm" src="https://github.com/user-attachments/assets/0ed37718-95be-44dd-ad2e-645df01ff651" />


After:

<img width="1784" height="1029" alt="2025-09-30 style jwm desktop" src="https://github.com/user-attachments/assets/4f880064-faf3-4453-88a3-12c7f04ff530" />

