### PR TITLE
Use a tuple to indicate termination in the distillation loop

### DIFF
--- a/getgather.py
+++ b/getgather.py
@@ -63,7 +63,7 @@ async def run_command(location: str):
     if not location.startswith("http"):
         location = f"https://{location}"
 
-    result = await run_distillation_loop(location, patterns=patterns)
+    result, _ = await run_distillation_loop(location, patterns=patterns)
     print(result)
 
     logger.info("Terminated.")

--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -379,8 +379,7 @@ async def run_distillation_loop(
     browser_profile: BrowserProfile | None = None,
     timeout: int = 15,
     interactive: bool = True,
-    with_terminate_flag: bool = False,
-) -> dict[str, str | ConversionResult | None | bool] | str | ConversionResult:
+) -> tuple[dict[str, str | ConversionResult | None] | str | ConversionResult, bool]:
     if len(patterns) == 0:
         logger.error("No distillation patterns provided")
         raise ValueError("No distillation patterns provided")
@@ -419,13 +418,7 @@ async def run_distillation_loop(
 
                     if await terminate(page, distilled):
                         converted = await convert(distilled)
-                        if with_terminate_flag:
-                            return {
-                                "terminated": True,
-                                "result": converted if converted else distilled,
-                            }
-                        else:
-                            return converted if converted else distilled
+                        return (converted if converted else distilled, True)
 
                     if interactive:
                         distilled = await autofill(page, distilled)
@@ -438,7 +431,4 @@ async def run_distillation_loop(
             else:
                 logger.debug(f"No matched pattern found")
 
-        if with_terminate_flag:
-            return {"terminated": False, "result": current.distilled}
-        else:
-            return current.distilled
+        return (current.distilled, False)

--- a/getgather/mcp/brand/aliexpress.py
+++ b/getgather/mcp/brand/aliexpress.py
@@ -14,7 +14,7 @@ async def get_orders() -> dict[str, Any]:
     browser_profile = get_mcp_browser_profile()
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
-    orders = await run_distillation_loop(
+    orders, _ = await run_distillation_loop(
         "https://www.aliexpress.com/p/order/index.html", patterns, browser_profile=browser_profile
     )
     return {"orders": orders}

--- a/getgather/mcp/brand/amain.py
+++ b/getgather/mcp/brand/amain.py
@@ -14,7 +14,7 @@ async def get_cart() -> dict[str, Any]:
     browser_profile = get_mcp_browser_profile()
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
-    cart = await run_distillation_loop(
+    cart, _ = await run_distillation_loop(
         "https://www.amainhobbies.com/shopping-cart",
         patterns,
         browser_profile=browser_profile,

--- a/getgather/mcp/brand/amazon.py
+++ b/getgather/mcp/brand/amazon.py
@@ -39,7 +39,7 @@ async def get_purchase_history(year: str | int | None = None) -> dict[str, Any]:
     browser_profile = get_mcp_browser_profile()
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
-    purchases = await run_distillation_loop(
+    purchases, _ = await run_distillation_loop(
         f"https://www.amazon.com/your-orders/orders?timeFilter=year-{target_year}",
         patterns,
         browser_profile=browser_profile,

--- a/getgather/mcp/brand/amazonca.py
+++ b/getgather/mcp/brand/amazonca.py
@@ -26,7 +26,7 @@ async def get_purchase_history() -> dict[str, Any]:
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
     current_year = datetime.now().year
-    purchases = await run_distillation_loop(
+    purchases, _ = await run_distillation_loop(
         f"https://www.amazon.ca/your-orders/orders?timeFilter=year-{current_year}",
         patterns,
         browser_profile=browser_profile,

--- a/getgather/mcp/brand/astro.py
+++ b/getgather/mcp/brand/astro.py
@@ -171,7 +171,7 @@ async def get_purchase_history() -> dict[str, Any]:
     browser_profile = get_mcp_browser_profile()
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
-    extract_result = await run_distillation_loop(
+    extract_result, _ = await run_distillation_loop(
         "https://www.astronauts.id/order/history",
         patterns,
         browser_profile=browser_profile,

--- a/getgather/mcp/brand/doordash.py
+++ b/getgather/mcp/brand/doordash.py
@@ -17,7 +17,7 @@ async def get_orders() -> dict[str, Any]:
     browser_profile = get_mcp_browser_profile()
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
-    orders = await run_distillation_loop(
+    orders, _ = await run_distillation_loop(
         "https://www.doordash.com/orders", patterns, browser_profile=browser_profile
     )
     return {"orders": orders}

--- a/getgather/mcp/brand/expedia.py
+++ b/getgather/mcp/brand/expedia.py
@@ -14,7 +14,7 @@ async def get_past_trips() -> dict[str, Any]:
     browser_profile = get_mcp_browser_profile()
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
-    past_trips = await run_distillation_loop(
+    past_trips, _ = await run_distillation_loop(
         "https://www.expedia.com/trips/list/3 ", patterns, browser_profile=browser_profile
     )
     return {"past_trips": past_trips}

--- a/getgather/mcp/brand/goodreads.py
+++ b/getgather/mcp/brand/goodreads.py
@@ -21,7 +21,7 @@ async def get_book_list() -> dict[str, Any]:
     browser_profile = get_mcp_browser_profile()
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
-    books = await run_distillation_loop(
+    books, _ = await run_distillation_loop(
         "https://www.goodreads.com/review/list?ref=nav_mybooks&view=table",
         patterns,
         browser_profile=browser_profile,

--- a/getgather/mcp/brand/hilton.py
+++ b/getgather/mcp/brand/hilton.py
@@ -14,7 +14,7 @@ async def get_activities() -> dict[str, Any]:
     browser_profile = get_mcp_browser_profile()
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
-    activities = await run_distillation_loop(
+    activities, _ = await run_distillation_loop(
         "https://www.hilton.com/en/hilton-honors/guest/activity/",
         patterns,
         browser_profile=browser_profile,

--- a/getgather/mcp/brand/officedepot.py
+++ b/getgather/mcp/brand/officedepot.py
@@ -15,7 +15,7 @@ async def get_order_history() -> dict[str, Any]:
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
 
-    purchase_history = await run_distillation_loop(
+    purchase_history, _ = await run_distillation_loop(
         # `https://www.officedepot.com/orderhistory/orderHistoryListSet.do` only shows the last 3 months of orders
         "https://www.officedepot.com/orderhistory/orderHistoryListSet.do?ordersInMonths=0&orderType=ALL&orderStatus=A",
         patterns,
@@ -32,7 +32,7 @@ async def get_order_history_details(order_number: str) -> dict[str, Any]:
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
 
-    purchase_history_details = await run_distillation_loop(
+    purchase_history_details, _ = await run_distillation_loop(
         f"https://www.officedepot.com/orderhistory/orderHistoryDetail.do?id={order_number}",
         patterns,
         browser_profile=browser_profile,

--- a/getgather/mcp/brand/revolve.py
+++ b/getgather/mcp/brand/revolve.py
@@ -14,7 +14,7 @@ async def get_orders() -> dict[str, Any]:
     browser_profile = get_mcp_browser_profile()
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
-    orders = await run_distillation_loop(
+    orders, _ = await run_distillation_loop(
         "https://www.revolve.com/r/MyOrderHistory.jsp", patterns, browser_profile=browser_profile
     )
     return {"orders": orders}

--- a/getgather/mcp/brand/shopee.py
+++ b/getgather/mcp/brand/shopee.py
@@ -21,7 +21,7 @@ async def get_purchase_history() -> dict[str, Any]:
     browser_profile = get_mcp_browser_profile()
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
-    purchase_history = await run_distillation_loop(
+    purchase_history, _ = await run_distillation_loop(
         "https://shopee.co.id/user/purchase", patterns, browser_profile=browser_profile
     )
     return {"purchase_history": purchase_history}

--- a/getgather/mcp/brand/ubereats.py
+++ b/getgather/mcp/brand/ubereats.py
@@ -14,7 +14,7 @@ async def get_orders() -> dict[str, Any]:
     browser_profile = get_mcp_browser_profile()
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
-    orders = await run_distillation_loop(
+    orders, _ = await run_distillation_loop(
         "https://www.ubereats.com/orders",
         patterns,
         browser_profile=browser_profile,

--- a/getgather/mcp/brand/wayfair.py
+++ b/getgather/mcp/brand/wayfair.py
@@ -14,7 +14,7 @@ async def get_order_history() -> dict[str, Any]:
     browser_profile = get_mcp_browser_profile()
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
-    purchase_history = await run_distillation_loop(
+    purchase_history, _ = await run_distillation_loop(
         "https://www.wayfair.com/session/secure/account/order_search.php",
         patterns,
         browser_profile=browser_profile,
@@ -38,7 +38,7 @@ async def get_order_history_details(order_id: str) -> dict[str, Any]:
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
 
-    purchase_history_details = await run_distillation_loop(
+    purchase_history_details, _ = await run_distillation_loop(
         f"https://www.wayfair.com/v/account/order/details?order_id={order_id}",
         patterns,
         browser_profile=browser_profile,

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -313,16 +313,15 @@ async def dpage_mcp_tool(initial_url: str, result_key: str, timeout: int = 2) ->
         browser_profile = global_browser_profile
 
         # First, try without any interaction as this will work if the user signed in previously
-        distillation_result = await run_distillation_loop(
+        distillation_result, terminated = await run_distillation_loop(
             initial_url,
             patterns,
             browser_profile=browser_profile,
             interactive=False,
             timeout=timeout,
-            with_terminate_flag=True,
         )
-        if isinstance(distillation_result, dict) and distillation_result["terminated"]:
-            return {result_key: distillation_result["result"]}
+        if terminated:
+            return {result_key: distillation_result}
 
     # If that didn't work, try signing in via distillation
     id = await dpage_add(browser_profile=browser_profile, location=initial_url)

--- a/tests/distillation/test_distill.py
+++ b/tests/distillation/test_distill.py
@@ -65,7 +65,7 @@ async def test_distillation_loop(location: str):
     patterns = load_distillation_patterns(path)
     assert patterns, "No patterns found to begin matching."
 
-    result = await run_distillation_loop(
+    result, _ = await run_distillation_loop(
         location=location,
         patterns=patterns,
         browser_profile=profile,


### PR DESCRIPTION
Rather than using the terminate flag (see PR #422), this adds the use of idiomatic tuple to always supply the terminated flag (up to the caller to use it or not).

I apologize for breaking pending/upcoming PRs for distillation migration.