### PR TITLE
fix: Locator.is_visible: Error: Can't query n-th element

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -323,9 +323,13 @@ async def locate(locator: Locator) -> Locator | None:
     count = await locator.count()
     if count > 0:
         for i in range(count):
-            el = locator.nth(i)
-            if await el.is_visible():
-                return el
+            try:
+                el = locator.nth(i)
+                if await el.is_visible():
+                    return el
+            except Exception:
+                logger.info("Element may have disappeared or selector can't be queried")
+                continue
     return None
 
 

--- a/tests/test_distill_locate.py
+++ b/tests/test_distill_locate.py
@@ -1,0 +1,74 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from patchright.async_api import Locator
+
+from getgather.distill import locate
+
+
+@pytest.mark.asyncio
+async def test_locate_handles_nth_element_error():
+    """Test locate() gracefully handles 'Can't query n-th element' errors."""
+
+    # Mock locator that has 2 elements but second one fails on nth()
+    mock_locator = MagicMock(spec=Locator)
+    mock_locator.count = AsyncMock(return_value=2)
+
+    # First element: nth() works, is_visible() returns False
+    mock_el1 = MagicMock(spec=Locator)
+    mock_el1.is_visible = AsyncMock(return_value=False)
+
+    # Second element: nth() works, is_visible() throws "Can't query n-th element"
+    mock_el2 = MagicMock(spec=Locator)
+    mock_el2.is_visible = AsyncMock(side_effect=Exception("Can't query n-th element"))
+
+    # Configure nth() to return different mocks
+    mock_locator.nth = MagicMock(side_effect=[mock_el1, mock_el2])
+
+    # Test that locate() doesn't crash and returns None
+    result = await locate(mock_locator)
+
+    assert result is None
+    assert mock_locator.nth.call_count == 2
+    mock_el1.is_visible.assert_called_once()
+    mock_el2.is_visible.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_locate_returns_first_visible_element():
+    """Test locate() returns first visible element when available."""
+
+    mock_locator = MagicMock(spec=Locator)
+    mock_locator.count = AsyncMock(return_value=3)
+
+    # First element: not visible
+    mock_el1 = MagicMock(spec=Locator)
+    mock_el1.is_visible = AsyncMock(return_value=False)
+
+    # Second element: visible - should be returned
+    mock_el2 = MagicMock(spec=Locator)
+    mock_el2.is_visible = AsyncMock(return_value=True)
+
+    # Third element: shouldn't be checked since we found visible one
+    mock_el3 = MagicMock(spec=Locator)
+    mock_el3.is_visible = AsyncMock(return_value=False)
+
+    mock_locator.nth = MagicMock(side_effect=[mock_el1, mock_el2, mock_el3])
+
+    result = await locate(mock_locator)
+
+    assert result is mock_el2
+    assert mock_locator.nth.call_count == 2  # Only checks first 2 elements
+
+
+@pytest.mark.asyncio
+async def test_locate_returns_none_when_no_elements():
+    """Test locate() returns None when no elements match."""
+
+    mock_locator = MagicMock(spec=Locator)
+    mock_locator.count = AsyncMock(return_value=0)
+
+    result = await locate(mock_locator)
+
+    assert result is None
+    mock_locator.nth.assert_not_called()


### PR DESCRIPTION
## Summary

• Add try-except handling in locate() function to gracefully handle Playwright's "Can't query n-th element" errors
• Prevents entire requests from failing when DOM elements disappear between count() and is_visible() calls
• Added comprehensive test coverage for the error scenario

## Background

The error occurred when checking element visibility after DOM changes caused elements to become unavailable for nth-indexing,
leading to request failures in the distillation pipeline.

## Changes

• getgather/distill.py:327: Wrap nth() and is_visible() calls in try-except
• tests/test_distill_locate.py: New tests verify error handling and normal behavior

## Impact

• Improves reliability of the distillation process
• No breaking changes to existing functionality

## Sentry
https://heyario.sentry.io/issues/7002114648/events/bf5d0d134b0d46c0b57ad908b9285d38/