### PR TITLE
feat: pass x-target-domains to chromefleet

### DIFF
--- a/getgather/browser/chromefleet.py
+++ b/getgather/browser/chromefleet.py
@@ -80,6 +80,7 @@ async def _call_chromefleet_api(
     method: HTTP_METHOD,
     browser_id: str,
     *,
+    initial_url: str | None = None,
     timeout: float = 120.0,
     retries: int = 3,
     raise_for_status: bool = True,
@@ -91,6 +92,7 @@ async def _call_chromefleet_api(
     url = f"{base_url}/api/v1/browsers/{browser_id}"
 
     mcp_headers = get_http_headers(include_all=True)
+    target_domain = urlparse(initial_url).hostname if initial_url else None
     headers = {
         "x-forwarded-for": mcp_headers.get("x-forwarded-for", None),
         "user-agent": mcp_headers.get("user-agent", None),
@@ -100,7 +102,7 @@ async def _call_chromefleet_api(
         "x-proxy-type": mcp_headers.get("x-proxy-type", None),
         "x-origin-ip": mcp_headers.get("x-origin-ip", None),
         "x-origin-ua": mcp_headers.get("x-origin-ua", None),
-        "x-target-domains": mcp_headers.get("x-target-domains", None),
+        "x-target-domains": target_domain,
     }
     headers = {k: v for k, v in headers.items() if v is not None}
 
@@ -149,13 +151,13 @@ async def get_remote_browser(browser_id: str) -> zd.Browser | None:
     return browser
 
 
-async def create_remote_browser(browser_id: str) -> zd.Browser:
+async def create_remote_browser(browser_id: str, *, initial_url: str | None = None) -> zd.Browser:
     """
     Start a remote Chrome via ChromeFleet and connect via CDP.
     The browser_id must not already be in use.
     """
     logger.info(f"Starting new ChromeFleet browser: {browser_id}")
-    await _call_chromefleet_api("POST", browser_id)
+    await _call_chromefleet_api("POST", browser_id, initial_url=initial_url)
     cdp_base = settings.CHROMEFLEET_URL.replace("https://", "wss://").replace("http://", "ws://")
     cdp_websocket_url = f"{cdp_base}/cdp/{browser_id}"
     logger.debug(f"Connecting to ChromeFleet CDP at {cdp_websocket_url}")

--- a/getgather/browser/chromefleet.py
+++ b/getgather/browser/chromefleet.py
@@ -100,6 +100,7 @@ async def _call_chromefleet_api(
         "x-proxy-type": mcp_headers.get("x-proxy-type", None),
         "x-origin-ip": mcp_headers.get("x-origin-ip", None),
         "x-origin-ua": mcp_headers.get("x-origin-ua", None),
+        "x-target-domains": mcp_headers.get("x-target-domains", None),
     }
     headers = {k: v for k, v in headers.items() if v is not None}
 

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -779,7 +779,7 @@ async def remote_zen_dpage_mcp_tool(
     elif incognito:
         prefix = "E"  # for Ephemeral
         browser_id = prefix + generate(FRIENDLY_CHARS, 7)
-        browser = await create_remote_browser(browser_id)
+        browser = await create_remote_browser(browser_id, initial_url=initial_url)
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
         logger.info(f"Start with an ephemeral browser {browser_id}")
@@ -788,7 +788,7 @@ async def remote_zen_dpage_mcp_tool(
         browser_id: str = user_id
         browser = await get_remote_browser(browser_id)
         if browser is None:
-            browser = await create_remote_browser(browser_id)
+            browser = await create_remote_browser(browser_id, initial_url=initial_url)
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
         logger.info(f"For user {user_id}: using browser {browser_id}")
@@ -869,7 +869,7 @@ async def remote_zen_dpage_with_action(
     elif incognito:
         prefix = "E"
         browser_id = prefix + generate(FRIENDLY_CHARS, 7)
-        browser = await create_remote_browser(browser_id)
+        browser = await create_remote_browser(browser_id, initial_url=initial_url)
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
         logger.info(f"Start with ephemeral remote browser {browser_id}")
@@ -878,7 +878,7 @@ async def remote_zen_dpage_with_action(
         browser_id = user_id
         browser = await get_remote_browser(browser_id)
         if browser is None:
-            browser = await create_remote_browser(browser_id)
+            browser = await create_remote_browser(browser_id, initial_url=initial_url)
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
         logger.info(f"For user {user_id}: using remote browser {browser_id}")


### PR DESCRIPTION
## Summary

- derive `x-target-domains` from `initial_url`
- send that header when creating a remote browser in Chromefleet
