### PR TITLE
add simple Bearer token auth

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -16,3 +16,5 @@ HOSTNAME=
 
 # where persisted data is stored
 DATA_DIR=
+
+AUTH_BEARER_TOKEN=

--- a/getgather/config.py
+++ b/getgather/config.py
@@ -45,6 +45,8 @@ class Settings(BaseSettings):
 
     HOSTNAME: str = ""
 
+    AUTH_BEARER_TOKEN: str = ""
+
     @property
     def brand_spec_dir(self) -> Path:
         return PROJECT_DIR / "getgather" / "connectors" / "brand_specs"

--- a/getgather/main.py
+++ b/getgather/main.py
@@ -15,6 +15,7 @@ from fastapi.responses import (
     Response,
 )
 from fastapi.routing import APIRoute
+from fastapi.security import HTTPBearer
 from fastapi.staticfiles import StaticFiles
 
 from getgather.api.api import api_app
@@ -217,3 +218,32 @@ async def mcp_slash_redirect_middleware(
 def frontend_router(full_path: str):
     logger.info(f"Routing {full_path} to frontend")
     return FileResponse(FRONTEND_DIR / "index.html")
+
+
+bearer = HTTPBearer(auto_error=False)
+AUTH_SKIP_PATHS = {
+    "/health",
+    "/extended-health",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+    "/live",
+    "/websockify",
+    "/__static",
+}
+
+
+@app.middleware("http")
+async def bearer_token_auth_middleware(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+):
+    if not settings.AUTH_BEARER_TOKEN or any(
+        request.url.path.startswith(path) for path in AUTH_SKIP_PATHS
+    ):
+        return await call_next(request)
+
+    auth = await bearer(request)
+    if not auth or auth.credentials != settings.AUTH_BEARER_TOKEN:
+        return Response(status_code=401, content="Authorization header missing or invalid")
+
+    return await call_next(request)

--- a/getgather/main.py
+++ b/getgather/main.py
@@ -221,16 +221,7 @@ def frontend_router(full_path: str):
 
 
 bearer = HTTPBearer(auto_error=False)
-AUTH_SKIP_PATHS = {
-    "/health",
-    "/extended-health",
-    "/docs",
-    "/redoc",
-    "/openapi.json",
-    "/live",
-    "/websockify",
-    "/__static",
-}
+AUTH_SKIP_PATHS = {"/health", "/extended-health", "/docs", "/redoc", "/openapi.json", "/__static"}
 
 
 @app.middleware("http")


### PR DESCRIPTION
for users who want to add minimal security to their servers they can add a `AUTH_BEARER_TOKEN`

tested with `curl -H 'Authorization: Bearer AUTH_BEARER_TOKEN' localhost:23456/mcp`

