### PR TITLE
exclude amazon.ca from blocklist

### DIFF
--- a/getgather/browser/resource_blocker.py
+++ b/getgather/browser/resource_blocker.py
@@ -10,7 +10,7 @@ from getgather.logs import logger
 
 _BLOCKED_RESOURCE_TYPES = {"image", "media", "font"}
 _blocked_domains: frozenset[str] | None = None
-_EXCLUDED_DOMAINS: list[str] = ["amazon.ca"]
+_allowed_domains: frozenset[str] = frozenset(["amazon.ca"])
 
 
 def _get_domain_variants(domain: str) -> list[str]:
@@ -84,8 +84,7 @@ async def _load_blocklists() -> None:
             domains = await _load_blocklist_from_file(blocklist_file)
             all_domains.update(domains)
 
-        excluded_set = set(_EXCLUDED_DOMAINS)
-        filtered_domains = all_domains - excluded_set
+        filtered_domains = all_domains - _allowed_domains
         _blocked_domains = frozenset(filtered_domains)
 
     else:


### PR DESCRIPTION
It turns out that amazon.ca is in our blocklist

https://raw.githubusercontent.com/hectorm/hmirror/master/data/mozilla-shavar-advertising/list.txt
<img width="241" height="157" alt="image" src="https://github.com/user-attachments/assets/6c461707-38b2-4ad7-bd94-db85705fcb9e" />
