### PR TITLE
fix: make whatsapp pattern more unique

### DIFF
--- a/getgather/mcp/patterns/amazon-verify-with-whatsapp.html
+++ b/getgather/mcp/patterns/amazon-verify-with-whatsapp.html
@@ -1,8 +1,11 @@
-<html gg-domain="amazon">
+<html gg-domain="amazon" gg-priority="3">
   <head>
     <title>Verify with WhatsApp</title>
   </head>
   <body>
+    <div
+      gg-match="div.a-alert-content div.cvf-alert-section:has-text('unable to send an SMS')"
+    ></div>
     <div gg-autoclick gg-match="span#whatsapp-button input[type='submit']">
       Verify with WhatsApp
     </div>


### PR DESCRIPTION

Currently the pattern will also auto-click this page
<img width="359" height="467" alt="Screenshot 2025-12-18 at 09 39 29" src="https://github.com/user-attachments/assets/cfdddb6e-5b91-4587-9fc1-a9a78f43e508" />


Our expectation is auto-click only run when this page occur
<img width="689" height="420" alt="Screenshot 2025-12-18 at 09 40 14" src="https://github.com/user-attachments/assets/9cdfb802-45b0-4992-b46c-12643c9baf1c" />
