### PR TITLE
fix: surpress get_hosted_link log being call on info

### DIFF
--- a/getgather/api/routes/link/endpoints.py
+++ b/getgather/api/routes/link/endpoints.py
@@ -99,7 +99,7 @@ async def get_hosted_link(
     request: Request,
     link_id: str,
 ) -> TokenLookupResponse:
-    logger.info(
+    logger.debug(
         "[get_hosted_link] Retrieving hosted link",
         extra={"link_id": link_id, "request_url": str(request.url)},
     )
@@ -126,7 +126,7 @@ async def get_hosted_link(
             message=link_data.status_message or "Auth in progress...",
         )
 
-        logger.info(
+        logger.debug(
             "[get_hosted_link] Successfully retrieved link data",
             extra={
                 "link_id": link_id,


### PR DESCRIPTION
<img width="1168" height="485" alt="Screenshot 2025-10-29 at 15 16 59" src="https://github.com/user-attachments/assets/6f0f13c0-4950-436c-9950-ad97b71da955" />

This one create a lot of noise on Sentry. Change from info to debug for now.