### PR TITLE
WIP: [EXPERIMENT]Separate captcha handling from error handling

### DIFF
--- a/getgather/distill.py
+++ b/getgather/distill.py
@@ -396,6 +396,12 @@ async def check_error(distilled: str) -> bool:
     return False
 
 
+async def check_captcha(distilled: str) -> bool:
+    document = BeautifulSoup(distilled, "html.parser")
+    captchas = document.find_all(attrs={"gg-captcha": True})
+    return len(captchas) > 0
+
+
 def load_distillation_patterns(path: str) -> list[Pattern]:
     patterns: list[Pattern] = []
     for name in glob(path, recursive=True):

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -19,6 +19,7 @@ from getgather.distill import (
     Match,
     autoclick,
     capture_page_artifacts,
+    check_captcha,
     check_error,
     convert,
     distill,
@@ -270,6 +271,9 @@ async def post_dpage(id: str, request: Request) -> HTMLResponse:
                 return HTMLResponse(render(FINISHED_MSG, options))
 
             converted = await convert(distilled)
+            if await check_captcha(distilled):
+                logger.info("Captcha detected, keeping browser alive...")
+                return HTMLResponse(render("CAPTCHA DETECTED", options))
             await dpage_close(id)
             if converted is not None:
                 print(converted)
@@ -554,6 +558,9 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                 return HTMLResponse(render(FINISHED_MSG, options))
 
             converted = await convert(distilled)
+            if await check_captcha(distilled):
+                logger.info("Captcha detected, keeping browser alive...")
+                return HTMLResponse(render("CAPTCHA DETECTED", options))
             await dpage_close(id)
             if converted is not None:
                 print(converted)

--- a/getgather/mcp/patterns/amazon-captcha-frame.html
+++ b/getgather/mcp/patterns/amazon-captcha-frame.html
@@ -5,7 +5,7 @@
   <body>
     <h1
       gg-stop
-      gg-error="captcha"
+      gg-captcha
       gg-match-html="iframe[id='cvf-aamation-challenge-iframe'] h1#aacb-captcha-header"
     >
       Solve this puzzle to protect your account

--- a/getgather/mcp/patterns/amazon-captcha.html
+++ b/getgather/mcp/patterns/amazon-captcha.html
@@ -3,7 +3,7 @@
     <title>Amazon Captcha</title>
   </head>
   <body>
-    <h1 gg-stop gg-error="captcha" gg-match-html="h1#aacb-captcha-header">
+    <h1 gg-stop gg-captcha gg-match-html="h1#aacb-captcha-header">
       Solve this puzzle to protect your account
     </h1>
   </body>


### PR DESCRIPTION
## Problem

Previously captcha handler was included in error handler via `gg-error="captcha"`, but this causes issues:

1. Regular errors (like `gg-error="account_not_found"`) were treated the same as captcha
2. When captcha is detected, the browser should stay alive so user can solve it
3. But error handling would close the browser and return "Finished!"

## Solution

1. Added new `gg-captcha` boolean attribute (replaces `gg-error="captcha"`)
2. Added `check_captcha()` function in `distill.py`
3. Updated `dpage.py` to check for `gg-captcha` separately from `gg-error`
4. Browser now stays alive when captcha is detected, allowing user to solve it in-browser

## Files Changed

- `getgather/distill.py` - Added `check_captcha()` function
- `getgather/mcp/dpage.py` - Imported and integrated captcha checking
- `getgather/mcp/patterns/amazon-captcha.html` - Updated attribute
- `getgather/mcp/patterns/amazon-captcha-frame.html` - Updated attribute