### PR TITLE
Pick a random remote browser, out of 3, for the short-lived MCP tools

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -1144,12 +1144,33 @@ async def run_distillation_loop(
     return (False, current.distilled, None)
 
 
+async def create_working_random_browser(req_info: Any | None = None) -> zd.Browser:
+    proxy_location = req_info.model_dump() if req_info else None
+
+    async def create_single_browser(proxy_location: Any | None) -> zd.Browser:
+        id = generate(FRIENDLY_CHARS, 6)
+        browser = await create_remote_browser(browser_id=id)
+        await change_and_validate_proxy(browser, location=proxy_location)
+        return browser
+
+    browsers = await asyncio.gather(*[create_single_browser(proxy_location) for _ in range(3)])
+    selected_browser = random.choice(browsers)
+
+    for browser in browsers:
+        if browser is not selected_browser:
+            await terminate_remote_browser(browser)
+
+    return selected_browser
+
+
 async def short_lived_mcp_tool(
     location: str,
     pattern_wildcard: str,
     result_key: str,
     url_hostname: str,
 ) -> tuple[bool, dict[str, Any]]:
+    browser = await create_working_random_browser(request_info.get())
+
     path = os.path.join(os.path.dirname(__file__), "mcp", "patterns", pattern_wildcard)
     patterns = load_distillation_patterns(path)
     browser_id = get_auth_user().user_id


### PR DESCRIPTION
To verify this, first run Chrome Fleet.

Then run this MCP server as usual (`npm run dev`) with `CHROMEFLEET_URL` pointing to the above Chrome Fleet instance.

After that, use MCP Inspector/Jam to invoke the tool, e.g. npr_get_headlines, while watching the log of Chrome Fleet. This log should indicate a rapid instantiation of 3 browsers, and a termination of 2 of them. The last one, the lucky browser, will be terminated once the tool finishes.

```
Starting browser her449...
Launching Chromium container as chromium-her449...
Container started: name=chromium-her449 id=dedb893207abe87e762ff924544322619713c7f8bad17fb1a06567a85e0a60e4
Connecting browser her449 to Tailscale...
Starting browser ia3ist...
Launching Chromium container as chromium-ia3ist...
Container started: name=chromium-ia3ist id=bb425da95d528ac5a4a7eb473909e5620490988518fea3de0bbf0cc195b3f5f0
Connecting browser ia3ist to Tailscale...
Starting browser zh62y6...
Launching Chromium container as chromium-zh62y6...
Container started: name=chromium-zh62y6 id=7555e4448b8b550ff3bb62cefec557355f0ef91e3020d6d4fa4a02e119b5fb98
Connecting browser zh62y6 to Tailscale..
```