### PR TITLE
feat(amazon): targetting iframe id for Captcha

### DIFF
--- a/getgather/mcp/patterns/amazon-arkose-challenge.html
+++ b/getgather/mcp/patterns/amazon-arkose-challenge.html
@@ -1,0 +1,14 @@
+<html gg-domain="amazon">
+  <head>
+    <title>Amazon Arkose Challenge</title>
+  </head>
+  <body>
+    <div
+      gg-stop
+      gg-error="captcha"
+      gg-match-html="iframe#cvf-aamation-challenge-iframe[title='verification puzzle']"
+    >
+      Solve this puzzle to protect your account
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Here’s the link to the issue: https://heyario.sentry.io/issues/7119287307/events/adf4565d20b64f098b6a911f039cc34d/attachments/?project=4509832551858176.

Currently, we can’t detect the Amazon CAPTCHA because the pattern isn’t recognized by the pattern file. For now, the current file targets the ID directly, which should hopefully cover the existing condition.