### PR TITLE
fix: separate stop_ok flag on distillation loop

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -494,6 +494,7 @@ async def run_distillation_loop(
     timeout: int = 15,
     interactive: bool = True,
     stop_ok: bool = False,
+    close_page: bool = False,
 ) -> tuple[bool, str, ConversionResult | None]:
     """Run the distillation loop.
 
@@ -557,7 +558,7 @@ async def run_distillation_loop(
 
                     if await terminate(distilled):
                         converted = await convert(distilled)
-                        if stop_ok:
+                        if close_page:
                             await page.close()
                         return (True, distilled, converted)
 

--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -63,9 +63,7 @@ async def search_product(keyword: str) -> dict[str, Any]:
 async def get_browsing_history() -> dict[str, Any]:
     """Get browsing history from amazon."""
 
-    async def get_browsing_history_action(
-        page: Page, browser_profile: BrowserProfile
-    ) -> dict[str, Any]:
+    async def get_browsing_history_action(page: Page, _) -> dict[str, Any]:
         current_url = page.url
         if "signin" in current_url:
             raise Exception("User is not signed in")
@@ -199,7 +197,7 @@ async def dpage_get_purchase_history_with_details(
             browser_profile=browser_profile,
             interactive=False,
             timeout=2,
-            stop_ok=False,
+            close_page=True,
         )
         if orders is None:
             return {"amazon_purchase_history": []}
@@ -235,8 +233,8 @@ async def dpage_get_purchase_history_with_details(
             for order in orders:
                 if order_prices[order["order_id"]] is not None:
                     order["product_prices"] = order_prices[order["order_id"]]
-        except Exception:
-            logger.error(f"Error getting order details for order")
+        except Exception as e:
+            logger.error(f"Error getting order details for order: {e}")
             pass
         return {"amazon_purchase_history": orders}
 


### PR DESCRIPTION
`stop_ok` means to stop the session, not the page. If we only need to stop or close the page (but not the session), we need a new flag