### PR TITLE
feat(nordstorm): add get_order_history from the network

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -433,7 +433,7 @@ async def dpage_with_action(
     if _signin_completed and _page_id is not None and _page_id in active_pages:
         logger.info(f"Resuming action after signin with page_id={_page_id}")
         page = active_pages[_page_id]
-        await page.goto(initial_url)
+        await page.goto(initial_url, wait_until="commit")
         result = await action(page)
         return result
 
@@ -445,7 +445,7 @@ async def dpage_with_action(
             session = BrowserSession.get(global_browser_profile)
             await session.start()
             page = await session.page()
-            await page.goto(initial_url)
+            await page.goto(initial_url, wait_until="commit")
             result = await action(page)
             logger.info("Action succeeded with existing session!")
             await page.close()


### PR DESCRIPTION
<img width="1100" height="246" alt="Screenshot 2025-10-31 at 14 44 16" src="https://github.com/user-attachments/assets/9331121b-3f8d-4786-9142-9439c814522a" />

Currently, we can get the detail directly using the URL since the lookup ID isn’t available in the DOM — it only appears in the network response.

With `dpage_with_action`, this also demonstrates how we can capture API calls directly from the network, which makes it possible to fetch data that’s not exposed in the page itself.

<img width="386" height="180" alt="Screenshot 2025-10-31 at 14 46 32" src="https://github.com/user-attachments/assets/c1df8dbe-f2a1-4a09-8c45-70096037502a" />
