### PR TITLE
Remove unused AUTH_BEARER_TOKEN

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -15,4 +15,3 @@ HOSTNAME=
 
 # where persisted data is stored
 DATA_DIR=
-AUTH_BEARER_TOKEN=


### PR DESCRIPTION
Since the authenticated API is removed, this env is not needed anymore.