### PR TITLE
Migrate ThriftBooks to Zendriver

### DIFF
--- a/getgather/mcp/patterns/thriftbooks-order-summary-empty.html
+++ b/getgather/mcp/patterns/thriftbooks-order-summary-empty.html
@@ -2,7 +2,7 @@
   <body>
     <div
       gg-stop
-      gg-match-html=".AccountDetails-content:has-text('No orders are available.') span"
+      gg-match-html="//div[contains(@class,'AccountDetails-content') and contains(text(),'No orders')]//span"
     ></div>
   </body>
 </html>

--- a/getgather/mcp/thriftbooks.py
+++ b/getgather/mcp/thriftbooks.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from getgather.mcp.dpage import dpage_mcp_tool
+from getgather.mcp.dpage import zen_dpage_mcp_tool
 from getgather.mcp.registry import GatherMCP
 
 thriftbooks_mcp = GatherMCP(brand_id="thriftbooks", name="Thriftbooks MCP")
@@ -9,6 +9,6 @@ thriftbooks_mcp = GatherMCP(brand_id="thriftbooks", name="Thriftbooks MCP")
 @thriftbooks_mcp.tool
 async def get_order_history() -> dict[str, Any]:
     """Get order history of thriftbooks."""
-    return await dpage_mcp_tool(
+    return await zen_dpage_mcp_tool(
         "https://www.thriftbooks.com/account/ordersummary/", "thriftbooks_order_history"
     )


### PR DESCRIPTION
To verify, use MCP Inspector and invoke the tool
`thriftbooks_get_order_history`.