### PR TITLE
Migrate ESPN tool to Zendriver

### DIFF
--- a/getgather/mcp/espn.py
+++ b/getgather/mcp/espn.py
@@ -2,8 +2,8 @@ from typing import Any
 
 from fastmcp import Context
 
-from getgather.mcp.dpage import dpage_mcp_tool
 from getgather.mcp.registry import GatherMCP
+from getgather.zen_distill import short_lived_mcp_tool
 
 espn_mcp = GatherMCP(brand_id="espn", name="ESPN MCP")
 
@@ -11,6 +11,12 @@ espn_mcp = GatherMCP(brand_id="espn", name="ESPN MCP")
 @espn_mcp.tool
 async def get_schedule(ctx: Context) -> dict[str, Any]:
     """Get the week's college football schedule from ESPN."""
-    return await dpage_mcp_tool(
-        "https://www.espn.com/college-football/schedule", "college_football_schedule"
+    terminated, result = await short_lived_mcp_tool(
+        location="https://www.espn.com/college-football/schedule",
+        pattern_wildcard="**/espn-*.html",
+        result_key="college_football_schedule",
+        url_hostname="espn.com",
     )
+    if not terminated:
+        raise ValueError("Failed to retrieve ESPN college football schedule")
+    return result

--- a/tests/mcp/test_espn.py
+++ b/tests/mcp/test_espn.py
@@ -1,0 +1,28 @@
+"""Tests for ESPN Tools: get_schedule."""
+
+import json
+import os
+
+import pytest
+from fastmcp import Client
+from mcp.types import TextContent
+
+config = {
+    "mcpServers": {"getgather": {"url": f"{os.environ.get('HOST', 'http://localhost:23456')}/mcp"}}
+}
+
+
+@pytest.mark.mcp
+@pytest.mark.asyncio
+async def test_espn_get_schedule():
+    """Test get schedule from ESPN."""
+    client = Client(config)
+    async with client:
+        mcp_call_result = await client.call_tool("espn_get_schedule")
+        assert isinstance(mcp_call_result.content[0], TextContent), (
+            f"Expected TextContent, got {type(mcp_call_result.content[0])}"
+        )
+        parsed_mcp_call_result = json.loads(mcp_call_result.content[0].text)
+        schedule = parsed_mcp_call_result.get("college_football_schedule")
+        assert schedule, "Expected 'college_football_schedule' to be non-empty"
+        assert isinstance(schedule, list), f"Expected list, got {type(schedule)}"


### PR DESCRIPTION
To test, use MCP Inspector to invoke `espn_get_schedule` tool.