### PR TITLE
Reuseable short-lived MCP tool

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from glob import glob
 from pathlib import Path
 from typing import Any, cast
+from urllib.parse import urlparse, urlunparse
 
 import pwinput
 import sentry_sdk
@@ -18,7 +19,7 @@ from patchright.async_api import Locator, Page
 from pydantic import BaseModel
 
 from getgather.browser.profile import BrowserProfile
-from getgather.browser.session import browser_session
+from getgather.browser.session import BrowserSession, browser_session
 from getgather.config import settings
 from getgather.logs import logger
 
@@ -575,3 +576,41 @@ async def run_distillation_loop(
 
         await page.close()
         return (current.distilled, False)
+
+
+async def short_lived_mcp_tool(
+    location: str,
+    pattern_wildcard: str,
+    result_key: str,
+    url_hostname: str,
+) -> tuple[bool, dict[str, Any]]:
+    path = os.path.join(os.path.dirname(__file__), "mcp", "patterns", pattern_wildcard)
+    patterns = load_distillation_patterns(path)
+
+    browser_profile = BrowserProfile()
+    session = BrowserSession.get(browser_profile)
+    session = await session.start()
+    distilled, terminated = await run_distillation_loop(
+        location, patterns, browser_profile, interactive=False
+    )
+    await session.context.close()
+
+    result: dict[str, Any] = {result_key: distilled}
+    if result_key in result:
+        items_value = result[result_key]
+        if isinstance(items_value, list):
+            for item in cast(list[dict[str, Any]], items_value):
+                if "link" in item:
+                    link = cast(str, item["link"])
+                    parsed = urlparse(link)
+                    netloc: str = parsed.netloc if parsed.netloc else url_hostname
+                    url: str = urlunparse((
+                        "https",
+                        netloc,
+                        parsed.path,
+                        parsed.params,
+                        parsed.query,
+                        parsed.fragment,
+                    ))
+                    item["url"] = url
+    return terminated, result

--- a/getgather/mcp/cnn.py
+++ b/getgather/mcp/cnn.py
@@ -1,12 +1,8 @@
-import os
-from typing import Any, cast
-from urllib.parse import urlparse, urlunparse
+from typing import Any
 
 from fastmcp import Context
 
-from getgather.browser.profile import BrowserProfile
-from getgather.browser.session import BrowserSession
-from getgather.distill import load_distillation_patterns, run_distillation_loop
+from getgather.distill import short_lived_mcp_tool
 from getgather.mcp.registry import GatherMCP
 
 cnn_mcp = GatherMCP(brand_id="cnn", name="CNN MCP")
@@ -15,39 +11,12 @@ cnn_mcp = GatherMCP(brand_id="cnn", name="CNN MCP")
 @cnn_mcp.tool
 async def get_latest_stories(ctx: Context) -> dict[str, Any]:
     """Get the latest stories from CNN."""
-
-    location = "https://lite.cnn.com"
-    path = os.path.join(os.path.dirname(__file__), "patterns", "**/cnn-*.html")
-    patterns = load_distillation_patterns(path)
-
-    browser_profile = BrowserProfile()
-    session = BrowserSession.get(browser_profile)
-    session = await session.start()
-    distilled, terminated = await run_distillation_loop(
-        location, patterns, browser_profile, interactive=False
+    terminated, result = await short_lived_mcp_tool(
+        location="https://lite.cnn.com",
+        pattern_wildcard="**/cnn-*.html",
+        result_key="stories",
+        url_hostname="cnn.com",
     )
-    await session.context.close()
-
-    if terminated:
-        result_key = "stories"
-        result: dict[str, Any] = {result_key: distilled}
-        if "stories" in result:
-            stories_value = result["stories"]
-            if isinstance(stories_value, list):
-                for story in cast(list[dict[str, Any]], stories_value):
-                    if "link" in story:
-                        link = cast(str, story["link"])
-                        parsed = urlparse(link)
-                        netloc: str = parsed.netloc if parsed.netloc else "cnn.com"
-                        url: str = urlunparse((
-                            "https",
-                            netloc,
-                            parsed.path,
-                            parsed.params,
-                            parsed.query,
-                            parsed.fragment,
-                        ))
-                        story["url"] = url
-        return result
-
-    raise ValueError("Failed to retrieve CNN stories")
+    if not terminated:
+        raise ValueError("Failed to retrieve CNN stories")
+    return result

--- a/getgather/mcp/groundnews.py
+++ b/getgather/mcp/groundnews.py
@@ -1,12 +1,8 @@
-import os
-from typing import Any, cast
-from urllib.parse import urlparse, urlunparse
+from typing import Any
 
 from fastmcp import Context
 
-from getgather.browser.profile import BrowserProfile
-from getgather.browser.session import BrowserSession
-from getgather.distill import load_distillation_patterns, run_distillation_loop
+from getgather.distill import short_lived_mcp_tool
 from getgather.mcp.registry import GatherMCP
 
 groundnews_mcp = GatherMCP(brand_id="groundnews", name="Ground News MCP")
@@ -15,39 +11,12 @@ groundnews_mcp = GatherMCP(brand_id="groundnews", name="Ground News MCP")
 @groundnews_mcp.tool
 async def get_stories(ctx: Context) -> dict[str, Any]:
     """Get the latest news stories from Ground News."""
-
-    location = "https://ground.news"
-    path = os.path.join(os.path.dirname(__file__), "patterns", "**/groundnews-*.html")
-    patterns = load_distillation_patterns(path)
-
-    browser_profile = BrowserProfile()
-    session = BrowserSession.get(browser_profile)
-    session = await session.start()
-    distilled, terminated = await run_distillation_loop(
-        location, patterns, browser_profile, interactive=False
+    terminated, result = await short_lived_mcp_tool(
+        location="https://ground.news",
+        pattern_wildcard="**/groundnews-*.html",
+        result_key="stories",
+        url_hostname="ground.news",
     )
-    await session.context.close()
-
-    if terminated:
-        result_key = "stories"
-        result: dict[str, Any] = {result_key: distilled}
-        if "stories" in result:
-            stories_value = result["stories"]
-            if isinstance(stories_value, list):
-                for story in cast(list[dict[str, Any]], stories_value):
-                    if "link" in story:
-                        link = cast(str, story["link"])
-                        parsed = urlparse(link)
-                        netloc: str = parsed.netloc if parsed.netloc else "ground.news"
-                        url: str = urlunparse((
-                            "https",
-                            netloc,
-                            parsed.path,
-                            parsed.params,
-                            parsed.query,
-                            parsed.fragment,
-                        ))
-                        story["url"] = url
-        return result
-
-    raise ValueError("Failed to retrieve Ground News stories")
+    if not terminated:
+        raise ValueError("Failed to retrieve Ground News stories")
+    return result

--- a/getgather/mcp/npr.py
+++ b/getgather/mcp/npr.py
@@ -1,12 +1,8 @@
-import os
-from typing import Any, cast
-from urllib.parse import urlparse, urlunparse
+from typing import Any
 
 from fastmcp import Context
 
-from getgather.browser.profile import BrowserProfile
-from getgather.browser.session import BrowserSession
-from getgather.distill import load_distillation_patterns, run_distillation_loop
+from getgather.distill import short_lived_mcp_tool
 from getgather.mcp.registry import GatherMCP
 
 npr_mcp = GatherMCP(brand_id="npr", name="NPR MCP")
@@ -15,39 +11,12 @@ npr_mcp = GatherMCP(brand_id="npr", name="NPR MCP")
 @npr_mcp.tool
 async def get_headlines(ctx: Context) -> dict[str, Any]:
     """Get the current news headlines from NPR."""
-
-    location = "https://text.npr.org"
-    path = os.path.join(os.path.dirname(__file__), "patterns", "**/npr-*.html")
-    patterns = load_distillation_patterns(path)
-
-    browser_profile = BrowserProfile()
-    session = BrowserSession.get(browser_profile)
-    session = await session.start()
-    distilled, terminated = await run_distillation_loop(
-        location, patterns, browser_profile, interactive=False
+    terminated, result = await short_lived_mcp_tool(
+        location="https://text.npr.org",
+        pattern_wildcard="**/npr-*.html",
+        result_key="headlines",
+        url_hostname="npr.org",
     )
-    await session.context.close()
-
-    if terminated:
-        result_key = "headlines"
-        result: dict[str, Any] = {result_key: distilled}
-        if "headlines" in result:
-            headlines_value = result["headlines"]
-            if isinstance(headlines_value, list):
-                for headline in cast(list[dict[str, Any]], headlines_value):
-                    if "link" in headline:
-                        link = cast(str, headline["link"])
-                        parsed = urlparse(link)
-                        netloc: str = parsed.netloc if parsed.netloc else "npr.org"
-                        url: str = urlunparse((
-                            "https",
-                            netloc,
-                            parsed.path,
-                            parsed.params,
-                            parsed.query,
-                            parsed.fragment,
-                        ))
-                        headline["url"] = url
-        return result
-
-    raise ValueError("Failed to retrieve NPR headlines")
+    if not terminated:
+        raise ValueError("Failed to retrieve NPR headlines")
+    return result


### PR DESCRIPTION
This is to abstract the tool used for NPR (#541), CNN (#543), and Ground News (#545).