### PR TITLE
Simplify the termination of a remote browser

### DIFF
--- a/getgather/browser/chromefleet.py
+++ b/getgather/browser/chromefleet.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Literal
+from typing import Literal, cast
 from urllib.parse import urlparse
 
 import httpx
@@ -72,8 +72,9 @@ async def create_remote_browser(browser_id: str) -> zd.Browser:
     return browser
 
 
-async def terminate_remote_browser(browser_id: str) -> None:
+async def terminate_remote_browser(browser: zd.Browser) -> None:
     """Terminate an existing remote Chrome via ChromeFleet."""
+    browser_id = cast(str, browser.id)  # type: ignore[attr-defined]
     logger.info(f"Terminating ChromeFleet browser: {browser_id}")
     await _call_chromefleet_api("DELETE", browser_id)
     logger.info(f"Successfully terminated ChromeFleet browser: {browser_id}")

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -1155,7 +1155,7 @@ async def short_lived_mcp_tool(
         proxy_location = None
     await change_and_validate_proxy(browser, location=proxy_location)
     terminated, distilled, converted = await run_distillation_loop(location, patterns, browser)
-    await terminate_remote_browser(browser_id=id)
+    await terminate_remote_browser(browser)
 
     result: dict[str, Any] = {result_key: converted if converted else distilled}
     if result_key in result:


### PR DESCRIPTION
This will be useful in a forthcoming refactoring, as there is no need to keep the browser id around (the zd.Browser instance is all that is necessary).