### PR TITLE
fix: remove completed_signins on remote zen 

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -198,7 +198,6 @@ async def dpage_check(id: str):
         try:
             terminated = await _probe_page(page=page, browser=browser, timeout=2)
             if terminated:
-                completed_signins.discard(id)
                 return True
         except Exception as e:
             logger.warning(f"Remote probe failed for {id}: {e}")
@@ -388,8 +387,9 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                     "Distillation reported page error pattern; sign-in still marked complete for polling."
                 )
 
-            completed_signins.add(id)
-            await dpage_close(id)
+            if not is_remote_browser(id):
+                completed_signins.add(id)
+                await dpage_close(id)
             return HTMLResponse(render(FINISHED_MSG, options))
 
         names: list[str] = []


### PR DESCRIPTION
## Problem

completed_signins is an in-memory set per process. When a remote sign-in completes on Instance A:
1. ID is written to Instance A's local completed_signins
2. The Chrome tab is closed via CDP

Instance B polling check_signin for the same ID:
  - Doesn't have the ID in its own completed_signins
  - Tries to probe the browser — but the tab is already closed
  - Times out and returns ERROR instead of SUCCESS

  This is the True → False or False -> True sync gap: the completion event only exists in one instance's memory.

 ## Fix

 Use the ChromeFleet browser itself as the source of truth instead of in-memory state.

For remote browsers, zen_post_dpage() no longer writes to completed_signins or closes the Chrome tab on completion. The tab stays alive with the gg-stop page loaded. Any instance polling dpage_check() can probe the browser via ChromeFleet, find the tab, detect gg-stop, and return success — no shared state needed.

  Local browser behavior is unchanged (migrating away from local anyway).

## Scope

  - completed_signins is still used for local browsers
  - dpage_finalize() / finalize_signin still handles actual browser termination
  - Minor tradeoff: each dpage_check() poll now always does a ChromeFleet probe instead of a fast in-memory lookup, but given the 1s sleep per iteration this is negligible
