### PR TITLE
Reduce distillation noise by not printing the distillation result

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -553,9 +553,6 @@ async def run_distillation_loop(
                     distilled = match.distilled
                     current = match
 
-                    print()
-                    print(distilled)
-
                     if await terminate(distilled):
                         converted = await convert(distilled)
                         await page.close()

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -184,8 +184,6 @@ async def post_dpage(id: str, request: Request) -> HTMLResponse:
         current = match
         distilled = match.distilled
 
-        print(distilled)
-
         title_element = BeautifulSoup(distilled, "html.parser").find("title")
         title = title_element.get_text() if title_element is not None else DEFAULT_TITLE
         action = f"/dpage/{id}"


### PR DESCRIPTION
We can't use logger since it may contain sensitive information. And in many cases it's a large content of HTML, printing it out stdout creates a lot of unnecessary noise.

When debugging some distillation patterns, it's easy enough to do that with Middleman and therefore we don't have to duplicate the functionality here.