### PR TITLE
Use Zendriver to get the IP address for the extended health check

### DIFF
--- a/getgather/main.py
+++ b/getgather/main.py
@@ -1,3 +1,4 @@
+import ast
 import asyncio
 import json
 import socket
@@ -18,13 +19,11 @@ from fastapi.responses import (
 from fastapi.routing import APIRoute
 from fastapi.staticfiles import StaticFiles
 
-from getgather.browser.profile import BrowserProfile
-from getgather.browser.session import BrowserSession
 from getgather.browser.session_cleanup import cleanup_old_sessions
 from getgather.config import settings
 from getgather.logs import logger
 from getgather.mcp.browser import browser_manager
-from getgather.mcp.dpage import router as dpage_router
+from getgather.mcp.dpage import router as dpage_router, zen_dpage_mcp_tool
 from getgather.mcp.main import MCPDoc, create_mcp_apps, mcp_app_docs
 from getgather.startup import startup
 
@@ -202,17 +201,17 @@ IP_CHECK_URL: Final[str] = "https://ip.fly.dev/ip"
 
 @app.get("/extended-health")
 async def extended_health():
-    session = BrowserSession.get(BrowserProfile())
     try:
-        session = await session.start()
-        page = await session.page()
-        await page.goto(IP_CHECK_URL, timeout=3000)
-        ip_text: str = await page.evaluate("() => document.body.innerText.trim()")
+        result = await zen_dpage_mcp_tool(
+            initial_url="https://ip.fly.dev/ip", result_key="ip_address", timeout=3
+        )
+        ip_text = str(result.get("ip_address", "Unknown"))[:100]
+        ip_list = ast.literal_eval(ip_text)
+        ip_address = ip_list[0]["ip_address"]
+        logger.debug(f"IP address: {ip_address}")
+        return PlainTextResponse(content=f"OK IP: {ip_address}")
     except Exception as e:
         return PlainTextResponse(content=f"Error: {e}")
-    finally:
-        await session.stop()
-    return PlainTextResponse(content=f"OK IP: {ip_text}")
 
 
 @app.middleware("http")


### PR DESCRIPTION
This is another attempt to minimize the usage of Patchright. To verify, run the server as usual and then:

```bash
$ curl localhost:23456/extended-health
OK IP: 73.170.132.36
```