### PR TITLE
Bin/fix proxy

### DIFF
--- a/getgather/browser/proxy_builder.py
+++ b/getgather/browser/proxy_builder.py
@@ -85,7 +85,6 @@ def build_proxy_config(
     }
     if username:
         result["username"] = username
-
     if proxy_config.password:
         result["password"] = proxy_config.password
 


### PR DESCRIPTION
username and mode are currently not used from template, which is in the format of `mcpgetgather.oxylabs-country_{country}_sessid_{session_id}`

mode in username is needed to use different proxy mode