### PR TITLE
fix: improve error handling in order details retrieval

### DIFF
--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -439,6 +439,12 @@ async def get_purchase_history_yearly(year: str | int | None = None) -> dict[str
             order_details_list = await asyncio.gather(
                 *[get_order_details(order) for order in orders], return_exceptions=True
             )
+
+            for i, item in enumerate(order_details_list):
+                if isinstance(item, BaseException):
+                    order_id = orders[i]["order_id"]
+                    logger.warning(f"Error getting order details for order: {order_id}: {item}")
+
             order_details = {
                 item["order_id"]: item
                 for item in order_details_list
@@ -693,6 +699,12 @@ async def get_purchase_history_with_details(
             order_details_list = await asyncio.gather(
                 *[get_order_details(order) for order in orders], return_exceptions=True
             )
+
+            for i, item in enumerate(order_details_list):
+                if isinstance(item, BaseException):
+                    order_id = orders[i]["order_id"]
+                    logger.warning(f"Error getting order details for order: {order_id}: {item}")
+
             order_details = {
                 item["order_id"]: item
                 for item in order_details_list


### PR DESCRIPTION
Will resolve this kind of error where the whole process is stopped because of a single error from a single `page.evaluate()`

https://heyario.sentry.io/issues/7119367965/events/465c49e4825842f4a7b77b85a0191d49/

## How this was tested
<img width="1103" height="399" alt="Cursor 2025-12-18 16 33 26" src="https://github.com/user-attachments/assets/1a7b689e-fb99-4d96-ab84-226b5bc8021c" />

## Result
<img width="3077" height="2040" alt="Firefox Developer Edition 2025-12-18 16 35 22" src="https://github.com/user-attachments/assets/7ff11dd6-7af8-4490-9e9a-c1d61f893554" />

