### PR TITLE
Remove APP_NAME configuration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,5 @@
 # Application Settings
 ENVIRONMENT=local
-APP_NAME=getgather-local
 LOG_LEVEL=DEBUG
 
 # Logging

--- a/getgather/config.py
+++ b/getgather/config.py
@@ -15,7 +15,6 @@ class Settings(BaseSettings):
         env_file=PROJECT_DIR / ".env", env_ignore_empty=True, extra="ignore"
     )
     ENVIRONMENT: str = "local"
-    APP_NAME: str = "getgather-local"
     LOG_LEVEL: str = "INFO"
     GIT_REV: str = ""
     LOGFIRE_TOKEN: str = ""


### PR DESCRIPTION
It was briefly used for the analytics, which has been removed since then.