### PR TITLE
In the distillation process, the list of matches is actually not used

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -163,7 +163,7 @@ async def post_dpage(id: str, request: Request) -> HTMLResponse:
     TIMEOUT = 15  # seconds
     max = TIMEOUT // TICK
 
-    current = Match(name="", priority=-1, distilled="", matches=[])
+    current = Match(name="", priority=-1, distilled="")
 
     if logger.isEnabledFor(logging.DEBUG):
         await capture_page_artifacts(page, identifier=id, prefix="dpage_debug")


### PR DESCRIPTION
Therefore, remove it completely. To have an additional tracking of found matches, just use a simple counter.