### PR TITLE
feat: reuse given page for run_distillation_loop

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -495,6 +495,7 @@ async def run_distillation_loop(
     interactive: bool = True,
     stop_ok: bool = False,
     close_page: bool = False,
+    page: Page | None = None,
 ) -> tuple[bool, str, ConversionResult | None]:
     """Run the distillation loop.
 
@@ -513,7 +514,7 @@ async def run_distillation_loop(
     profile = browser_profile or BrowserProfile()
 
     async with browser_session(profile, stop_ok=stop_ok) as session:
-        page = await session.new_page()
+        page = page or await session.new_page()
 
         logger.info(f"Starting browser {profile.id}")
         logger.info(f"Navigating to {location}")

--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -213,7 +213,7 @@ async def dpage_get_purchase_history_with_details(
             browser_profile=browser_profile,
             interactive=False,
             timeout=2,
-            close_page=True,
+            page=page,
         )
         if orders is None:
             return {"amazon_purchase_history": []}

--- a/getgather/mcp/amazonca.py
+++ b/getgather/mcp/amazonca.py
@@ -79,7 +79,7 @@ async def dpage_get_purchase_history_with_details(
             browser_profile=browser_profile,
             interactive=False,
             timeout=2,
-            stop_ok=False,
+            page=page,
         )
         if orders is None:
             return {"amazon_purchase_history": []}


### PR DESCRIPTION
Currently, the Amazon tool uses `run_distillation_loop` inside their custom action. Because of that, `run_distillation_loop` always opens a new tab, resulting in two active tabs (one from the custom action and one from `run_distillation_loop`), which consumes more resources.
With this change, the page can be reused inside `run_distillation_loop`, so it will use the same page and save resources.