### PR TITLE
News MCP tools should also supply the absolute URL for each story

### DIFF
--- a/getgather/mcp/cnn.py
+++ b/getgather/mcp/cnn.py
@@ -1,4 +1,5 @@
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 from fastmcp import Context
 
@@ -11,4 +12,20 @@ cnn_mcp = GatherMCP(brand_id="cnn", name="CNN MCP")
 @cnn_mcp.tool
 async def get_latest_stories(ctx: Context) -> dict[str, Any]:
     """Get the latest stories from CNN."""
-    return await dpage_mcp_tool("https://lite.cnn.com", "stories")
+    result = await dpage_mcp_tool("https://lite.cnn.com", "stories")
+    if "stories" in result:
+        for story in result["stories"]:
+            link: str = story["link"]
+            parsed = urlparse(link)
+            netloc: str = parsed.netloc if parsed.netloc else "cnn.com"
+            url: str = urlunparse((
+                "https",
+                netloc,
+                parsed.path,
+                parsed.params,
+                parsed.query,
+                parsed.fragment,
+            ))
+            story["url"] = url
+
+    return result

--- a/getgather/mcp/groundnews.py
+++ b/getgather/mcp/groundnews.py
@@ -1,4 +1,5 @@
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 from fastmcp import Context
 
@@ -11,4 +12,20 @@ groundnews_mcp = GatherMCP(brand_id="groundnews", name="Ground News MCP")
 @groundnews_mcp.tool
 async def get_stories(ctx: Context) -> dict[str, Any]:
     """Get the latest news stories from Ground News."""
-    return await dpage_mcp_tool("https://ground.news", "stories", timeout=10)
+    result = await dpage_mcp_tool("https://ground.news", "stories", timeout=10)
+    if "stories" in result:
+        for story in result["stories"]:
+            link: str = story["link"]
+            parsed = urlparse(link)
+            netloc: str = parsed.netloc if parsed.netloc else "ground.news"
+            url: str = urlunparse((
+                "https",
+                netloc,
+                parsed.path,
+                parsed.params,
+                parsed.query,
+                parsed.fragment,
+            ))
+            story["url"] = url
+
+    return result

--- a/getgather/mcp/npr.py
+++ b/getgather/mcp/npr.py
@@ -1,4 +1,5 @@
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 from fastmcp import Context
 
@@ -11,4 +12,21 @@ npr_mcp = GatherMCP(brand_id="npr", name="NPR MCP")
 @npr_mcp.tool
 async def get_headlines(ctx: Context) -> dict[str, Any]:
     """Get the current news headlines from NPR."""
-    return await dpage_mcp_tool("https://text.npr.org", "headlines")
+
+    result = await dpage_mcp_tool("https://text.npr.org", "headlines")
+    if "headlines" in result:
+        for headline in result["headlines"]:
+            link: str = headline["link"]
+            parsed = urlparse(link)
+            netloc: str = parsed.netloc if parsed.netloc else "npr.org"
+            url: str = urlunparse((
+                "https",
+                netloc,
+                parsed.path,
+                parsed.params,
+                parsed.query,
+                parsed.fragment,
+            ))
+            headline["url"] = url
+
+    return result


### PR DESCRIPTION
This way, the caller (e.g. an MCP client) does not need to deduce the actual usable URL for the said story.

To verify, run `npm run dev` as usual, connect MCP Inspector, and invoke the tool related to news (NPR, Ground News, or CNN). Check that the result should contain an absolute URL, in addition to the relative link.

<img width="2560" height="1384" alt="2025-04-10 news mcp tool absolute url" src="https://github.com/user-attachments/assets/a44e8a1e-f201-40cc-b1cd-c9e0099e162c" />
