### PR TITLE
fix: Fix slow server shutdown caused by background cleanup task

### DIFF
--- a/getgather/main.py
+++ b/getgather/main.py
@@ -47,7 +47,10 @@ async def lifespan(app: FastAPI):
     async def timer_loop():
         while not stop_event.is_set():
             await cleanup_old_sessions()
-            await asyncio.sleep(5 * 60)  # every 5 minutes
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=5 * 60)
+            except asyncio.TimeoutError:
+                pass  # Timeout = 5 minutes passed, continue loop
 
     background_task = asyncio.create_task(timer_loop())
 


### PR DESCRIPTION
## Problem
When stopping the server (Ctrl+C), shutdown took up to 5 minutes because the background cleanup task used `asyncio.sleep(5 * 60)`, which blocks for the full duration regardless of the `stop_event` being set. The lifespan context manager would wait for the full sleep duration to complete before the server could exit.

## Solution
Replace `asyncio.sleep()` with `asyncio.wait_for(stop_event.wait(), timeout=5*60)`. This waits for either:
- The stop event to be set (immediate shutdown), or
- 5 minutes to elapse (normal cleanup interval)

When `stop_event.set()` is called during shutdown, the wait completes immediately instead of blocking for the remaining sleep time.

## Result
- Server now shuts down instantly on Ctrl+C
- Cleanup still runs every 5 minutes during normal operation
- No change to cleanup behavior, only shutdown responsiveness
