### PR TITLE
Reduce the frequency of the browser cleanup

### DIFF
--- a/getgather/main.py
+++ b/getgather/main.py
@@ -47,7 +47,7 @@ async def lifespan(app: FastAPI):
     async def timer_loop():
         while not stop_event.is_set():
             await cleanup_old_sessions()
-            await asyncio.sleep(60)
+            await asyncio.sleep(5 * 60)  # every 5 minutes
 
     background_task = asyncio.create_task(timer_loop())
 


### PR DESCRIPTION
Instead of every minute, it is only every 5 minute. If we observe the need to do it more often, we'll tweak it again in the future.

See previously PR #573.