### PR TITLE
close dpage browser after terminate

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -65,7 +65,7 @@ async def dpage_add(
 
 async def dpage_close(id: str) -> None:
     if id in active_pages:
-        # await active_pages[id].close()
+        await active_pages[id].close()
         del active_pages[id]
 
 


### PR DESCRIPTION
Because we never close the browser after the dpage reaches the `terminate` state, there are a lot of "zombie" browsers running on our machine.

<img width="1511" height="844" alt="image" src="https://github.com/user-attachments/assets/df56df67-13e4-40bc-91de-96c72380fd1a" />
