### PR TITLE
Start with maximized browser window

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -140,7 +140,9 @@ async def init_zendriver_browser() -> zd.Browser:
         f"Launching Zendriver browser with user_data_dir: {user_data_dir}",
         extra={"profile_id": id},
     )
-    browser = await zd.start(user_data_dir=str(user_data_dir), browser_args=["--no-sandbox"])
+
+    browser_args = ["--no-sandbox", "--start-maximized"]
+    browser = await zd.start(user_data_dir=str(user_data_dir), browser_args=browser_args)
     browser.id = id  # type: ignore[attr-defined]
 
     return browser


### PR DESCRIPTION
When using Zendriver, the initial Chromium window should be maximized to the desktop screen estate.

## Before

<img width="1920" height="1484" alt="image" src="https://github.com/user-attachments/assets/b34484f9-e99b-481f-bef0-cb6e08995e12" />


## After

<img width="1920" height="1484" alt="image" src="https://github.com/user-attachments/assets/0a7410f0-f456-4a6d-8d58-0c5990379188" />
