### PR TITLE
Make sure all CI jobs have a reasonable timeout

### DIFF
--- a/.github/workflows/api-signin-tests.yml
+++ b/.github/workflows/api-signin-tests.yml
@@ -10,7 +10,7 @@ jobs:
   api-signin-tests:
     name: API Signin Tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/mcp-tests.yml
+++ b/.github/workflows/mcp-tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   mcp-pytest:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   backend-format:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,6 +24,7 @@ jobs:
 
   frontend-lint:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -35,6 +37,7 @@ jobs:
 
   frontend-format:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -47,6 +50,7 @@ jobs:
 
   backend-types:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -59,6 +63,7 @@ jobs:
 
   yaml-format:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   pytest:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Some jobs ran for hours, leading to zombies. With this explicit timeout, it shall never happen again.