### PR TITLE
add input value to distilled result

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -449,6 +449,11 @@ async def distill(hostname: str | None, page: Page, patterns: list[Pattern]) -> 
                     raw_text = await source.text_content()
                     if raw_text:
                         target.string = raw_text.strip()
+
+                    tag = await source.evaluate("el => el.tagName.toLowerCase()")
+                    if tag in ["input", "textarea", "select"]:
+                        input_value = await source.input_value()
+                        target["value"] = input_value
             else:
                 optional = target.get("gg-optional") is not None
                 logger.debug(f"Optional {selector} has no match")


### PR DESCRIPTION
This solve issue of distillation matches the same page again, but treats it as a different page because we only added the "input" value to the previous distill result. The new distill result won’t have the "input" value, even though the real site does contain it.

So in this PR I add "input" value to new distill result.

This should unblock:
https://github.com/mcp-getgather/mcp-getgather/pull/297
https://github.com/mcp-getgather/mcp-getgather/pull/445
https://github.com/mcp-getgather/mcp-getgather/pull/454
https://github.com/mcp-getgather/mcp-getgather/pull/482
