### PR TITLE
Take into account the hostname when creating a distilled page

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -8,12 +8,14 @@ from typing import Any
 from bs4 import BeautifulSoup, Tag
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
+from fastmcp import settings
 from fastmcp.server.dependencies import get_http_headers
 from nanoid import generate
 from patchright.async_api import Page, Route
 
 from getgather.browser.profile import BrowserProfile
 from getgather.browser.session import BrowserSession
+from getgather.config import settings
 from getgather.distill import (
     Match,
     autoclick,
@@ -51,6 +53,8 @@ async def dpage_add(
     if id is None:
         FRIENDLY_CHARS: str = "23456789abcdefghijkmnpqrstuvwxyz"
         id = generate(FRIENDLY_CHARS, 8)
+        if settings.HOSTNAME:
+            id = f"{settings.HOSTNAME}-{id}"
 
     if browser_profile is None:
         browser_profile = BrowserProfile()

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -8,7 +8,6 @@ from typing import Any
 from bs4 import BeautifulSoup, Tag
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
-from fastmcp import settings
 from fastmcp.server.dependencies import get_http_headers
 from nanoid import generate
 from patchright.async_api import Page, Route


### PR DESCRIPTION
This is necessary so that the MCP Gateway can route the tool call to the right instance of MCP server, similar to the way it's done for hosted links.

To verify, run by setting the hostname, e.g.:

```
HOSTNAME=foobar npm run dev
```

and then connect MCP Inspector, invoke a tool that requires distillation, e.g. `bbc_get_saved_articles`. The result is the request to continue with the sign in at a special distilled page, which has `foobar` as the prefix.

<img width="1920" height="1655" alt="2025-10-01 hostname dpage" src="https://github.com/user-attachments/assets/7250834d-910a-4563-a485-398d8fa21a65" />
