### PR TITLE
Don't use get_mcp_browser_profile

### DIFF
--- a/getgather/mcp/doordash.py
+++ b/getgather/mcp/doordash.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from getgather.distill import load_distillation_patterns, run_distillation_loop
 from getgather.mcp.registry import GatherMCP
-from getgather.mcp.shared import get_mcp_browser_profile
 
 doordash_mcp = GatherMCP(brand_id="doordash", name="Doordash MCP")
 
@@ -11,11 +10,10 @@ doordash_mcp = GatherMCP(brand_id="doordash", name="Doordash MCP")
 # TODO: add signin pattern
 async def get_orders() -> dict[str, Any]:
     """Get orders from Doordash.com."""
-    browser_profile = get_mcp_browser_profile()
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
     _terminated, distilled, converted = await run_distillation_loop(
-        "https://www.doordash.com/orders", patterns, browser_profile=browser_profile
+        "https://www.doordash.com/orders", patterns
     )
     orders = converted if converted else distilled
     return {"orders": orders}

--- a/getgather/mcp/ubereats.py
+++ b/getgather/mcp/ubereats.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from getgather.distill import load_distillation_patterns, run_distillation_loop
 from getgather.mcp.registry import GatherMCP
-from getgather.mcp.shared import get_mcp_browser_profile
 
 ubereats_mcp = GatherMCP(brand_id="ubereats", name="UberEats MCP")
 
@@ -11,13 +10,11 @@ ubereats_mcp = GatherMCP(brand_id="ubereats", name="UberEats MCP")
 # TODO: add signin pattern
 async def get_orders() -> dict[str, Any]:
     """Get orders from UberEats.com."""
-    browser_profile = get_mcp_browser_profile()
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
     _terminated, distilled, converted = await run_distillation_loop(
         "https://www.ubereats.com/orders",
         patterns,
-        browser_profile=browser_profile,
     )
     orders = converted if converted else distilled
     return {"orders": orders}


### PR DESCRIPTION
For the temporary stub for Doordash and Uber Eats, the browser profile can't be related to the profile tracked by the brand state, as it must migrate towards the distillation approach.