### PR TITLE
fix: amazon convert

### DIFF
--- a/getgather/mcp/patterns/amazon-orders.html
+++ b/getgather/mcp/patterns/amazon-orders.html
@@ -1,8 +1,11 @@
 <html gg-domain="amazon">
   <body>
     <div>
-      <div gg-stop gg-match-html="div.your-orders-content-container__content"></div>
+      <div
+        gg-stop
+        gg-convert="amazon-orders.json"
+        gg-match-html="div.your-orders-content-container__content"
+      ></div>
     </div>
-    <script type="application/json" src="amazon-orders.json"></script>
   </body>
 </html>


### PR DESCRIPTION
Previously, `amazon_get_purchase_history` fell back to returning the distilled HTML for Amazon orders because no converter was detected for the `amazon-orders` pattern.

Updated `amazon-orders.html` to point at `amazon-orders.json` so `run_distillation_loop()` now returns the converted JSON orders as originally intended.

<img width="933" height="777" alt="Firefox Developer Edition 2026-02-24 14 04 04" src="https://github.com/user-attachments/assets/7c57a7cb-f85c-4d88-99c9-7f6d7231917f" />

