### PR TITLE
optimize amazon purchase tool

### DIFF
--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -490,7 +490,7 @@ async def get_purchase_with_details(page: Page, year: int, start_index: int) -> 
 
 
 @amazon_mcp.tool
-async def dpage_get_purchase_history_optimized(year: str | int | None = None) -> dict[str, Any]:
+async def get_purchase_history_yearly(year: str | int | None = None) -> dict[str, Any]:
     """Get purchase/order history of a amazon with dpage."""
 
     if year is None:


### PR DESCRIPTION
Create a new tool named `dpage_get_purchase_history_optimized` (basically a copy of `dpage_get_purchase_history_with_details` with some adjustments).

Remove the `start_index` parameter, the tool should retrieve all data for the specified year. Using this code to fetch the purchase page. So it does not open a browser tab or execute any js, which helps save resources and speed.

```javascript
await fetch('https://www.amazon.com/gp/css/order-history?disableCsd=no-js&ref_=nav_AccountFlyout_orders&timeFilter=year-{year}&startIndex={start_index}')
```







Comparison using grabbit with Yuxi account (~330 purchases):

Before, took 6 minutes from first purchase to last purchase.
  <details>
  <summary>dpage_get_purchase_history_with_details </summary>
<img width="683" height="305" alt="Screenshot 2025-12-05 at 17 17 58" src="https://github.com/user-attachments/assets/ee0fa4a2-16e9-4bba-9906-1e98896ba1d1" />
  </details>
  



After, took 2 minutes from first purchase to last purchase.
  <details>
  <summary>dpage_get_purchase_history_optimized </summary>
<img width="662" height="299" alt="Screenshot 2025-12-05 at 18 01 55" src="https://github.com/user-attachments/assets/85b3accf-98b0-4ba7-9db2-4b7ba16f9c85" />
  </details>
  


