### PR TITLE
Support URL blocklists for Zendriver-based distillation

### DIFF
--- a/blocklists-basic.txt
+++ b/blocklists-basic.txt
@@ -1,5 +1,7 @@
 adnxs.com
 doubleclick.net
 googlesyndication.com
+growthbook.io
+osano.com
 rubiconproject.com
 taboola.com


### PR DESCRIPTION
To verify, run with the verbose log level:
```
LOG_LEVEL=DEBUG npm run dev
```

then connect the MCP inspector to this server, choose `/mcp-media`, and then invoke `groundnews_get_stories` tool. The log should show the loading of the blocklists, e.g.:

```
INFO     Loading blocklists...
DEBUG    Loading blocklist file: blocklists-basic.txt
DEBUG    Loading blocked domains from mcp-getgather/blocklists-basic.txt...
DEBUG    Loaded 6 domains from mcp-getgather/blocklists-basic.txt
DEBUG    Loading blocklist file: blocklists-adguard.txt
DEBUG    Loading blocked domains from mcp-getgather/blocklists-adguard.txt...
DEBUG    Loaded 139813 domains from mcp-getgather/blocklists-adguard.txt
DEBUG    Loading blocklist file: blocklists-privacy.txt
DEBUG    Loading blocked domains from mcp-getgather/blocklists-privacy.txt...
DEBUG    Loaded 41979 domains from mcp-getgather/blocklists-privacy.txt
DEBUG    Loading blocklist file: blocklists-analytics.txt
DEBUG    Loading blocked domains from mcp-getgather/blocklists-analytics.txt...
DEBUG    Loaded 435 domains from mcp-getgather/blocklists-analytics.txt
DEBUG    Loading blocklist file: blocklists-ads.txt
DEBUG    Loading blocked domains from mcp-getgather/blocklists-ads.txt...
DEBUG    Loaded 2310 domains from mcp-getgather/blocklists-ads.txt
INFO     Blocklists loaded: 156210 total domains
INFO     Navigating to https://ground.news
```

and also some lines indicating the blocking, such as:

```
DEBUG     DENY URL: https://cdn.growthbook.io/api/features/sdk-2eg09ZhAR8TcGGf
DEBUG     DENY URL: https://d34r8q7sht0t9k.cloudfront.net/tag.js
```