### PR TITLE
add amazon pattern to select personal account

### DIFF
--- a/getgather/mcp/patterns/amazon-select-personal-account.html
+++ b/getgather/mcp/patterns/amazon-select-personal-account.html
@@ -1,0 +1,16 @@
+<html gg-domain="amazon" gg-priority="3">
+  <head>
+    <title>Select Account</title>
+  </head>
+  <body>
+    <div
+      gg-match="h2#cvf-filtered-account-switcher-header-text:has-text('Which account do you want to use?')"
+    ></div>
+    <div
+      gg-autoclick
+      gg-match="div[data-test-id='switchableAccounts'] span[data-test-id='accountType']:has-text('Personal account')"
+    >
+      Personal account
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
New amazon pattern, if we have multiple account type, we should select one first.


<img width="537" height="388" alt="image" src="https://github.com/user-attachments/assets/63713894-e59f-4fcc-a0b4-b108d665eb08" />
