### PR TITLE
fix: get distilled input value from zendriver element

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -468,7 +468,7 @@ async def distill(hostname: str | None, page: zd.Tab, patterns: list[Pattern]) -
                     if raw_text:
                         target.string = raw_text.strip()
                     if source.tag in ["input", "textarea", "select"]:
-                        target["value"] = source.element.value or ""
+                        target["value"] = source.element.get("value") or ""
                 match_count += 1
             else:
                 optional = target.get("gg-optional") is not None


### PR DESCRIPTION
When using `source.element.value` always get empty value. Resulting distill compare (current & prev) always `False`

Before:
<img width="1061" height="98" alt="Screenshot 2025-11-26 at 16 19 02" src="https://github.com/user-attachments/assets/748f95a8-f2ea-443b-83a4-4209e4cd6981" />

After:
<img width="1058" height="139" alt="Screenshot 2025-11-26 at 16 18 08" src="https://github.com/user-attachments/assets/8fc039ca-8164-40b2-8d1a-f81c816e7e2d" />

Fixes #700