### PR TITLE
Remove obsolete debugging in dpage

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -114,6 +114,17 @@ def redirect(id: str) -> HTMLResponse:
     """)
 
 
+@router.get("", response_class=HTMLResponse)
+@router.get("/{id}", response_class=HTMLResponse)
+async def get_dpage(id: str | None = None) -> HTMLResponse:
+    if id:
+        if id in active_pages:
+            return redirect(id)
+        raise HTTPException(status_code=404, detail="Invalid page id")
+
+    raise HTTPException(status_code=400, detail="Missing page id")
+
+
 FINISHED_MSG = "Finished! You can close this window now."
 
 


### PR DESCRIPTION
Originally you can hit `localhost:23456/dpage?location=...` to start the distillation on that URL (location). However, the proper way to debug is to use the MCP inspector which invokes the right MCP tool. And since it's so easy anway to use MCP inspector, there's almost no meaningful benefit anymore using the above `dpage?location=` trick.

This PR removes it, and we should use MCP inspector for proper debugging.