### PR TITLE
feat: handle error pattern on custom action

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -249,9 +249,9 @@ async def post_dpage(id: str, request: Request) -> HTMLResponse:
 
         if await terminate(distilled):
             logger.info("Finished!")
-            converted = await convert(distilled)
+            error = await check_error(distilled)
 
-            if id in pending_actions:
+            if id in pending_actions and not error:
                 action_info = pending_actions[id]
                 logger.info(f"Signin completed for {id}, resuming action...")
 
@@ -269,6 +269,7 @@ async def post_dpage(id: str, request: Request) -> HTMLResponse:
                 await dpage_close(id)
                 return HTMLResponse(render(FINISHED_MSG, options))
 
+            converted = await convert(distilled)
             await dpage_close(id)
             if converted is not None:
                 print(converted)


### PR DESCRIPTION
Porting [this](https://github.com/remotebrowser/mcp-getgather/pull/871)

Since we use Patchright for Amazon, we also need to porting these code.