### PR TITLE
Experiment with short-lived MCP tool

### DIFF
--- a/getgather/mcp/npr.py
+++ b/getgather/mcp/npr.py
@@ -1,9 +1,12 @@
-from typing import Any
+import os
+from typing import Any, cast
 from urllib.parse import urlparse, urlunparse
 
 from fastmcp import Context
 
-from getgather.mcp.dpage import dpage_mcp_tool
+from getgather.browser.profile import BrowserProfile
+from getgather.browser.session import BrowserSession
+from getgather.distill import load_distillation_patterns, run_distillation_loop
 from getgather.mcp.registry import GatherMCP
 
 npr_mcp = GatherMCP(brand_id="npr", name="NPR MCP")
@@ -13,19 +16,38 @@ npr_mcp = GatherMCP(brand_id="npr", name="NPR MCP")
 async def get_headlines(ctx: Context) -> dict[str, Any]:
     """Get the current news headlines from NPR."""
 
-    result = await dpage_mcp_tool("https://text.npr.org", "headlines")
-    if "headlines" in result:
-        for headline in result["headlines"]:
-            link: str = headline["link"]
-            parsed = urlparse(link)
-            netloc: str = parsed.netloc if parsed.netloc else "npr.org"
-            url: str = urlunparse((
-                "https",
-                netloc,
-                parsed.path,
-                parsed.params,
-                parsed.query,
-                parsed.fragment,
-            ))
-            headline["url"] = url
-    return result
+    location = "https://text.npr.org"
+    path = os.path.join(os.path.dirname(__file__), "patterns", "**/npr-*.html")
+    patterns = load_distillation_patterns(path)
+
+    browser_profile = BrowserProfile()
+    session = BrowserSession.get(browser_profile)
+    session = await session.start()
+    distilled, terminated = await run_distillation_loop(
+        location, patterns, browser_profile, interactive=False
+    )
+    await session.context.close()
+
+    if terminated:
+        result_key = "headlines"
+        result: dict[str, Any] = {result_key: distilled}
+        if "headlines" in result:
+            headlines_value = result["headlines"]
+            if isinstance(headlines_value, list):
+                for headline in cast(list[dict[str, Any]], headlines_value):
+                    if "link" in headline:
+                        link = cast(str, headline["link"])
+                        parsed = urlparse(link)
+                        netloc: str = parsed.netloc if parsed.netloc else "npr.org"
+                        url: str = urlunparse((
+                            "https",
+                            netloc,
+                            parsed.path,
+                            parsed.params,
+                            parsed.query,
+                            parsed.fragment,
+                        ))
+                        headline["url"] = url
+        return result
+
+    raise ValueError("Failed to retrieve NPR headlines")


### PR DESCRIPTION
While eventually this will be a wrapper so that other tools can use it, right now it's to check whether NPR headline tool can use the concept.

After the tool finishes, the entire ephemeral browser session for the tool will be disposed completely. Thus there won't any more "dormant" Chromium processes.

To verify, build the container image and run it. Open the live view, click on the Start menu, open terminal, and run `top`. Use MCP Inspector to connect to /mcp-media and call the NPR headline tool

Before this PR, after the tool completes the extraction of NPR headlines, the browser session is still alive, witnessed by the remaining Chromium window and top.

<img width="1614" height="1148" alt="2025-10-19 dormant chromium" src="https://github.com/user-attachments/assets/f75b20e1-28f5-4abe-ab97-6bd4bc2581f6" />


After this PR, the cleanup is performed. No more Chromium process, as also evidenced by looking at top.

<img width="1614" height="1148" alt="2025-10-19 short lived mcp tool" src="https://github.com/user-attachments/assets/6dbc6fa3-e3c5-4f28-bd02-cd9f3e7ad51d" />
