### PR TITLE
Increase the timeout to build and publish container images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-22.04
     needs: test-local-container
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Some CI runs fail because apparently 30 minutes were too short. Thus, let's bump it to 45 minutes.
If this is still not enough, we may need to switch to a faster (but non-free) GitHub Action runner.