### PR TITLE
chore: change vite port

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "npm run generate:schema && concurrently --raw \"npm run dev:backend\" \"npm run dev:frontend\"",
     "dev:backend": "uv run -m uvicorn getgather.main:app --reload --host 127.0.0.1 --port 23456",
-    "dev:frontend": "concurrently --raw \"npm run watch:schema:api\" \"vite\"",
+    "dev:frontend": "concurrently --raw \"npm run watch:schema:api\" \"vite --port 5170\"",
     "build": "npm run generate:schema && tsc -b && vite build",
     "build:ci": "tsc -b && vite build",
     "preview": "vite preview",


### PR DESCRIPTION
Change port used by vite from `5173` to `5170` to prevent port conflict with all of our demos

Will resolve https://github.com/mcp-getgather/page-turner/issues/19

