### PR TITLE
Speculative container fix: switch to Debian 13 (trixie)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Builder
-FROM mirror.gcr.io/library/python:3.13-slim-bookworm AS builder
+FROM mirror.gcr.io/library/python:3.13-slim-trixie AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:0.8.4 /uv /uvx /bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN curl -o /app/blocklists-privacy.txt https://raw.githubusercontent.com/hector
 RUN curl -o /app/blocklists-adguard.txt https://raw.githubusercontent.com/hectorm/hmirror/master/data/adguard-simplified/list.txt
 
 # Stage 2: Final image
-FROM mirror.gcr.io/library/python:3.13-slim-bookworm
+FROM mirror.gcr.io/library/python:3.13-slim-trixie
 
 RUN apt-get update && apt-get install -y \
     tigervnc-standalone-server \


### PR DESCRIPTION
Lately, failed container build affected the CI runs, e.g. https://github.com/remotebrowser/mcp-getgather/actions/runs/21954088417/job/63455019493.

Let's see if moving from Debian 12 (bookworm) to Debian 13 (trixie) will improve the realiability of the container image build.