### PR TITLE
fix: add product url to amazon orders pattern

### DIFF
--- a/getgather/mcp/patterns/amazon-orders.html
+++ b/getgather/mcp/patterns/amazon-orders.html
@@ -35,6 +35,12 @@
             "kind": "list"
           },
           {
+            "name": "product_urls",
+            "selector": "div.yohtmlc-product-title a",
+            "attribute": "href",
+            "kind": "list"
+          },
+          {
             "name": "return_window_dates",
             "selector": "span[class='a-size-small']",
             "kind": "list"


### PR DESCRIPTION
<img width="410" height="843" alt="Cursor 2025-10-15 14 29 38" src="https://github.com/user-attachments/assets/e501c3dd-fd95-4ba5-b2fb-9916937f7635" />
