### PR TITLE
handle empty amazon browsing history

### DIFF
--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -68,6 +68,18 @@ async def get_browsing_history() -> dict[str, Any]:
         if "signin" in current_url:
             raise Exception("User is not signed in")
 
+        await page.wait_for_load_state("domcontentloaded")
+        is_empty = await page.locator(
+            "span:has-text('You have no recently viewed items.')"
+        ).is_visible()
+        if is_empty:
+            return {"browsing_history_data": []}
+
+        await page.goto(
+            "https://www.amazon.com/gp/history?ref_=nav_AccountFlyout_browsinghistory",
+            wait_until="commit",
+        )
+
         def _url_matches(resp: Response) -> bool:
             """Predicate that checks if the response URL contains the predicate string."""
 

--- a/getgather/mcp/amazonca.py
+++ b/getgather/mcp/amazonca.py
@@ -155,6 +155,18 @@ async def get_browsing_history() -> dict[str, Any]:
         if "signin" in current_url:
             raise Exception("User is not signed in")
 
+        await page.wait_for_load_state("domcontentloaded")
+        is_empty = await page.locator(
+            "span:has-text('You have no recently viewed items.')"
+        ).is_visible()
+        if is_empty:
+            return {"browsing_history_data": []}
+
+        await page.goto(
+            "https://www.amazon.ca/gp/history?ref_=nav_AccountFlyout_browsinghistory",
+            wait_until="commit",
+        )
+
         def _url_matches(resp: Response) -> bool:
             """Predicate that checks if the response URL contains the predicate string."""
 


### PR DESCRIPTION
When the user browsing history is empty, mcp-getgather will time out. I believe this is the root cause of the error below:

<img width="1481" height="445" alt="Screenshot 2025-11-24 at 14 37 59" src="https://github.com/user-attachments/assets/6eec69b4-bebc-46d6-ae07-1bc6077711de" />
