### PR TITLE
make blocking the default

### DIFF
--- a/getgather/config.py
+++ b/getgather/config.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
 
     # Browser Package Settings
     HEADLESS: bool = False
-    SHOULD_BLOCK_UNWANTED_RESOURCES: bool = False
+    SHOULD_BLOCK_UNWANTED_RESOURCES: bool = True
 
     # Browser-use settings
     BROWSER_USE_MODEL: str = "o4-mini"


### PR DESCRIPTION
As an example of how hard env variable management is, I don't think we ever blocked images in production...


I'll have a followup pr that does the blocking at the sesion level 