### PR TITLE
Migrate Revolve to Zendriver

### DIFF
--- a/getgather/mcp/patterns/revolve-carts-empty.html
+++ b/getgather/mcp/patterns/revolve-carts-empty.html
@@ -3,9 +3,6 @@
     <title>Revolve Carts</title>
   </head>
   <body>
-    <div
-      gg-stop
-      gg-match-html="p:has-text('Your shopping bag is empty.  Start shopping and check out our new arrivals.')"
-    ></div>
+    <div gg-stop gg-match-html="//p[contains(text(), 'Your shopping bag is empty')]"></div>
   </body>
 </html>

--- a/getgather/mcp/patterns/revolve-carts-not-signin.html
+++ b/getgather/mcp/patterns/revolve-carts-not-signin.html
@@ -3,9 +3,7 @@
     <title>Revolve Carts</title>
   </head>
   <body>
-    <div
-      gg-match="p:has-text('Your shopping bag is empty.  Start shopping and check out our new arrivals.')"
-    ></div>
+    <div gg-match="//p[contains(text(), 'Your shopping bag is empty')]"></div>
     <a gg-autoclick gg-match="a#js-header-signin-link"></a>
   </body>
 </html>

--- a/getgather/mcp/revolve.py
+++ b/getgather/mcp/revolve.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from getgather.mcp.dpage import dpage_mcp_tool
+from getgather.mcp.dpage import zen_dpage_mcp_tool
 from getgather.mcp.registry import GatherMCP
 
 revolve_mcp = GatherMCP(brand_id="revolve", name="Revolve MCP")
@@ -9,4 +9,4 @@ revolve_mcp = GatherMCP(brand_id="revolve", name="Revolve MCP")
 @revolve_mcp.tool
 async def get_carts() -> dict[str, Any]:
     """Get carts items from Revolve."""
-    return await dpage_mcp_tool("https://www.revolve.com/r/ShoppingBag.jsp", "revolve_cart")
+    return await zen_dpage_mcp_tool("https://www.revolve.com/r/ShoppingBag.jsp", "revolve_cart")


### PR DESCRIPTION
To test, use MCP Inspector and invoke the `revolve_get_carts` tool.