### PR TITLE
clean up deploy-fly workflow script

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -22,8 +22,7 @@ jobs:
         org:
           - name: production
             config: prd
-            app_name: remotebrowser-prod
-            doppler_token_secret: DOPPLER_TOKEN_PRD
+            app_name: remotebrowser
 
     steps:
       - name: Check out source repository
@@ -37,7 +36,7 @@ jobs:
       - name: Download environment variables for ${{ matrix.org.config }} config
         uses: ./.github/actions/download-env
         with:
-          doppler-token: ${{ secrets[matrix.org.doppler_token_secret] }}
+          doppler-token: ${{ secrets.DOPPLER_TOKEN_PRD }}
           project: remotebrowser
           config: ${{ matrix.org.config }}
 
@@ -50,26 +49,18 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Import secrets to ${{ matrix.org.app_name }} app
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
           cat .env | flyctl secrets import --app ${{ matrix.org.app_name }} --stage
 
       - name: Deploy ${{ matrix.org.app_name }} app
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
           flyctl deploy --remote-only --app ${{ matrix.org.app_name }}
 
       - name: Start machines for ${{ matrix.org.app_name }} app
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
           flyctl machines start $(flyctl machines list --app ${{ matrix.org.app_name }} --json | jq -r '.[].id') || true
 
       - name: Run health check validation for ${{ matrix.org.app_name }} app
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |-
           echo "Checking machine states..."
           STATES=$(flyctl status -a ${{ matrix.org.app_name }} --json | jq -r '.Machines[].state' | sort -u)


### PR DESCRIPTION
use `remotebrowser` app name to match with `flyfleet` etc., in prod environment
`FLY_API_TOKEN` can be downloaded from doppler into `$GITHUB_ENV`
and we only have 1 doppler account so we can use it directly instead of setting it in matrix