### PR TITLE
Close the page after distillation is completed

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -546,6 +546,7 @@ async def run_distillation_loop(
 
                     if await terminate(page, distilled):
                         converted = await convert(distilled)
+                        await page.close()
                         return (converted if converted else distilled, True)
 
                     if interactive:
@@ -568,4 +569,5 @@ async def run_distillation_loop(
                     iteration=iteration,
                 )
 
+        await page.close()
         return (current.distilled, False)


### PR DESCRIPTION
Now that the page is always a fresh new one, the tool needs to close it explicitly after the distillation process.

To test, run the MCP server and connect MCP Inspector. Check with BBC tool (which is 100% distillation-based) and also Goodreads (sign-in with orchestraton, then handed off to distillation-based extraction). In both cases, the page which has the information (saved article for BBC, bookshelf list for Goodreads, etc) should not stay in the browser window forever, as it gets closed right after extraction.