### PR TITLE
change element.click to pointerEvent

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -375,6 +375,7 @@ class Element:
                 element.scrollIntoView({{ block: "center" }});
                 element.dispatchEvent(new PointerEvent("pointerdown", {{ bubbles: true }}));
                 element.dispatchEvent(new PointerEvent("pointerup", {{ bubbles: true }}));
+                element.dispatchEvent(new MouseEvent("click", {{ bubbles: true, cancelable: true, view: window }}));
                 return true;
             }})()
             """
@@ -401,6 +402,7 @@ class Element:
                 element.scrollIntoView({{ block: "center" }});
                 element.dispatchEvent(new PointerEvent("pointerdown", {{ bubbles: true }}));
                 element.dispatchEvent(new PointerEvent("pointerup", {{ bubbles: true }}));
+                element.dispatchEvent(new MouseEvent("click", {{ bubbles: true, cancelable: true, view: window }}));
                 return true;
             }})()
             """


### PR DESCRIPTION
somehow `element.click()` not work for some website (eg: https://www.horizonhobby.com/). 

Example: 
1. Open https://www.horizonhobby.com
2. Close popup dialog if present
3. Try using `element.click()`, will not trigger anything
```python
(() => {{
    let element = document.querySelector("div[data-test='account-dropdown'] button[aria-label='Sign In']");
    if (element) { element.click(); return true; }
    return false;
}})()
```
4. Try using pointerEvent, will trigger click
```python
(() => {{
    let element = document.querySelector("div[data-test='account-dropdown'] button[aria-label='Sign In']");
    if (!element) return false;
    element.scrollIntoView({ block: "center" });
    element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
    element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
    return true;
}})()
```


https://github.com/user-attachments/assets/12e99e42-66ef-4ead-bfb5-fa2f65636213

