### PR TITLE
skip dpage result check when using incognito

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -313,17 +313,18 @@ async def dpage_mcp_tool(initial_url: str, result_key: str, timeout: int = 2) ->
 
         browser_profile = global_browser_profile
 
-    # First, try without any interaction as this will work if the user signed in previously
-    distillation_result = await run_distillation_loop(
-        initial_url,
-        patterns,
-        browser_profile=browser_profile,
-        interactive=False,
-        timeout=timeout,
-        with_terminate_flag=True,
-    )
-    if isinstance(distillation_result, dict) and distillation_result["terminated"]:
-        return {result_key: distillation_result["result"]}
+    if not incognito:
+        # First, try without any interaction as this will work if the user signed in previously
+        distillation_result = await run_distillation_loop(
+            initial_url,
+            patterns,
+            browser_profile=browser_profile,
+            interactive=False,
+            timeout=timeout,
+            with_terminate_flag=True,
+        )
+        if isinstance(distillation_result, dict) and distillation_result["terminated"]:
+            return {result_key: distillation_result["result"]}
 
     # If that didn't work, try signing in via distillation
     id = await dpage_add(browser_profile=browser_profile, location=initial_url)


### PR DESCRIPTION
skip signin check when use `x-incognito`, since we already know that using `x-incognito` will always launch fresh borwser profile.