### PR TITLE
add simple retry to page.goto

### DIFF
--- a/getgather/browser/session.py
+++ b/getgather/browser/session.py
@@ -4,7 +4,7 @@ import asyncio
 from collections import defaultdict
 from contextlib import asynccontextmanager, suppress
 from datetime import datetime
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 from fastapi import HTTPException
 from nanoid import generate
@@ -71,7 +71,8 @@ class BrowserSession:
 
     async def new_page(self) -> Page:
         logger.info(f"Creating new page in context with profile {self.profile.id}")
-        return await self.context.new_page()
+        page = await self.context.new_page()
+        return add_retry_to_page_goto(page)
 
     async def page(self) -> Page:
         # TODO: It's okay for now to return the last page. We may want to track all pages in the future.
@@ -167,3 +168,30 @@ async def browser_session(profile: BrowserProfile, *, nested: bool = False, stop
     finally:
         if not nested and stop_ok:
             await session.stop()
+
+
+def add_retry_to_page_goto(page: Page, max_retries: int = 3) -> Page:
+    original_goto = page.goto
+
+    async def goto_with_retry(
+        url: str,
+        *,
+        timeout: float | None = None,
+        wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] | None = None,
+        referer: str | None = None,
+    ):
+        for i in range(max_retries):
+            try:
+                return await original_goto(
+                    url, timeout=timeout, wait_until=wait_until, referer=referer
+                )
+            except Exception as error:
+                msg = f"page.goto {url} {i + 1} of {max_retries} failed: {error}"
+                if i < max_retries - 1:
+                    logger.warning(msg + "\nRetrying...")
+                else:
+                    logger.exception(msg)
+                    raise
+
+    setattr(page, "goto", goto_with_retry)
+    return page


### PR DESCRIPTION
override page.goto with simple retry loop

this should help with sentry errors like
```
TimeoutError
Page.goto: Timeout 30000ms exceeded.
Call log:
  - navigating to "https://www.goodreads.com/review/list?ref=nav_mybooks&view=table", waiting until "load"
```

simulated test log look like
```
[10/30/25 10:59:33] WARNING  page.goto http://localhost:23456/test 1 of 3 failed: Page.goto: Timeout 3000ms
                             exceeded.                                                                     
                             Call log:                                                                     
                               - navigating to "http://localhost:23456/test", waiting until "load"         
                                                                                                           
                             Retrying...  
```
