### PR TITLE
fix(amazon): removing title and directly use the alert content

### DIFF
--- a/getgather/mcp/patterns/amazon-signin-email-only.html
+++ b/getgather/mcp/patterns/amazon-signin-email-only.html
@@ -5,7 +5,8 @@
   <body>
     <span gg-optional gg-match="div#auth-email-missing-alert"></span>
     <span gg-optional gg-match="div#auth-email-invalid-claim-alert"></span>
-    <span gg-optional gg-match="div#auth-error-message-box"></span>
+    <span gg-optional gg-match="div#auth-error-message-box div.a-alert-content"></span>
+
     <input
       autofocus
       name="email"


### PR DESCRIPTION
AT

<img width="569" height="371" alt="Screenshot 2025-12-18 at 19 23 31" src="https://github.com/user-attachments/assets/0e0fb1b0-7caa-4e54-a513-83b463d746c1" />
