### PR TITLE
Rename "OTP" to "Verification (Code)" in the user-visible sign-in message

### DIFF
--- a/getgather/mcp/patterns/aliexpress-otp.html
+++ b/getgather/mcp/patterns/aliexpress-otp.html
@@ -1,6 +1,6 @@
 <html gg-domain="aliexpress" gg-priority="1">
   <head>
-    <title>OTP</title>
+    <title>Verification</title>
   </head>
   <body>
     <span gg-match="div:has-text('Email verification code')"></span>

--- a/getgather/mcp/patterns/amazon-otp-auth.html
+++ b/getgather/mcp/patterns/amazon-otp-auth.html
@@ -1,6 +1,6 @@
 <html gg-domain="amazon">
   <head>
-    <title>Amazon OTP Authenticator</title>
+    <title>Amazon Verification</title>
   </head>
   <body>
     <h1 gg-match="h1:has-text('Two-Step Verification')">Two-Step Verification</h1>

--- a/getgather/mcp/patterns/amazon-otp-email.html
+++ b/getgather/mcp/patterns/amazon-otp-email.html
@@ -1,6 +1,6 @@
 <html gg-domain="amazon">
   <head>
-    <title>Amazon OTP Email</title>
+    <title>Amazon Verification</title>
   </head>
   <body>
     <h2 gg-match="span:has-text('Enter verification code')">Enter verification code</h2>

--- a/getgather/mcp/patterns/amazon-otp-phone.html
+++ b/getgather/mcp/patterns/amazon-otp-phone.html
@@ -1,6 +1,6 @@
 <html gg-domain="amazon">
   <head>
-    <title>Amazon OTP</title>
+    <title>Amazon Verification</title>
   </head>
   <body>
     <span gg-optional gg-match="div#verifyAlerts"></span>

--- a/getgather/mcp/patterns/astro-otp.html
+++ b/getgather/mcp/patterns/astro-otp.html
@@ -1,6 +1,6 @@
 <html gg-domain="astronauts.id">
   <head>
-    <title>Astro OTP</title>
+    <title>Astro Verification</title>
   </head>
   <body>
     <span gg-optional gg-match='[data-testid="otpErrorMessage"]'>Kode OTP tidak sesuai</span>

--- a/getgather/mcp/patterns/gofood-otp.html
+++ b/getgather/mcp/patterns/gofood-otp.html
@@ -1,13 +1,13 @@
 <html gg-domain="gofood">
   <head>
-    <title>GoFood OTP Verification</title>
+    <title>GoFood Verification</title>
   </head>
   <body>
-    <h1 gg-match="p.gf-heading-xl">OTP sent securely to SMS</h1>
-    <p gg-match="p.gf-body-m">Enter the OTP we've just sent to</p>
+    <h1 gg-match="p.gf-heading-xl">Verification code sent securely to SMS</h1>
+    <p gg-match="p.gf-body-m">Enter the code we've just sent to</p>
     <p gg-optional gg-match="p:has-text('Invalid verification code. Please try again')"></p>
     <div class="otp-input">
-      <label gg-match="p.gf-label-m">Enter OTP</label>
+      <label gg-match="p.gf-label-m">Enter code</label>
       <input name="otp" type="tel" gg-match="input[name='data.otp']" placeholder="4-digit OTP" />
     </div>
     <button type="submit" gg-autoclick gg-match="button[type=submit]">Continue</button>

--- a/getgather/mcp/patterns/nike-otp.html
+++ b/getgather/mcp/patterns/nike-otp.html
@@ -1,6 +1,6 @@
 <html gg-domain="nike">
   <head>
-    <title>Nike OTP</title>
+    <title>Nike Verification</title>
   </head>
   <body>
     <div>

--- a/getgather/mcp/patterns/tokopedia-otp-choose.html
+++ b/getgather/mcp/patterns/tokopedia-otp-choose.html
@@ -1,6 +1,6 @@
 <html gg-domain="tokopedia" gg-priority="3">
   <head>
-    <title>Tokopedia Choose OTP Method</title>
+    <title>Tokopedia Choose Verification Method</title>
   </head>
   <body>
     <div gg-match="div.css-280ezp:has-text('Pilih Metode Verifikasi')">Pilih Metode Verifikasi</div>

--- a/getgather/mcp/patterns/tokopedia-otp.html
+++ b/getgather/mcp/patterns/tokopedia-otp.html
@@ -1,6 +1,6 @@
 <html gg-domain="tokopedia" gg-priority="1">
   <head>
-    <title>Tokopedia OTP Verification</title>
+    <title>Tokopedia Verification</title>
   </head>
   <body>
     <p gg-optional gg-match="span:has-text('Kode yang kamu masukkan salah.')"></p>

--- a/getgather/mcp/patterns/wayfair-email-otp.html
+++ b/getgather/mcp/patterns/wayfair-email-otp.html
@@ -1,6 +1,6 @@
 <html gg-domain="wayfair">
   <head>
-    <title>Wayfair Email OTP</title>
+    <title>Wayfair Email Verification</title>
   </head>
   <body>
     <h1 gg-match="[data-test-id='AuthHeaderTitle']">Enter the Code We Emailed You</h1>

--- a/getgather/mcp/patterns/wayfair-phone-otp.html
+++ b/getgather/mcp/patterns/wayfair-phone-otp.html
@@ -1,6 +1,6 @@
 <html gg-domain="wayfair">
   <head>
-    <title>Wayfair Phone OTP</title>
+    <title>Wayfair Phone Verification</title>
   </head>
   <body>
     <div>


### PR DESCRIPTION
"OTP" is too technical for the typical consumer. Note that the site's own copy also always use verification and some variations thereof.