### PR TITLE
fix: respect stop_ok parameter to prevent premature page closure

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -558,7 +558,8 @@ async def run_distillation_loop(
 
                     if await terminate(distilled):
                         converted = await convert(distilled)
-                        await page.close()
+                        if stop_ok:
+                            await page.close()
                         return (True, distilled, converted)
 
                     if interactive:


### PR DESCRIPTION
 ## Summary

  Fix premature page closure in the distillation loop when stop elements are detected. The `stop_ok` parameter was being ignored, causing the browser session to close even when subsequent operations still
  needed the page.

  ## Problem

<img width="686" height="328" alt="Screenshot 2025-11-14 at 10 49 22" src="https://github.com/user-attachments/assets/19015e6b-f434-452f-abdd-5b79ad2622c4" />


[Link to Sentry](https://heyario.sentry.io/issues/7022745529/?alert_rule_id=16209527&alert_timestamp=1762998594874&alert_type=email&notification_uuid=390b0f5e-0cd6-46f5-8eb4-d8f374a72d9e&project=4509832551858176&referrer=digest_email&seerDrawer=true#request)