### PR TITLE
fix: shopee parser to extract list of product name

### DIFF
--- a/getgather/mcp/patterns/shopee-purchase.html
+++ b/getgather/mcp/patterns/shopee-purchase.html
@@ -2,6 +2,7 @@
   <head>
     <title>Shopee Purchase</title>
   </head>
+
   <body>
     <div gg-match="div.YL_VlX"></div>
     <div gg-stop gg-match-html="main"></div>
@@ -10,8 +11,8 @@
         "rows": "div.YL_VlX",
         "columns": [
           { "name": "store_name", "selector": "div.UDaMW3" },
-          { "name": "product_name", "selector": "span.DWVWOJ" },
-          { "name": "product_image", "selector": "img.gQuHsZ", "attribute": "src" },
+          { "name": "product_name", "selector": "span.DWVWOJ", "kind": "list" },
+          { "name": "product_image", "selector": "img.gQuHsZ", "attribute": "src", "kind": "list" },
           {
             "name": "total_price",
             "selector": "div[aria-label*='Total Pesanan']"


### PR DESCRIPTION
Previously, we only extracted one product per order; now we extract all available products from a single order.

<img width="983" height="700" alt="image" src="https://github.com/user-attachments/assets/b701f836-3b3d-454e-b6b6-e0582ca4b8da" />
