### PR TITLE
implement retry mechanism on blindster custom action

### DIFF
--- a/getgather/mcp/blindster.py
+++ b/getgather/mcp/blindster.py
@@ -3,6 +3,7 @@ from typing import Any, cast
 
 import httpx
 import zendriver as zd
+from zendriver.core.connection import ProtocolException
 
 from getgather.logs import logger
 from getgather.mcp.dpage import zen_dpage_mcp_tool, zen_dpage_with_action
@@ -25,7 +26,7 @@ async def get_order_details(id: str, authorization_headers: str | None = None) -
     headers: dict[str, str] = {}
     if authorization_headers:
         headers["Authorization"] = authorization_headers
-
+    logger.info(f"Getting order details for {id} with headers: {headers}")
     async with httpx.AsyncClient() as client:
         response = await client.get(url, headers=headers)
         response.raise_for_status()
@@ -38,19 +39,39 @@ async def get_orders() -> dict[str, Any]:
 
     async def get_orders_action(page: zd.Tab, browser: zd.Browser) -> dict[str, Any]:
         logger.info("🔧 Executing get_orders_action...")
-        await zen_navigate_with_retry(
-            page, "https://www.blindster.com/account/orders", wait_for_ready=False
-        )
-        orders = None
+
+        max_retries = 3
+        orders: list[dict[str, Any]] = []
         authorization_headers: str | None = None
