### PR TITLE
Enable fetch domain in all cases

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -393,6 +393,8 @@ async def get_new_page(browser: zd.Browser) -> zd.Tab:
             else:
                 raise
 
+    # Enable fetch domain to intercept requests. Will be overridden if proxy auth is set up.
+    await page.send(zd.cdp.fetch.enable())
     page.add_handler(zd.cdp.fetch.RequestPaused, handle_request)  # type: ignore[reportUnknownMemberType]
 
     id = cast(str, browser.id)  # type: ignore[attr-defined]


### PR DESCRIPTION
[This sentry error](https://heyario.sentry.io/issues/7063675363/?environment=production&project=4509832551858176&query=is%3Aunresolved&referrer=issue-stream) has to do with sometimes our code path doesn't enable the fetch domain which is needed for interceptions (like for blocking). This makes sure it's always enabled. 

[This](https://py-cdp.readthedocs.io/en/latest/api/fetch.html#commands) is good reference