### PR TITLE
Really get a new page with Zendriver

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -219,7 +219,7 @@ async def terminate_zendriver_browser(browser: zd.Browser):
 
 
 async def get_new_page(browser: zd.Browser) -> zd.Tab:
-    page = await browser.get()
+    page = await browser.get("about:blank", new_tab=True)
 
     if blocked_domains is None:
         await load_blocklists()


### PR DESCRIPTION
Open a new tab, instead of reusing the existing one. This is preparing for more Zendriver migration of MCP tools.