### PR TITLE
refactor(amazon): change match pattern using xpath for undetectable css selector 

### DIFF
--- a/getgather/mcp/patterns/amazon-something-error.html
+++ b/getgather/mcp/patterns/amazon-something-error.html
@@ -3,7 +3,11 @@
     <title>Amazon Something Error</title>
   </head>
   <body>
-    <h1 gg-stop gg-error="something_error" gg-match-html="//div[@id='g']//a[contains(@href, 'cs_503_link')]">
+    <h1
+      gg-stop
+      gg-error="something_error"
+      gg-match-html="//div[@id='g']//a[contains(@href, 'cs_503_link')]"
+    >
       Sorry! Something went wrong on our end. Please go back and try again or go to Amazon's home
       page.
     </h1>


### PR DESCRIPTION
Somehow this pattern isn't detected 

![54242085808b-4eeivqm3_distill_error_20260115_022303_rRn5Y](https://github.com/user-attachments/assets/1ea33fd3-b239-46f6-a8c0-3103660f08df)

I think we might want to use xpath for this and look a bit closely. 