### PR TITLE
fix: cleanup browser on success or failed terminate zendriver browser

### DIFF
--- a/getgather/mcp/browser.py
+++ b/getgather/mcp/browser.py
@@ -113,10 +113,11 @@ class BrowserManager:
                         logger.warning(f"Signin ID {signin_id} not found, skipping termination")
                         continue
                     await terminate_zendriver_browser(browser)
-                    self.remove_incognito_browser(signin_id)
                     logger.info(f"Successfully stopped browser with signin ID {signin_id}")
                 except Exception as e:
                     logger.error(f"Failed to stop browser with signin ID {signin_id}: {e}")
+                finally:
+                    self.remove_incognito_browser(signin_id)
 
 
 browser_manager = BrowserManager()


### PR DESCRIPTION
solve [this](https://heyario.sentry.io/issues/7174028760/?environment=production&project=4509832551858176&query=is%3Aunresolved&referrer=issue-stream)