### PR TITLE
Migrate NYTimes best-sellers MCP tool to Zendriver

### DIFF
--- a/getgather/mcp/nytimes.py
+++ b/getgather/mcp/nytimes.py
@@ -2,8 +2,8 @@ from typing import Any
 
 from fastmcp import Context
 
-from getgather.mcp.dpage import dpage_mcp_tool
 from getgather.mcp.registry import GatherMCP
+from getgather.zen_distill import short_lived_mcp_tool
 
 nytimes_mcp = GatherMCP(brand_id="nytimes", name="NYTimes MCP")
 
@@ -11,4 +11,12 @@ nytimes_mcp = GatherMCP(brand_id="nytimes", name="NYTimes MCP")
 @nytimes_mcp.tool
 async def get_bestsellers_list(ctx: Context) -> dict[str, Any]:
     """Get the bestsellers list from NY Times."""
-    return await dpage_mcp_tool("https://www.nytimes.com/books/best-sellers/", "best_sellers")
+    terminated, result = await short_lived_mcp_tool(
+        location="https://www.nytimes.com/books/best-sellers/",
+        pattern_wildcard="**/nytimes-*.html",
+        result_key="best_sellers",
+        url_hostname="nytimes.com",
+    )
+    if not terminated:
+        raise ValueError("Failed to retrieve NY Times best sellers")
+    return result


### PR DESCRIPTION
See previously: PR #653, #608, and #632.