### PR TITLE
ci: add --stage flag to flyctl secrets import

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
-          cat .env | flyctl secrets import --app ${{ matrix.org.app_name }}
+          cat .env | flyctl secrets import --app ${{ matrix.org.app_name }} --stage
 
       - name: Deploy ${{ matrix.org.app_name }} app
         env:


### PR DESCRIPTION
Add --stage flag to secrets import command to skip deployment for machine apps when setting environment variables.