### PR TITLE
hide element with empty text on distillation page

### DIFF
--- a/getgather/mcp/html_renderer.py
+++ b/getgather/mcp/html_renderer.py
@@ -172,6 +172,11 @@ def render_form(content: str, title: str = DEFAULT_TITLE, action: str = "") -> s
         flex-direction: column;
         gap: 1rem;
       }}
+      
+    .content-wrapper
+      :is(a, div, p, span, h1, h2, h3, h4, h5, h6):empty {{
+      display: none;
+    }}
 
       @media (max-width: 640px) {{
         .card {{


### PR DESCRIPTION
close #820 

Before:
<img width="614" height="482" alt="Screenshot 2025-12-25 at 17 52 03" src="https://github.com/user-attachments/assets/945e6f23-0dbe-435e-be21-6a57ae9f1afb" />

After:
<img width="597" height="309" alt="Screenshot 2025-12-25 at 17 49 20" src="https://github.com/user-attachments/assets/60acbfaf-ade2-4ce9-a5bc-8d444e7b2726" />
