### PR TITLE
fix amazon continue pattern

### DIFF
--- a/getgather/mcp/patterns/amazon-continue-shopping.html
+++ b/getgather/mcp/patterns/amazon-continue-shopping.html
@@ -4,7 +4,6 @@
   </head>
   <body>
     <h4 gg-match="//h4[contains(text(), 'Click the button below to continue shopping')]"></h4>
-    <div gg-match="form[action='/errors/continue-shopping']"></div>
-    <div type="submit" gg-autoclick gg-match="button:has-text('Continue shopping')"></div>
+    <div gg-autoclick gg-match="//button[contains(text(), 'Continue shopping')]"></div>
   </body>
 </html>


### PR DESCRIPTION
- remove gg-match `form[action]` (can have different value)
- change has-text to xpath
- 
<img width="1350" height="690" alt="image" src="https://github.com/user-attachments/assets/b6ec82f7-c640-4369-8d1d-26bcab7513f8" />
