### PR TITLE
Use a neutral default title in distilled page

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -28,7 +28,7 @@ from getgather.distill import (
     terminate,
 )
 from getgather.logs import logger
-from getgather.mcp.html_renderer import render_form
+from getgather.mcp.html_renderer import DEFAULT_TITLE, render_form
 
 router = APIRouter(prefix="/dpage", tags=["dpage"])
 
@@ -104,7 +104,7 @@ def render(content: str, options: dict[str, str] | None = None) -> str:
     if options is None:
         options = {}
 
-    title = options.get("title", "GetGather")
+    title = options.get("title", DEFAULT_TITLE)
     action = options.get("action", "")
 
     return render_form(content, title, action)
@@ -186,7 +186,7 @@ async def post_dpage(id: str, request: Request) -> HTMLResponse:
         print(distilled)
 
         title_element = BeautifulSoup(distilled, "html.parser").find("title")
-        title = title_element.get_text() if title_element is not None else "GetGather"
+        title = title_element.get_text() if title_element is not None else DEFAULT_TITLE
         action = f"/dpage/{id}"
         options = {"title": title, "action": action}
 

--- a/getgather/mcp/html_renderer.py
+++ b/getgather/mcp/html_renderer.py
@@ -1,7 +1,9 @@
 """HTML template renderer for dpage forms."""
 
+DEFAULT_TITLE = "Sign In"
 
-def render_form(content: str, title: str = "GetGather", action: str = "") -> str:
+
+def render_form(content: str, title: str = DEFAULT_TITLE, action: str = "") -> str:
     """Render HTML form with the given content and options."""
     return f"""<!doctype html>
 <html lang="en">


### PR DESCRIPTION
In case the distillation pattern does not supply the HTML title, use the neutral "Sign In" instead of "GetGather". This distilled page might be used by some demo apps (e.g. Page Turner) and it can be confusing for the user to see the text "GetGather", which has nothing to do with the app itself.

Beside, the distilled page is solely used for the sign-in process anyway, hence the default title "Sign In" is sensible enough.