### PR TITLE
fix building proxy username

### DIFF
--- a/getgather/browser/proxy_builder.py
+++ b/getgather/browser/proxy_builder.py
@@ -72,7 +72,8 @@ def build_proxy_config(
         # Build from template (may not need base_username)
         params = _build_params(proxy_config.username_template, values)
         if params:
-            username = params
+            prefix = proxy_config.username_template.split("-", 1)[0]
+            username = f"{prefix}-{params}"
     elif proxy_config.base_username:
         # Use base username if no template
         username = proxy_config.base_username


### PR DESCRIPTION
username and mode are currently not used from template, which is in the format of `mcpgetgather.oxylabs-country_{country}_sessid_{session_id}`

mode in username is needed to use different proxy mode