### PR TITLE
fix: improve year parameter type handling in amazon mcp

### DIFF
--- a/getgather/mcp/brand/amazon.py
+++ b/getgather/mcp/brand/amazon.py
@@ -19,13 +19,26 @@ amazon_mcp = BrandMCPBase(brand_id="amazon", name="Amazon MCP")
 
 
 @amazon_mcp.tool(tags={"private"})
-async def get_purchase_history(year: int | None = None) -> dict[str, Any]:
+async def get_purchase_history(year: str | int | None = None) -> dict[str, Any]:
     """Get purchase/order history of a amazon."""
+
+    if year is None:
+        target_year = datetime.now().year
+    elif isinstance(year, str):
+        try:
+            target_year = int(year)
+        except ValueError:
+            target_year = datetime.now().year
+    else:
+        target_year = int(year)
+
+    current_year = datetime.now().year
+    if not (1900 <= target_year <= current_year + 1):
+        raise ValueError(f"Year {target_year} is out of valid range (1900-{current_year + 1})")
 
     browser_profile = get_mcp_browser_profile()
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
-    target_year = year if year is not None else datetime.now().year
     purchases = await run_distillation_loop(
         f"https://www.amazon.com/your-orders/orders?timeFilter=year-{target_year}",
         patterns,


### PR DESCRIPTION
This is improvement from #435 

Improves the type handling and validation for the year parameter in Amazon MCP's get_purchase_history function, because LLM (e.g. Cursor Agent) always sending year parameter as string to the MPC tool.

<img width="410" height="843" alt="Cursor 2025-10-15 15 14 48" src="https://github.com/user-attachments/assets/9daaa5da-9d27-423e-ad46-7d04c3a4e86e" />

