### PR TITLE
fix: improve zen distillation speed by separating iframe selector

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -575,8 +575,11 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
         for input in inputs:
             if isinstance(input, Tag):
                 gg_match = input.get("gg-match")
+                selector, frame_selector = get_selector(
+                    str(gg_match) if gg_match is not None else ""
+                )
                 element = await page_query_selector(
-                    page, selector=str(gg_match) if gg_match is not None else ""
+                    page, selector if selector is not None else "", iframe_selector=frame_selector
                 )
                 name = input.get("name")
                 input_type = input.get("type")
@@ -609,8 +612,12 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                                 continue
                             logger.info(f"Handling radio button group {name}")
                             logger.info(f"Using form data {name}={value}")
+                            radio_gg_match = str(radio.get("gg-match"))
+                            selector, frame_selector = get_selector(radio_gg_match)
                             radio_element = await page_query_selector(
-                                page, selector=str(radio.get("gg-match"))
+                                page,
+                                selector if selector is not None else "",
+                                iframe_selector=frame_selector,
                             )
                             if radio_element:
                                 await radio_element.click()

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -637,7 +637,9 @@ class Element:
             logger.error(f"JavaScript XPath click failed: {js_error}")
 
 
-async def page_query_selector(page: zd.Tab, selector: str, timeout: float = 0) -> Element | None:
+async def page_query_selector(
+    page: zd.Tab, selector: str, timeout: float = 0, iframe_selector: str | None = None
+) -> Element | None:
     try:
         if selector.startswith("//"):
             elements = await page.xpath(selector, timeout)
@@ -647,20 +649,19 @@ async def page_query_selector(page: zd.Tab, selector: str, timeout: float = 0) -
                     return element
             return None
 
-        try:
-            element = await page.select(selector, timeout=timeout)
-            if element:
-                element = Element(element, css_selector=selector)
-                if await element.is_visible():
-                    return element
-            return None
-        except (asyncio.TimeoutError, Exception):
+        if iframe_selector is not None:
             element = await page.select_all(selector, timeout=timeout, include_frames=True)
             if element and len(element) > 0:
                 element = Element(element[0], css_selector=selector)
                 if await element.is_visible():
                     return element
-            return None
+        else:
+            element = await page.select(selector, timeout=timeout)
+            if element:
+                element = Element(element, css_selector=selector)
+                if await element.is_visible():
+                    return element
+        return None
     except (asyncio.TimeoutError, Exception):
         return None
 
@@ -705,12 +706,12 @@ async def distill(
                 break
 
             html = target.get("gg-match-html")
-            selector, _ = get_selector(str(html if html else target.get("gg-match")))
+            selector, iframe_selector = get_selector(str(html if html else target.get("gg-match")))
 
             if not selector:
                 continue
 
-            source = await page_query_selector(page, selector)
+            source = await page_query_selector(page, selector, iframe_selector=iframe_selector)
             if source:
                 match_count += 1
                 if html:
@@ -773,9 +774,9 @@ async def autoclick(page: zd.Tab, distilled: str, expr: str):
     document = BeautifulSoup(distilled, "html.parser")
     elements = document.select(expr)
     for el in elements:
-        selector, _ = get_selector(str(el.get("gg-match")))
+        selector, iframe_selector = get_selector(str(el.get("gg-match")))
         if selector:
-            target = await page_query_selector(page, selector)
+            target = await page_query_selector(page, selector, iframe_selector=iframe_selector)
             if target:
                 logger.debug(f"Clicking {selector}")
                 await target.click()


### PR DESCRIPTION
In `page_query_selector`, we currently always use `page.select`, and if no element is found, we fall back to `page.select_all` (to also search inside iframes). However, this leads to slower performance because `select_all` is always attempted, even though it is only needed for iframe searches.

This change improves performance by separating the logic into different functions. If iframe search is not required, we only use `page.select`.