### PR TITLE
feat: reload page when error pattern detected

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -388,7 +388,9 @@ def load_distillation_patterns(path: str) -> list[Pattern]:
     return patterns
 
 
-async def distill(hostname: str | None, page: Page, patterns: list[Pattern]) -> Match | None:
+async def distill(
+    hostname: str | None, page: Page, patterns: list[Pattern], reload_on_error: bool = True
+) -> Match | None:
     result: list[Match] = []
 
     for item in patterns:
@@ -483,6 +485,16 @@ async def distill(hostname: str | None, page: Page, patterns: list[Pattern]) -> 
             logger.debug(f" - {item.name} with priority {item.priority}")
         match = result[0]
         logger.info(f"✓ Best match: {match.name}")
+
+        if reload_on_error and (
+            "err-timed-out" in match.name
+            or "err-ssl-protocol-error" in match.name
+            or "err-tunnel-connection-failed" in match.name
+        ):
+            logger.info(f"Error pattern detected: {match.name}")
+            await page.reload(timeout=settings.BROWSER_TIMEOUT, wait_until="domcontentloaded")
+            logger.info("Retrying distillation after error...")
+            return await distill(hostname, page, patterns, reload_on_error=False)
         return match
 
 

--- a/getgather/mcp/patterns/err-ssl-protocol-error.html
+++ b/getgather/mcp/patterns/err-ssl-protocol-error.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>Error: SSL Protocol Error</title>
+  </head>
+  <body>
+    <div gg-match="div#main-message p:has-text('sent an invalid response')"></div>
+    <div gg-match="div.error-code:has-text('ERR_SSL_PROTOCOL_ERROR')"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/err-timed-out.html
+++ b/getgather/mcp/patterns/err-timed-out.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>Error: Timed Out</title>
+  </head>
+  <body>
+    <div gg-match="div#main-message p:has-text('took too long to respond')"></div>
+    <div gg-match="div.error-code:has-text('ERR_TIMED_OUT')"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/err-tunnel-connection-failed.html
+++ b/getgather/mcp/patterns/err-tunnel-connection-failed.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <title>Error: Tunnel Connection Failed</title>
+  </head>
+  <body>
+    <div
+      gg-match="div#main-message p:has-text('might be temporarily down or it may have moved permanently to a new web address')"
+    ></div>
+    <div gg-match="div.error-code:has-text('ERR_TUNNEL_CONNECTION_FAILED')"></div>
+  </body>
+</html>


### PR DESCRIPTION
Related error:
[ERR_TUNNEL_CONNECTION_FAILED](https://heyario.sentry.io/issues/7118213904/events/24dead166126446c9f47c6505d66e987/?project=4509832551858176)
[ERR_SSL_PROTOCOL_ERROR](https://heyario.sentry.io/issues/7118213904/events/d6b8d74b9498438a98f1571177a306d7/?project=4509832551858176) 
[ERR_TIMED_OUT](https://heyario.sentry.io/issues/7118213904/events/e6938066cbb9490c98e713d44fe73abe/) 

Currently, when we receive those error page, the distillation/dpage process Timeout because no pattern is detected.
However, when I manually reload the browser, the error disappears.
So in this PR, I 'reload' the page when those patterns are detected.


<details>
  <summary>Error Page</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/97070c1b-bc5a-4147-91b7-c220d16f00e6" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a504d499-fb8a-4c28-aaf5-1c7e8fd956be" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b7e4e2bd-0ff7-4ac2-a006-95e906152e07" />


</details>
