### PR TITLE
fix nordstrom pattern to show where the code is sent to

### DIFF
--- a/getgather/mcp/patterns/nordstrom-mfa.html
+++ b/getgather/mcp/patterns/nordstrom-mfa.html
@@ -6,7 +6,13 @@
   <body>
     <h1 gg-match="//span[contains(text(), 'Enter your code to sign in')]"></h1>
     <span gg-optional gg-match="span[data-cy='hit-a-snag-error']"></span>
-    <div gg-optional gg-match="//section/div[contains(., 'We sent a code to:')]"></div>
+    <div>
+      <div gg-optional gg-match="//section/div[contains(., 'We sent a code to:')]"></div>
+      <strong
+        gg-optional
+        gg-match="//section/div[contains(., 'We sent a code to:')]/div/strong"
+      ></strong>
+    </div>
     <input
       inputmode="numeric"
       autofocus


### PR DESCRIPTION
<img width="676" height="780" alt="Screenshot 2025-12-19 at 12 11 01" src="https://github.com/user-attachments/assets/5463f6cc-1c9a-4d99-a685-2f4d18db0c5d" />
<img width="615" height="565" alt="Screenshot 2025-12-19 at 12 09 29" src="https://github.com/user-attachments/assets/020549bc-24ba-493b-9f26-739695b782e8" />
