### PR TITLE
fix: render the page when prev and current distilled still same after timeout

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -240,7 +240,9 @@ async def post_dpage(id: str, request: Request) -> HTMLResponse:
 
         if match.distilled == current.distilled:
             logger.info(f"Still the same: {match.name}")
-            if iteration == max - 1 and len(inputs) > 0:
+            has_inputs = len(inputs) > 0
+            max_reached = iteration == max - 1
+            if max_reached and has_inputs:
                 logger.info("Still the same after timeout and need inputs, render the page...")
                 return HTMLResponse(render(str(document.find("body")), options))
             continue


### PR DESCRIPTION
https://heyario.sentry.io/issues/7118213904/events/064567fe258b4df1aacbfc0f0b939783/?project=4509832551858176

Currently, when we receive the same page, the distillation loop continues without any condition. Because of this, if a user receives the same page multiple times (e.g., entering the wrong email repeatedly), the user will eventually see a “Timeout Reached” page.

With this fix, we will still render the distilled page if the page requires user input and the timeout is reached due to receiving the same page again (i.e., the previous and current pages are the same).
