### PR TITLE
Handle incognito mode for remote dpage with Chrome Fleet

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -13,7 +13,11 @@ from loguru import logger
 from nanoid import generate
 
 from getgather.auth.auth import get_auth_user
-from getgather.browser.chromefleet import create_remote_browser, get_remote_browser
+from getgather.browser.chromefleet import (
+    create_remote_browser,
+    get_remote_browser,
+    terminate_remote_browser,
+)
 from getgather.config import settings
 from getgather.mcp.browser import browser_manager, terminate_zendriver_browser
 from getgather.mcp.html_renderer import DEFAULT_TITLE, render_form
@@ -47,6 +51,10 @@ pending_actions: dict[str, dict[str, Any]] = {}
 element_configs: dict[str, ElementConfig] = {}
 
 FRIENDLY_CHARS: str = "23456789abcdefghijkmnpqrstuvwxyz"
+
+
+def is_remote_browser(dpage_id: str) -> bool:
+    return "--" in dpage_id
 
 
 async def dpage_add(
@@ -107,6 +115,13 @@ async def dpage_finalize(id: str):
         await terminate_zendriver_browser(browser)
         browser_manager.remove_incognito_browser(id)
         return True
+
+    if is_remote_browser(id):
+        browser_id, _ = id.split("--")
+        if browser := await get_remote_browser(browser_id):
+            await terminate_remote_browser(browser)
+            return True
+
     raise ValueError(f"Browser profile for signin {id} not found in incognito browser profiles")
 
 
@@ -149,10 +164,6 @@ async def get_dpage(id: str | None = None) -> HTMLResponse:
 
 
 FINISHED_MSG = "Finished! You can close this window now."
-
-
-def is_remote_browser(dpage_id: str) -> bool:
-    return "--" in dpage_id
 
 
 @router.post("/{id}", response_class=HTMLResponse)
@@ -596,16 +607,42 @@ async def remote_zen_dpage_mcp_tool(
     path = os.path.join(os.path.dirname(__file__), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
 
-    user_id = get_auth_user().user_id
+    headers = get_http_headers(include_all=True)
+    signin_id = headers.get("x-signin-id") or None
+    incognito = headers.get("x-incognito", "0") == "1"
 
-    browser_id: str = user_id
-    browser = await get_remote_browser(browser_id)
-    if browser is None:
+    browser = None
+    page = None
+
+    if signin_id:
+        browser_id, page_id = signin_id.split("--")
+        dpage_id = signin_id
+        browser = await get_remote_browser(browser_id)
+        if browser is None:
+            raise HTTPException(status_code=400, detail="Remote browser not found")
+        for tab in browser.tabs:
+            if tab.target_id == page_id:
+                page = tab
+                break
+        if page is None:
+            raise HTTPException(status_code=400, detail="Page not found")
+        logger.info(f"Continue with browser {browser_id} and page {page_id}")
+    elif incognito:
+        prefix = "E"  # for Ephemeral
+        browser_id = prefix + generate(FRIENDLY_CHARS, 7)
         browser = await create_remote_browser(browser_id)
-
-    page = await get_new_page(browser)
-    dpage_id = f"{browser_id}--{page.target_id}"
-    logger.info(f"For user {user_id}: using browser {browser_id}")
+        page = await get_new_page(browser)
+        dpage_id = f"{browser_id}--{page.target_id}"
+        logger.info(f"Start with an ephemeral browser {browser_id}")
+    else:
+        user_id = get_auth_user().user_id
+        browser_id: str = user_id
+        browser = await get_remote_browser(browser_id)
+        if browser is None:
+            browser = await create_remote_browser(browser_id)
+        page = await get_new_page(browser)
+        dpage_id = f"{browser_id}--{page.target_id}"
+        logger.info(f"For user {user_id}: using browser {browser_id}")
 
     logger.info(f"Navigating remote browser to {initial_url}")
     await zen_navigate_with_retry(page, initial_url)


### PR DESCRIPTION
When `x-incognito` is set, an ephemeral remote browser will be created (marked with `E` prefix in its browser id, e.g. `Exyz123`). This particular instance of remote browser will be used for subsequent distilation operation, linked by its `x-signin-id` (which is now simply mapped to the id of that dpage).

Just like in PR #981, for this remote dpage, the id consists of two parts, the browser id (indexed by Chrome Fleet to find the browser instance) and the page id (corresponding to the actual zd.Tab). That way, there is no need to keep track of its state at all.

This remote browser will be terminated at the end of the distillation process. In the future, Chrome Fleet will have a built-in feature for implicit termination, after some idle time, on an ephemeral instance.

To try this, run this MCP server with Chrome Fleet, per the instructions in PR #981.

After that, launch Page Turner pointing to this MCP server and with the following change (to use the "remote" version of the tool instead). Sign in to Goodreads as usual with Page Turner and at the end, it should show the book list. While that happens, pay attention to Chrome Fleet as it launches a new remote browser (and tears it down, after a while).

```diff
diff --git a/src/server.ts b/src/server.ts
index a8f0b65..53891fe 100644
--- a/src/server.ts
+++ b/src/server.ts
@@ -86,7 +86,7 @@ app.get('/health', (req, res) => {
 app.post('/api/get-book-list', async (req, res) => {
   try {
     const result = await callToolWithReconnect({
-      name: 'goodreads_get_book_list',
+      name: 'goodreads_remote_get_book_list',
       sessionId: req.sessionID,
       ipAddress: getClientIp(req),
     });
```

<img width="3839" height="1964" alt="2026-02-12 page turner remote browser chromefleet" src="https://github.com/user-attachments/assets/fcf761c7-0365-4b57-89ca-53a88db05bad" />

<img width="3065" height="1706" alt="2026-02-12 page turner mcp ephemeral" src="https://github.com/user-attachments/assets/c5fc920b-9b22-4d7e-ba22-7e4d90b30831" />
