### PR TITLE
add back /api/docs-mcp endpoint

### DIFF
--- a/getgather/api/api.py
+++ b/getgather/api/api.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime
 
 from fastapi import FastAPI
@@ -5,6 +6,7 @@ from fastapi.responses import PlainTextResponse
 from fastapi.routing import APIRoute
 
 from getgather.config import settings
+from getgather.mcp.main import MCPDoc, create_mcp_apps, mcp_app_docs
 
 
 def custom_generate_unique_id(route: APIRoute) -> str:
@@ -28,3 +30,8 @@ def health():
     return PlainTextResponse(
         content=f"API OK {int(datetime.now().timestamp())} GIT_REV: {settings.GIT_REV}"
     )
+
+
+@api_app.get("/docs-mcp")
+async def mcp_docs() -> list[MCPDoc]:
+    return await asyncio.gather(*[mcp_app_docs(mcp_app) for mcp_app in create_mcp_apps()])


### PR DESCRIPTION
/api/docs-mcp is used by mcp-gateway to bootstrap proxy routes