### PR TITLE
Container image: download additional resources blocklists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -506,3 +506,7 @@ frontend/__generated__/
 !frontend/src/lib
 
 .claude/
+
+# Additional blocklists
+blocklists-*.txt
+!blocklists-basic.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,12 @@ RUN uv sync --no-dev
 # Generate OpenAPI schema
 RUN $VENV_PATH/bin/python -m getgather.generate_openapi -o /tmp/openapi.json
 
+# Grab additional blocklists
+RUN curl -o /app/blocklists-analytics.txt https://raw.githubusercontent.com/hectorm/hmirror/master/data/mozilla-shavar-analytics/list.txt
+RUN curl -o /app/blocklists-ads.txt https://raw.githubusercontent.com/hectorm/hmirror/master/data/mozilla-shavar-advertising/list.txt
+RUN curl -o /app/blocklists-privacy.txt https://raw.githubusercontent.com/hectorm/hmirror/master/data/easyprivacy/list.txt
+RUN curl -o /app/blocklists-adguard.txt https://raw.githubusercontent.com/hectorm/hmirror/master/data/adguard-simplified/list.txt
+
 # Stage 2: Frontend Builder
 FROM mirror.gcr.io/library/node:22-alpine AS frontend-builder
 
@@ -105,6 +111,7 @@ COPY --from=backend-builder /app/tests /app/tests
 COPY --from=backend-builder /app/entrypoint.sh /app/entrypoint.sh
 COPY --from=backend-builder /app/.jwmrc /app/.jwmrc
 COPY --from=backend-builder /opt/ms-playwright /opt/ms-playwright
+COPY --from=backend-builder /app/blocklists-*.txt /app/
 COPY --from=frontend-builder /app/getgather/frontend /app/getgather/frontend
 
 ENV PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
This is a follow-up to PR #516. For production container image, some additional blocklists are downloaded and bundled in the container image.

To verify, build the container image and launch the container. Test the usual MCP tools and they should still work as expected.

For a quick check without building the container image, do the download manually (see the diff on the Dockerfile) with curl, placing those files as blocklists-*.txt. Launch with `npm run dev` and then hit `http://127.0.0.1:23456/extended-health`.

The log should shows something like:

```
INFO     Loading blocklists...
INFO     Blocklists loaded: 156211 total domains
```

The number of total domains has to be very large (in the thousands), otherwise only blocklists-basic.txt was loaded correctly.