### PR TITLE
introduce wait for page to be ready

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -41,6 +41,7 @@ from getgather.zen_distill import (
     page_query_selector,
     run_distillation_loop as zen_run_distillation_loop,
     safe_close_page,
+    wait_for_ready_state,
     zen_navigate_with_retry,
     zen_report_distill_error,
 )
@@ -506,12 +507,20 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
     if settings.LOG_LEVEL == "DEBUG":
         await zen_capture_page_artifacts(page, identifier=id, prefix="dpage_debug")
 
+    # Force browser to complete rendering by evaluating document state
+    try:
+        await wait_for_ready_state(page, timeout=5)
+        # Additional wait for any dynamic content/JavaScript to settle
+        await page.sleep(1)
+        logger.debug("Page ready state is complete")
+    except Exception as e:
+        logger.warning(f"Error waiting for page ready state: {e}")
+
     for iteration in range(max):
         logger.debug(f"Iteration {iteration + 1} of {max}")
         await asyncio.sleep(TICK)
 
         hostname = str(urllib.parse.urlparse(page.url).hostname) if page.url else None
-
         match = await zen_distill(hostname, page, patterns)
         if not match:
             logger.info("No matched pattern found")


### PR DESCRIPTION
This fixes a race condition that was exposed by 
- [ ] #898 

where the bbc tool (and maybe others) would consistently fail with on the dpage link. 


During debugging I found that a screenshot helped and that led me to this solution. 

Try it yourself with the BBC tool. 

I am purposely not updating with main for now so the bug will be there if the code isn't there.

<img width="897" height="921" alt="Screenshot 2026-01-19 at 5 54 43 PM" src="https://github.com/user-attachments/assets/6987f055-5947-490b-8657-b6db4646aceb" />
