### PR TITLE
Fix the missing MCP category bundle for books

### DIFF
--- a/getgather/mcp/main.py
+++ b/getgather/mcp/main.py
@@ -106,6 +106,7 @@ class AuthMiddleware(Middleware):
 
 CATEGORY_BUNDLES: dict[str, list[str]] = {
     "food": ["doordash", "ubereats"],
+    "books": [],
     "shopping": ["amazon", "shopee", "wayfair", "astro"],
     "media": [],
 }


### PR DESCRIPTION
This is due to the mistake in the previous PR #628. Without this fix, `/mcp-books` will not exist.