### PR TITLE
add dpage_timeout for custom dpage tick timeout

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -490,7 +490,7 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
     logger.debug(f"Available distillation patterns: {len(patterns)}")
 
     TICK = 1  # seconds
-    TIMEOUT = 15  # seconds
+    TIMEOUT = pending_actions.get(id, {}).get("dpage_timeout", 15)  # seconds
     max = TIMEOUT // TICK
 
     current = Match(name="", priority=-1, distilled="")
@@ -830,6 +830,7 @@ async def zen_dpage_with_action(
     initial_url: str,
     action: Any,
     timeout: int = 2,
+    dpage_timeout: int = 15,
     _signin_completed: bool = False,
     _page_id: str | None = None,
 ) -> dict[str, Any]:
@@ -912,6 +913,7 @@ async def zen_dpage_with_action(
         "timeout": timeout,
         "page_id": id,
         "browser": browser_instance,
+        "dpage_timeout": dpage_timeout,
     }
 
     if incognito:

--- a/getgather/mcp/nordstrom.py
+++ b/getgather/mcp/nordstrom.py
@@ -97,4 +97,5 @@ async def get_order_history(page_number: int = 1) -> dict[str, Any]:
     return await zen_dpage_with_action(
         "https://www.nordstrom.com/my-account",
         get_order_details_action,
+        dpage_timeout=60,
     )

--- a/getgather/mcp/patterns/nordstrom-unusual-activity.html
+++ b/getgather/mcp/patterns/nordstrom-unusual-activity.html
@@ -3,7 +3,9 @@
     <title>Nordstrom Unusual Activity</title>
   </head>
   <body>
-    <h1 gg-stop gg-match-html="h1.header">We've noticed some unusual activity</h1>
+    <h1 gg-stop gg-error="unusual_activity" gg-match-html="h1.header">
+      We've noticed some unusual activity
+    </h1>
     <p gg-match-html="p.copy">Contact Customer Service at 1.888.282.6060</p>
   </body>
 </html>


### PR DESCRIPTION
In the current condition, when the website we access is an SPA, `dpage` will continuously run the tick even while the page is still in a loading state. In some cases, Nordstrom’s loading time can exceed 15 seconds, so we need a way to increase the timeout.