### PR TITLE
Prioritize checking for termination in the distillation loop

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -417,15 +417,10 @@ async def run_distillation_loop(
                     logger.debug(f"Still the same: {match.name}")
                 else:
                     distilled = match.distilled
-                    if interactive:
-                        distilled = await autofill(page, distilled)
-
                     current = match
-                    current.distilled = distilled
                     print()
                     print(distilled)
-                    if interactive:
-                        await autoclick(page, distilled)
+
                     if await terminate(page, distilled):
                         converted = await convert(distilled)
                         if with_terminate_flag:
@@ -435,6 +430,11 @@ async def run_distillation_loop(
                             }
                         else:
                             return converted if converted else distilled
+
+                    if interactive:
+                        distilled = await autofill(page, distilled)
+                        await autoclick(page, distilled)
+                        current.distilled = distilled
 
             else:
                 logger.debug(f"No matched pattern found")


### PR DESCRIPTION
This is to prepare for the separation of autoclick and form submission.

See https://github.com/mcp-getgather/middleman/pull/40.

To verify, run the distillation manually on the CLI, e.g.:

```bash
./getgather.py run goodreads.com/review
```

Alternatively, launch the MCP server as usual, connect MCP Inspector, try an MCP tool such as `bbc_get_saved_articles`, and follow the sign-in steps as instructed.