### PR TITLE
Install system-wide Chromium

### DIFF
--- a/.jwmrc
+++ b/.jwmrc
@@ -54,7 +54,8 @@
 
    <!-- Start menu -->
    <RootMenu onroot="1" labeled="true" label="Start">
-      <Program label="Chromium">/opt/ms-playwright/chromium-1169/chrome-linux/chrome --no-sandbox</Program>
+      <Program label="Chromium (system)">/usr/bin/chromium --no-sandbox</Program>
+      <Program label="Chromium (Patchright)">/opt/ms-playwright/chromium-1169/chrome-linux/chrome --no-sandbox</Program>
       <Program label="Terminal">xterm</Program>
       <Exit label="Shut Down"/>
    </RootMenu>

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ FROM mirror.gcr.io/library/python:3.13-slim-bookworm
 
 RUN apt-get update && apt-get install -y \
     tigervnc-standalone-server \
+    chromium \
     libnss3 \
     libatk-bridge2.0-0 \
     libgtk-3-0 \


### PR DESCRIPTION
This is primarily to prepare for the upcoming support for Zendriver, which requires a system-wide Chromium browser.

To facilitate troubleshooting, this system-wide Chromium is also added as a new menu item in the start menu.