### PR TITLE
Fix ip check order

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -192,7 +192,9 @@ async def init_zendriver_browser(id: str | None = None) -> zd.Browser:
         browser = await _create_zendriver_browser(id)
         try:
             logger.info(f"Validating browser at {CHECK_URL}...")
-            await get_new_page(browser, CHECK_URL)
+            # Create page with proxy setup first, then navigate
+            page = await get_new_page(browser)
+            await page.get(CHECK_URL)
             logger.info(f"Browser validated on attempt {attempt}")
             return browser
         except Exception as e:
@@ -236,8 +238,8 @@ async def terminate_zendriver_browser(browser: zd.Browser):
                 logger.warning(f"Failed to remove {directory}: {e}")
 
 
-async def get_new_page(browser: zd.Browser, location: str = "about:blank") -> zd.Tab:
-    page = await browser.get(location, new_tab=True)
+async def get_new_page(browser: zd.Browser) -> zd.Tab:
+    page = await browser.get("about:blank", new_tab=True)
 
     if blocked_domains is None:
         await load_blocklists()


### PR DESCRIPTION
There was a subtle bug that prevented us from actually getting the IP when doing the check. Basically we would authenticate with the proxy **after** going to the check url. Thus, when we were routing through oxylabs we would get no IP but the system would work since afterwards we would navigate to a blank page and then go to the location. 

This pr fixes that by standardizing the logic to _always_ go to the blank page first and then all navigations (including ip verification) happen after.


**Before:**
<img width="2505" height="1079" alt="Screenshot 2025-12-02 at 11 10 51 AM" src="https://github.com/user-attachments/assets/582e9bb4-06e9-4092-be5e-83a98598d5a0" />

**After**
<img width="1543" height="582" alt="Screenshot 2025-12-02 at 2 03 22 PM" src="https://github.com/user-attachments/assets/461d188d-fe4c-4e3d-b36a-46fa2e374893" />
