### PR TITLE
Use an alternative service to check the public IP address

### DIFF
--- a/getgather/browser/session.py
+++ b/getgather/browser/session.py
@@ -93,7 +93,7 @@ class BrowserSession:
                 await configure_context(self._context)
 
                 debug_page = await self.page()
-                await debug_page.goto("https://ifconfig.me")
+                await debug_page.goto("https://checkip.amazonaws.com")
 
                 # Intentionally create a new page to apply resources filtering (from blocklists)
                 page = await self.new_page()


### PR DESCRIPTION
Let's try to shave off 1-2 seconds to perform the sanity check of the connection (particulary on a slow connection). We lost some details which ifconfig offers (e.g. User Agent string, etc) but IMO it's an acceptable trade-off.