### PR TITLE
Remove the flaky marker for NYTimes test

### DIFF
--- a/tests/mcp/test_nytimes.py
+++ b/tests/mcp/test_nytimes.py
@@ -14,7 +14,6 @@ config = {
 
 @pytest.mark.mcp
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="Flaky test")
 async def test_nytimes_get_bestsellers_list():
     """Test get bestsellers list from NY Times."""
     client = Client(config)


### PR DESCRIPTION
Let's try our luck! This test was flaky and marked as such previously in PR #408.