### PR TITLE
refactor: move rrweb recording to browser session lifecycle

### DIFF
--- a/getgather/mcp/activity.py
+++ b/getgather/mcp/activity.py
@@ -5,7 +5,6 @@ from typing import AsyncGenerator
 
 from pydantic import BaseModel, Field, computed_field
 
-from getgather import rrweb
 from getgather.mcp.persist import PersistentStore
 
 
@@ -50,6 +49,5 @@ async def activity(name: str, brand_id: str = "") -> AsyncGenerator[str, None]:
     try:
         yield activity.id
     finally:
-        await rrweb.rrweb_manager.save_recording(activity.id)
         activity.end_time = datetime.now(UTC)
         activity_manager.update(activity)


### PR DESCRIPTION
## Summary

Move rrweb recording storage from activity context manager to browser session lifecycle.

Previously, rrweb events were stored when the activity context manager ended. This didn't work for distillation flows that don't run inside an activity context.

Since rrweb recording starts when the browser session starts (via `setup_rrweb` on page load), it's more appropriate to save recordings when the session stops. This ensures recordings are always saved regardless of whether an activity context exists.

## Benefits

- Recording lifecycle matches browser session lifecycle (start recording → stop recording)
- Works for both activity-based flows and distillation flows
- No dependency on activity context for recording storage
- Each session gets unique identifier for its recording

## Tests
<img width="1065" height="640" alt="Untitled" src="https://github.com/user-attachments/assets/575171e6-4e0f-4025-be11-f60d4b34e3eb" />
