### PR TITLE
fix: wrap browser cleanup inside try catch

### DIFF
--- a/getgather/main.py
+++ b/getgather/main.py
@@ -46,8 +46,14 @@ async def lifespan(app: FastAPI):
 
     async def timer_loop():
         while not stop_event.is_set():
-            await cleanup_old_sessions()
-            await browser_manager.cleanup_incognito_browsers()
+            try:
+                await cleanup_old_sessions()
+            except Exception as e:
+                logger.error(f"Error in cleanup_old_sessions: {e}", exc_info=True)
+            try:
+                await browser_manager.cleanup_incognito_browsers()
+            except Exception as e:
+                logger.error(f"Error in cleanup_incognito_browsers: {e}", exc_info=True)
             try:
                 await asyncio.wait_for(stop_event.wait(), timeout=5 * 60)
             except asyncio.TimeoutError:


### PR DESCRIPTION
Not sure why the timer no longer seems to run after the first Zendriver browser terminates, so let’s add a try-catch for now.

<img width="975" height="128" alt="Screenshot 2026-01-08 at 14 58 02" src="https://github.com/user-attachments/assets/bfee32a9-7aac-41c6-a8ca-118cd7344c15" />
