### PR TITLE
reusable incognito browser

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -346,6 +346,7 @@ async def dpage_mcp_tool(initial_url: str, result_key: str, timeout: int = 2) ->
 
         browser_profile = global_browser_profile
 
+    if not incognito or browser_profile_id is not None:
         # First, try without any interaction as this will work if the user signed in previously
         distillation_result, terminated = await run_distillation_loop(
             initial_url,


### PR DESCRIPTION
Since we want to migrate Amazon to dpage, we should be able to retrieve multiple tool calls and using the same browser profile (so we don’t need to sign in again for each tool call). Therefore, I propose adding a `browser_profile_id` and handling it appropriately so that we can reuse the same browser profile.

*Alternative approch: #522 