### PR TITLE
remove old goodreads get_book_list tool

### DIFF
--- a/getgather/mcp/brand/goodreads.py
+++ b/getgather/mcp/brand/goodreads.py
@@ -1,32 +1,14 @@
-import os
 from typing import Any
 
 from fastmcp import Context
 
-from getgather.distill import load_distillation_patterns, run_distillation_loop
 from getgather.mcp.agent import run_agent_for_brand
 from getgather.mcp.registry import BrandMCPBase
-from getgather.mcp.shared import get_mcp_browser_profile
 from getgather.mcp.stagehand_agent import (
     run_stagehand_agent,
 )
 
 goodreads_mcp = BrandMCPBase(brand_id="goodreads", name="Goodreads MCP")
-
-
-@goodreads_mcp.tool(tags={"private"})
-async def get_book_list() -> dict[str, Any]:
-    """Get the book list from a user's Goodreads account."""
-
-    browser_profile = get_mcp_browser_profile()
-    path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
-    patterns = load_distillation_patterns(path)
-    books, _ = await run_distillation_loop(
-        "https://www.goodreads.com/review/list?ref=nav_mybooks&view=table",
-        patterns,
-        browser_profile=browser_profile,
-    )
-    return {"books": books}
 
 
 @goodreads_mcp.tool(tags={"private"})


### PR DESCRIPTION
We’ve migrated the get_book_list tool to Dpage ([here](https://github.com/mcp-getgather/mcp-getgather/blob/3271b49eb41083cd560758650e56c3600e9ff431/getgather/mcp/goodreads.py#L9-L14)), but forgot to delete the old one.