### PR TITLE
CI for web UI tests: ensure it does not run forever

### DIFF
--- a/.github/workflows/webui-tests.yml
+++ b/.github/workflows/webui-tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   webui-list-tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,6 +41,7 @@ jobs:
 
   webui-auth-tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
We just had a case where the CI run is not finished after almost 2 hours: https://github.com/mcp-getgather/mcp-getgather/actions/runs/19240549232/job/55001855824.