### PR TITLE
Speculative fix for container build issue in MCP tests

### DIFF
--- a/.github/workflows/mcp-tests.yml
+++ b/.github/workflows/mcp-tests.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - run: docker build -t getgather .
+
       - name: Load environment variables from Doppler
         uses: ./.github/actions/download-env
         with:
@@ -29,8 +31,6 @@ jobs:
 
       - name: check the health of chromefleet connection
         run: curl -s "${{ env.CHROMEFLEET_URL }}/health"
-
-      - run: docker build -t getgather .
 
       - run: |
           docker run --network host --name getgather -d \


### PR DESCRIPTION
`docker build` seems to be failing all the time in `mcp-tests` workflow, which is weird since the same step passes (with flying colors) in `container` workflow.

This change shuffles the workflow step so that `docker build` happens before any Wireguard setup.