### PR TITLE
MCP tests: increase MCP client timeout

### DIFF
--- a/tests/mcp/test_bbc.py
+++ b/tests/mcp/test_bbc.py
@@ -15,7 +15,7 @@ from mcp.types import TextContent
 @pytest.mark.xfail(reason="flaky")
 async def test_bbc_login_and_get_bookmarks(mcp_config: dict[str, Any]):
     """Test login to bbc."""
-    client = Client(mcp_config, timeout=60)
+    client = Client(mcp_config, timeout=120)
     async with client:
         mcp_call_tool = await client.call_tool("bbc_get_saved_articles")
         assert isinstance(mcp_call_tool.content[0], TextContent), (

--- a/tests/mcp/test_espn.py
+++ b/tests/mcp/test_espn.py
@@ -12,7 +12,7 @@ from mcp.types import TextContent
 @pytest.mark.asyncio
 async def test_espn_get_schedule(mcp_config: dict[str, Any]):
     """Test get schedule from ESPN."""
-    client = Client(mcp_config, timeout=60)
+    client = Client(mcp_config, timeout=120)
     async with client:
         mcp_call_result = await client.call_tool("espn_get_schedule")
         assert isinstance(mcp_call_result.content[0], TextContent), (

--- a/tests/mcp/test_goodreads.py
+++ b/tests/mcp/test_goodreads.py
@@ -15,7 +15,7 @@ from mcp.types import TextContent
 @pytest.mark.xfail(reason="flaky")
 async def test_goodreads_login_and_get_book_list(mcp_config: dict[str, Any]):
     """Test login to goodreads."""
-    client = Client(mcp_config, timeout=60)
+    client = Client(mcp_config, timeout=120)
     async with client:
         mcp_call_tool = await client.call_tool("goodreads_get_book_list")
         assert isinstance(mcp_call_tool.content[0], TextContent), (

--- a/tests/mcp/test_npr.py
+++ b/tests/mcp/test_npr.py
@@ -12,7 +12,7 @@ from mcp.types import TextContent
 @pytest.mark.asyncio
 async def test_npr_get_headlines(mcp_config: dict[str, Any]):
     """Test get headlines from NPR."""
-    client = Client(mcp_config, timeout=60)
+    client = Client(mcp_config, timeout=120)
     async with client:
         mcp_call_result = await client.call_tool("npr_get_headlines")
         assert isinstance(mcp_call_result.content[0], TextContent), (

--- a/tests/mcp/test_nytimes.py
+++ b/tests/mcp/test_nytimes.py
@@ -12,7 +12,7 @@ from mcp.types import TextContent
 @pytest.mark.asyncio
 async def test_nytimes_get_bestsellers_list(mcp_config: dict[str, Any]):
     """Test get bestsellers list from NY Times."""
-    client = Client(mcp_config, timeout=60)
+    client = Client(mcp_config, timeout=120)
     async with client:
         mcp_call_result = await client.call_tool("nytimes_get_bestsellers_list")
         assert isinstance(mcp_call_result.content[0], TextContent), (

--- a/tests/mcp/test_wayfair.py
+++ b/tests/mcp/test_wayfair.py
@@ -18,7 +18,7 @@ load_dotenv()
 @pytest.mark.xfail(reason="flaky")
 async def test_wayfair_login_and_get_order_history(mcp_config: dict[str, Any]):
     """Test login to wayfair and get order history."""
-    client = Client(mcp_config, timeout=60)
+    client = Client(mcp_config, timeout=120)
     async with client:
         mcp_call_tool = await client.call_tool("wayfair_get_order_history")
         assert isinstance(mcp_call_tool.content[0], TextContent), (
@@ -76,7 +76,7 @@ async def test_wayfair_login_and_get_order_history(mcp_config: dict[str, Any]):
 @pytest.mark.xfail(reason="flaky")
 async def test_wayfair_get_cart(mcp_config: dict[str, Any]):
     """Test get cart from wayfair."""
-    client = Client(mcp_config, timeout=60)
+    client = Client(mcp_config, timeout=120)
     async with client:
         mcp_call_get_cart = await client.call_tool("wayfair_get_cart")
         assert isinstance(mcp_call_get_cart.content[0], TextContent), (
@@ -94,7 +94,7 @@ async def test_wayfair_get_cart(mcp_config: dict[str, Any]):
 @pytest.mark.xfail(reason="flaky")
 async def test_wayfair_get_wishlists(mcp_config: dict[str, Any]):
     """Test get wishlists from wayfair."""
-    client = Client(mcp_config, timeout=60)
+    client = Client(mcp_config, timeout=120)
     async with client:
         mcp_call_get_wishlists = await client.call_tool("wayfair_get_wishlists")
         assert isinstance(mcp_call_get_wishlists.content[0], TextContent), (


### PR DESCRIPTION
This improves the success probability, tested locally.