### PR TITLE
Tweak Amazon OTP for a smoother UX

### DIFF
--- a/getgather/mcp/patterns/amazon-otp-auth.html
+++ b/getgather/mcp/patterns/amazon-otp-auth.html
@@ -17,10 +17,8 @@
       name="rememberDevice"
       type="checkbox"
       gg-match="input#auth-mfa-remember-device"
+      style="display: none"
     />
-    <label gg-optional gg-match="label[for='auth-mfa-remember-device']">
-      Don't require code on this browser
-    </label>
     <button type="submit" gg-match="input#auth-signin-button[type=submit]">Sign in</button>
   </body>
 </html>


### PR DESCRIPTION
Do not display the "remember me" checkbox. Behind the scene, the distillation process will automatically click on it anyway. Consequently, avoid displaying the label associated with that checkbox.