### PR TITLE
fix: respect the configured level logger & add sse_starlette to log handler

### DIFF
--- a/getgather/logs.py
+++ b/getgather/logs.py
@@ -128,3 +128,4 @@ def setup_logging(level: str = "INFO", logs_dir: Path | None = None):
         lib_logger = logging.getLogger(logger_name)
         lib_logger.handlers = [InterceptHandler()]
         lib_logger.propagate = False
+        lib_logger.setLevel(level)


### PR DESCRIPTION
## Problem
External libraries like `sse_starlette` were emitting DEBUG logs such as:
```
ping: b'• ping • 2025-12-22 02:25:50.723316+00:00\r\n\r\n'
```

<img width="1729" height="99" alt="image" src="https://github.com/user-attachments/assets/62d99418-76c3-4924-afa7-1364bf34e6b3" />

it prints so many logs, until our free plan exceeded on the logfire

<img width="971" height="408" alt="image" src="https://github.com/user-attachments/assets/b70a36cd-4441-47a6-9a01-2e916f334e93" />

## Solution
- Added `sse_starlette` to the list of managed external loggers
- Set `lib_logger.setLevel(level)` to make external libraries respect the configured log level

## Source
The `ping:` log was coming from `.venv/lib/python3.11/site-packages/sse_starlette/sse.py:236`:
```python
logger.debug("ping: %s", ping_bytes)
```
