### PR TITLE
fix: cannot select nordstrom phone otp

### DIFF
--- a/getgather/mcp/patterns/nordstrom-mfa-choice.html
+++ b/getgather/mcp/patterns/nordstrom-mfa-choice.html
@@ -9,14 +9,16 @@
       <p gg-match="strong:has-text('How should we send your code?')"></p>
       <div class="vertical-radios">
         <div class="radio-wrapper">
-          <input
-            type="radio"
-            name="delivery-method"
-            id="EMAIL"
-            gg-match="input[name='delivery-method'][value='EMAIL']"
-            value="EMAIL"
-            checked
-          />
+          <div style="font-size: 0">
+            <input
+              type="radio"
+              name="delivery-method"
+              id="EMAIL"
+              gg-match="fieldset > label:nth-of-type(1)"
+              value="EMAIL"
+              checked
+            />
+          </div>
           <div>
             <label gg-optional for="email">Email</label>
             <strong
@@ -27,14 +29,16 @@
           </div>
         </div>
         <div class="radio-wrapper">
-          <input
-            gg-optional
-            type="radio"
-            name="delivery-method"
-            id="sms"
-            gg-match="input[name='delivery-method'][value='sms']"
-            value="sms"
-          />
+          <div style="font-size: 0">
+            <input
+              gg-optional
+              type="radio"
+              name="delivery-method"
+              id="sms"
+              gg-match="fieldset > label:nth-of-type(2)"
+              value="sms"
+            />
+          </div>
           <div>
             <label gg-optional for="sms">Text Message</label>
             <strong
@@ -42,7 +46,12 @@
               for="sms"
               gg-match="fieldset > label:nth-of-type(2) strong"
             ></strong>
-            <span gg-optional for="sms" gg-match="fieldset > label:nth-of-type(2) span"></span>
+            <p
+              style="font-size: 12px; color: #666"
+              gg-optional
+              for="sms"
+              gg-match="fieldset > label:nth-of-type(2) span"
+            ></p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Turn's out nordstrom have custom radio button with hidden input (not visible), so we need to click the label, not the actual input.