### PR TITLE
increase blinds timeout

### DIFF
--- a/getgather/mcp/blinds.py
+++ b/getgather/mcp/blinds.py
@@ -10,6 +10,5 @@ blinds_mcp = GatherMCP(brand_id="blinds", name="Blinds MCP")
 async def get_favorites() -> dict[str, Any]:
     """Get favorites of blinds."""
     return await zen_dpage_mcp_tool(
-        f"https://www.blinds.com/myaccount/favorites",
-        "blinds_favorites",
+        f"https://www.blinds.com/myaccount/favorites", "blinds_favorites", timeout=60
     )


### PR DESCRIPTION
Blinds are SPA, just like Nordstrom. We need to increase the page timeout; otherwise, we always receive the sign-in link when calling the tools, even after we have signed in previously.