### PR TITLE
Short-circuit pattern matching during distillation

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -423,6 +423,9 @@ async def distill(hostname: str | None, page: Page, patterns: list[Pattern]) -> 
             if not isinstance(target, Tag):
                 continue
 
+            if not found:
+                break
+
             html = target.get("gg-match-html")
             selector, frame_selector = get_selector(str(html if html else target.get("gg-match")))
 


### PR DESCRIPTION
If a page fails to match a non-optional element in the pattern, then there's no point of checking other element(s) in the pattern.

This should speed-up the pattern matching process.