-        async with page.expect_response(".*/ecommerce/customer/orders") as resp:
-            logger.info("Response listener active...")
-            request_value = await resp.request
-            request_headers = cast(dict[str, str], request_value.headers)
-            authorization_headers = request_headers.get("authorization") or request_headers.get(
-                "Authorization"
-            )
-            orders = await parse_response_json(resp, [])
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                logger.info(f"get_orders_action attempt {attempt}/{max_retries}")
+                await zen_navigate_with_retry(
+                    page, "https://www.blindster.com/account/orders", wait_for_ready=False
+                )
+
+                async with page.expect_response(".*/ecommerce/customer/orders") as resp:
+                    logger.info("Response listener active...")
+                    request_value = await resp.request
+                    request_headers = cast(dict[str, str], request_value.headers)
+                    authorization_headers = request_headers.get(
+                        "authorization"
+                    ) or request_headers.get("Authorization")
+                    orders = await parse_response_json(resp, [])
+
+                logger.info("Orders successfully retrieved from Blindster.")
+                break
+
+            except ProtocolException as e:
+                logger.error(
+                    f"get_orders_action attempt {attempt}/{max_retries} failed with "
+                    f"ProtocolException while fetching orders: {e}"
+                )
+                if attempt == max_retries:
+                    logger.error("Max retries reached for get_orders_action; re-raising error.")
+                    raise
+                logger.info("Retrying get_orders_action...")
 
         order_details_list = await asyncio.gather(
             *[get_order_details(order["orderNumber"], authorization_headers) for order in orders],


### PR DESCRIPTION
Sometimes we get an error when retrieving the response body from the Blindster API. Using a retry mechanism might solve the problem.


Error

```
Task exception was never retrieved
future: <Task finished name='Task-31564' coro=<RequestResponseCycle.run_asgi() done, defined at /Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py:407> exception=RecursionError('maximum recursion depth exceeded in comparison')>
  + Exception Group Traceback (most recent call last):
  |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/_utils.py", line 76, in collapse_excgroups
  |     yield
  |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 177, in __call__
  |     async with anyio.create_task_group() as task_group:
  |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 772, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
    |     result = await app(  # type: ignore[func-returns-value]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    |     return await self.app(scope, receive, send)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
    |     await super().__call__(scope, receive, send)
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/applications.py", line 112, in __call__
    |     await self.middleware_stack(scope, receive, send)
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 187, in __call__
    |     raise exc
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 165, in __call__
    |     await self.app(scope, receive, _send)
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 176, in __call__
    |     with recv_stream, send_stream, collapse_excgroups():
    |   File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/contextlib.py", line 155, in __exit__
    |     self.gen.throw(typ, value, traceback)
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    |     raise exc
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 178, in __call__
    |     response = await self.dispatch_func(request, call_next)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/faisalakbar/Documents/work/getgather/getgather/main.py", line 270, in mcp_slash_middleware
    |     return await call_next(request)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 156, in call_next
    |     raise app_exc
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 141, in coro
    |     await self.app(scope, receive_or_disconnect, send_no_error)
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 176, in __call__
    |     with recv_stream, send_stream, collapse_excgroups():
    |   File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/contextlib.py", line 155, in __exit__
    |     self.gen.throw(typ, value, traceback)
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    |     raise exc
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 178, in __call__
    |     response = await self.dispatch_func(request, call_next)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/faisalakbar/Documents/work/getgather/getgather/main.py", line 257, in mcp_logging_context_middleware
    |     return await call_next(request)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 156, in call_next
    |     raise app_exc
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 141, in coro
    |     await self.app(scope, receive_or_disconnect, send_no_error)
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    |     raise exc
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    |     await app(scope, receive, sender)
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/routing.py", line 714, in __call__
    |     await self.middleware_stack(scope, receive, send)
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/routing.py", line 734, in app
    |     await route.handle(scope, receive, send)
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/routing.py", line 288, in handle
    |     await self.app(scope, receive, send)
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/routing.py", line 76, in app
    |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    |     raise exc
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    |     await app(scope, receive, sender)
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/routing.py", line 73, in app
    |     response = await f(request)
    |                ^^^^^^^^^^^^^^^^
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 301, in app
    |     raw_response = await run_endpoint_function(
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 212, in run_endpoint_function
    |     return await dependant.call(**values)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/faisalakbar/Documents/work/getgather/getgather/mcp/dpage.py", line 157, in post_dpage
    |     return await zen_post_dpage(page, id, request)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/faisalakbar/Documents/work/getgather/getgather/mcp/dpage.py", line 237, in zen_post_dpage
    |     action_result = await zen_dpage_with_action(
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/faisalakbar/Documents/work/getgather/getgather/mcp/dpage.py", line 470, in zen_dpage_with_action
    |     result = await action(page, action_info["browser"])
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/faisalakbar/Documents/work/getgather/getgather/mcp/blindster.py", line 53, in get_orders_action
    |     orders = await parse_response_json(resp, [])
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/faisalakbar/Documents/work/getgather/getgather/zen_actions.py", line 31, in parse_response_json
    |     body, _ = await resp.response_body
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/zendriver/core/expect.py", line 153, in response_body
    |     body = await self.tab.send(cdp.network.get_response_body(request_id=request_id))
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/zendriver/core/connection.py", line 581, in send
    |     raise e
    |   File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/zendriver/core/connection.py", line 577, in send
    |     return await tx  # type: ignore
    |            ^^^^^^^^
    | zendriver.core.connection.ProtocolException: No resource with given identifier found
    | command:Network.getResponseBody
    | params:{'requestId': RequestId('EE821BC2E3B0D3871D5EC7F55B1E792F')} [code: -32000]
    +------------------------------------

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 187, in __call__
    raise exc
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 176, in __call__
    with recv_stream, send_stream, collapse_excgroups():
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    raise exc
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 178, in __call__
    response = await self.dispatch_func(request, call_next)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/getgather/main.py", line 270, in mcp_slash_middleware
    return await call_next(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 156, in call_next
    raise app_exc
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 141, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 176, in __call__
    with recv_stream, send_stream, collapse_excgroups():
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    raise exc
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 178, in __call__
    response = await self.dispatch_func(request, call_next)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/getgather/main.py", line 257, in mcp_logging_context_middleware
    return await call_next(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 156, in call_next
    raise app_exc
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 141, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/routing.py", line 714, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/routing.py", line 734, in app
    await route.handle(scope, receive, send)
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/routing.py", line 76, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/starlette/routing.py", line 73, in app
    response = await f(request)
               ^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 301, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 212, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/getgather/mcp/dpage.py", line 157, in post_dpage
    return await zen_post_dpage(page, id, request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/getgather/mcp/dpage.py", line 237, in zen_post_dpage
    action_result = await zen_dpage_with_action(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/getgather/mcp/dpage.py", line 470, in zen_dpage_with_action
    result = await action(page, action_info["browser"])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/getgather/mcp/blindster.py", line 53, in get_orders_action
    orders = await parse_response_json(resp, [])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/getgather/zen_actions.py", line 31, in parse_response_json
    body, _ = await resp.response_body
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/zendriver/core/expect.py", line 153, in response_body
    body = await self.tab.send(cdp.network.get_response_body(request_id=request_id))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/zendriver/core/connection.py", line 581, in send
    raise e
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/zendriver/core/connection.py", line 577, in send
    return await tx  # type: ignore
           ^^^^^^^^
zendriver.core.connection.ProtocolException: No resource with given identifier found
command:Network.getResponseBody
params:{'requestId': RequestId('EE821BC2E3B0D3871D5EC7F55B1E792F')} [code: -32000]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 414, in run_asgi
    self.logger.error(msg, exc_info=exc)
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/logging/__init__.py", line 1518, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/logging/__init__.py", line 1634, in _log
    self.handle(record)
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/logging/__init__.py", line 1644, in handle
    self.callHandlers(record)
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/logging/__init__.py", line 1706, in callHandlers
    hdlr.handle(record)
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/logging/__init__.py", line 978, in handle
    self.emit(record)
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/rich/logging.py", line 144, in emit
    traceback = Traceback.from_exception(
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/rich/traceback.py", line 381, in from_exception
    rich_traceback = cls.extract(
                     ^^^^^^^^^^^^
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/rich/traceback.py", line 466, in extract
    Traceback.extract(
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/rich/traceback.py", line 466, in extract
    Traceback.extract(
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/rich/traceback.py", line 466, in extract
    Traceback.extract(
  [Previous line repeated 974 more times]
  File "/Users/faisalakbar/Documents/work/getgather/.venv/lib/python3.11/site-packages/rich/traceback.py", line 491, in extract
    iter_locals: Iterable[Tuple[str, object]],
                          ~~~~~^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/typing.py", line 355, in inner
    return cached(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^^^
RecursionError: maximum recursion depth exceeded in comparison
15:52:17 INFO     Checking for old browsers to stop.     browser.py:93
                  Found 2 browsers                                    

```