### PR TITLE
fix: use same zen browser if exists

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -185,6 +185,14 @@ async def _create_zendriver_browser(id: str | None = None) -> zd.Browser:
 
 
 async def init_zendriver_browser(id: str | None = None) -> zd.Browser:
+    from getgather.mcp.dpage import incognito_browsers
+
+    if id is not None:
+        if id in incognito_browsers:
+            return incognito_browsers[id]
+        else:
+            raise ValueError(f"Browser profile for signin {id} not found")
+
     MAX_ATTEMPTS = 3
     LIVE_CHECK_URL = "https://ip.fly.dev/all"
     IP_ONLY_CHECK_URL = "https://ip.fly.dev/ip"


### PR DESCRIPTION
Currently, we always create a new browser instance when using `x-incognito` + `x-signin-id`. With this fix, the same browser profile will be reused when `x-signin-id` is present.

End-to-end test with Lilalane

<img width="1219" height="1015" alt="Screenshot 2025-12-19 at 14 36 27" src="https://github.com/user-attachments/assets/92f74116-3b5d-42bd-8b40-925f3e7d42bd" />
