### PR TITLE
feat(amazon): add pattern for otp email

### DIFF
--- a/getgather/mcp/patterns/amazon-otp-email.html
+++ b/getgather/mcp/patterns/amazon-otp-email.html
@@ -6,7 +6,7 @@
     <span gg-optional gg-match="div#verifyAlerts"></span>
     <span gg-optional gg-match="div#verifyFailureAlerts"></span>
     <h2 gg-match="span:has-text('Enter verification code')">Enter verification code</h2>
-    <span gg-match="div#channelDetailsForOtp span:has-text('your email')"></span>
+    <span gg-optional gg-match="div#channelDetailsForOtp span:has-text('your email')"></span>
     <input autofocus name="otp" type="tel" placeholder="OTP" gg-match="input#input-box-otp" />
     <button type="submit" gg-match="span#cvf-submit-otp-button input[type=submit]">
       Submit code


### PR DESCRIPTION
Based on this snapshot. Email OTP is quite similar with phone. 

<img width="981" height="545" alt="screenshot_2025-12-09_at_17 16 35" src="https://github.com/user-attachments/assets/9a648a43-2ce3-4b0d-960e-e620c1ba3085" />
