### PR TITLE
fix: handle blinds API not detected

### DIFF
--- a/getgather/mcp/blinds.py
+++ b/getgather/mcp/blinds.py
@@ -48,14 +48,34 @@ async def get_orders() -> dict[str, Any]:
 
     async def get_orders_action(page: zd.Tab, browser: zd.Browser) -> dict[str, Any]:
         logger.info("🔧 Executing get_orders_action...")
-        await zen_navigate_with_retry(
-            page, "https://www.blinds.com/myaccount/orders", wait_for_ready=False
-        )
-        orders = None
-        async with page.expect_response(".*/ordersummarylist") as resp:
-            logger.info("Response listener active...")
-            logger.info(f"Response: {resp}")
-            orders = await parse_response_json(resp, [])
+
+        max_retries = 3
+        timeout_seconds = 5
+        orders: list[dict[str, Any]] = []
+
+        for attempt in range(1, max_retries + 1):
+            await zen_navigate_with_retry(
+                page, "https://www.blinds.com/myaccount/orders", wait_for_ready=False
+            )
+            logger.info(f"get_orders_action attempt {attempt}/{max_retries}")
+            try:
+                async with page.expect_response(".*/ordersummarylist") as resp:
+                    logger.info("Response listener active...")
+                    orders = await asyncio.wait_for(
+                        parse_response_json(resp, []),
+                        timeout=timeout_seconds,
+                    )
+                logger.info("Successfully received orders response.")
+                break
+
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"No matching 'ordersummarylist' response within {timeout_seconds}s "
+                    f"(attempt {attempt}/{max_retries})."
+                )
+                if attempt == max_retries:
+                    logger.error("Max retries reached for get_orders_action.")
+                    return {"blinds_orders": []}
 
         logger.info(f"🔍 Orders: {orders}")
 


### PR DESCRIPTION
Several times, the zendriver response listener got stuck, indicating that no matching URL was found. Retrying the request might solve the issue.

https://logfire-us.pydantic.dev/getgather/getgather?traceId=019c0612f5bca74f1725be27f2545743&spanId=6d4cc4fcd94d77fe&q=trace_id%3D%27019c0612f5bca74f1725be27f2545743%27&since=2026-01-28T18%3A27%3A11.870477Z&until=2026-01-28T19%3A27%3A26.209613Z