### PR TITLE
amazon custom action to extract prices

### DIFF
--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -31,6 +31,32 @@ async def dpage_get_purchase_history(
     if not (1900 <= target_year <= current_year + 1):
         raise ValueError(f"Year {target_year} is out of valid range (1900-{current_year + 1})")
 
+    return await dpage_mcp_tool(
+        f"https://www.amazon.com/your-orders/orders?timeFilter=year-{target_year}&startIndex={start_index}",
+        "amazon_purchase_history",
+    )
+
+
+@amazon_mcp.tool
+async def dpage_get_purchase_history_with_details(
+    year: str | int | None = None, start_index: int = 0
+) -> dict[str, Any]:
+    """Get purchase/order history of a amazon with dpage."""
+
+    if year is None:
+        target_year = datetime.now().year
+    elif isinstance(year, str):
+        try:
+            target_year = int(year)
+        except ValueError:
+            target_year = datetime.now().year
+    else:
+        target_year = int(year)
+
+    current_year = datetime.now().year
+    if not (1900 <= target_year <= current_year + 1):
+        raise ValueError(f"Year {target_year} is out of valid range (1900-{current_year + 1})")
+
     async def get_order_details_action(page: Page) -> dict[str, Any]:
         current_url = page.url
         if "signin" in current_url:
@@ -75,7 +101,7 @@ async def dpage_get_purchase_history(
         except Exception:
             logger.error(f"Error getting order details for order")
             pass
-        return {"orders": orders, "current_url": current_url}
+        return {"amazon_purchase_history": orders}
 
     return await dpage_with_action(
         f"https://www.amazon.com/your-orders/orders?timeFilter=year-{target_year}&startIndex={start_index}",


### PR DESCRIPTION
Extract Amazon order item prices in parallel using `eval` (since the Amazon page is server-side rendered). This method is much faster than opening each order detail in a separate browser tab.

<img width="739" height="751" alt="Screenshot 2025-11-11 at 19 37 54" src="https://github.com/user-attachments/assets/442be63d-a61a-42b5-88cd-cbd6718f01a7" />
