### PR TITLE
feat: handle error pattern on custom action

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -379,6 +379,15 @@ async def terminate(distilled: str) -> bool:
     return False
 
 
+async def check_error(distilled: str) -> bool:
+    document = BeautifulSoup(distilled, "html.parser")
+    errors = document.find_all(attrs={"gg-error": True})
+    if len(errors) > 0:
+        logger.info("Found error elements...")
+        return True
+    return False
+
+
 def load_distillation_patterns(path: str) -> list[Pattern]:
     patterns: list[Pattern] = []
     for name in glob(path, recursive=True):

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -19,6 +19,7 @@ from getgather.distill import (
     Match,
     autoclick,
     capture_page_artifacts,
+    check_error,
     convert,
     distill,
     get_incognito_browser_profile,
@@ -522,9 +523,10 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
 
         if await terminate(distilled):
             logger.info("Finished!")
-            converted = await convert(distilled)
 
-            if id in pending_actions:
+            error = await check_error(distilled)
+
+            if id in pending_actions and not error:
                 action_info = pending_actions[id]
                 logger.info(f"Signin completed for {id}, resuming action...")
 
@@ -542,6 +544,7 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                 await dpage_close(id)
                 return HTMLResponse(render(FINISHED_MSG, options))
 
+            converted = await convert(distilled)
             await dpage_close(id)
             if converted is not None:
                 print(converted)

--- a/getgather/mcp/patterns/amazon-create-new-password-required.html
+++ b/getgather/mcp/patterns/amazon-create-new-password-required.html
@@ -3,7 +3,11 @@
     <title>Create new password required</title>
   </head>
   <body>
-    <h1 gg-stop gg-match-html="//h1[contains(., 'Create new password')]"></h1>
+    <h1
+      gg-stop
+      gg-error="reset_password"
+      gg-match-html="//h1[contains(., 'Create new password')]"
+    ></h1>
     <span gg-match="//span.a-button-inner[contains(., 'Save changes and Sign-In')]"></span>
   </body>
 </html>

--- a/getgather/mcp/patterns/amazon-password-reset-required.html
+++ b/getgather/mcp/patterns/amazon-password-reset-required.html
@@ -5,7 +5,7 @@
   <body>
     <h2
       gg-stop
-      gg-stop="reset_password"
+      gg-error="reset_password"
       gg-match-html="//h2[contains(normalize-space(.), 'Password reset required')]"
     >
       Password reset required


### PR DESCRIPTION
Currently, `zen_dpage_with_action` runs a custom action after sign-in or `gg-stop` element is detected. However, not all patterns containing `gg-stop` indicate a successful sign-in. In such cases, we should not execute the custom action when the user is not authenticated.

To address this, we introduce an additional indicator to differentiate between successful and unsuccessful sign-in patterns. This PR adds a `gg-error` element. On the frontend side (e.g., Grabbit/Twinpersona), the error can be read to determine the next action ([see](https://github.com/gather-engineering/demos/blob/main/apps/twin-persona/src/server/services/brand.service.ts#L312-L322)).

Examples:
- If a captcha pattern is detected, Grabbit can re-initiate the connection (in some cases, launching a new browser profile resolves the captcha).
- If a “reset password required” pattern is detected, the message can be surfaced to the user.

⚠️ Note: This approach is not considered best practice and should be improved in the future. However, it effectively addresses the current requirement.