### PR TITLE
Reduce the frequency of early error in the distillation loop

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -561,14 +561,14 @@ async def run_distillation_loop(
 
             else:
                 logger.debug(f"No matched pattern found")
-                await report_distill_error(
-                    error=ValueError("No matched pattern found"),
-                    page=page,
-                    profile_id=profile.id,
-                    location=location,
-                    hostname=hostname,
-                    iteration=iteration,
-                )
 
+        await report_distill_error(
+            error=ValueError("No matched pattern found"),
+            page=page,
+            profile_id=profile.id,
+            location=location,
+            hostname=hostname,
+            iteration=max,
+        )
         await page.close()
         return (current.distilled, False)


### PR DESCRIPTION
This is a follow-up to #504.

If there is no found/matched pattern during the distillation process, it does not automatically mean an error. Most likely the actual web page itself is still doing some processing (e.g. digesting the password etc). Only after several failed attempts and the loop terminates, the error should be reported.

Before this PR, there would be superfluous logs like this (and screenshots sent to Sentry):

```
 INFO     Iteration 4 of 15
 ERROR    Distillation error

              profile_id: 8xggnp
              location: https://www.amazon.com/your-orders/orders?timeFilter=year-2024&startIndex=0
              iteration: 3
              screenshot:
file:///home/a/opensource/gather/mcp-getgather/data/screenshots/8xggnp_distill_error_2025102
0_090154_7V7oR.png

 INFO
 INFO     Iteration 5 of 15
 ERROR    Distillation error

              profile_id: 8xggnp
              location: https://www.amazon.com/your-orders/orders?timeFilter=year-2024&startIndex=0
              iteration: 4
              screenshot:
file:///home/a/opensource/gather/mcp-getgather/data/screenshots/8xggnp_distill_error_2025102
0_090156_23nO2.png

 INFO
 INFO     Iteration 6 of 15
 ERROR    Distillation error

              profile_id: 8xggnp
              location: https://www.amazon.com/your-orders/orders?timeFilter=year-2024&startIndex=0
              iteration: 5
              screenshot:
file:///home/a/opensource/gather/mcp-getgather/data/screenshots/8xggnp_distill_error_2025102
0_090158_T-EDU.png

 INFO
 INFO     Iteration 7 of 15
 ERROR    Distillation error

              profile_id: 8xggnp
              location: https://www.amazon.com/your-orders/orders?timeFilter=year-2024&startIndex=0
              iteration: 6
              screenshot:
file:///home/a/opensource/gather/mcp-getgather/data/screenshots/8xggnp_distill_error_2025102
0_090200_3Oi1J.png
```