### PR TITLE
Fix: sign in loop on tool call

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -308,9 +308,7 @@ def get_base_url() -> str:
 
 
 def is_incognito_request(headers: dict[str, str]) -> bool:
-    if headers.get("x-incognito", "0") == "1":
-        return True
-    return get_auth_user().auth_provider == "noauth"
+    return headers.get("x-incognito", "0") == "1"
 
 
 async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLResponse:


### PR DESCRIPTION
## Issue
User always asked for sign in when calling a tools that requires sign in.

## Root Cause
`is_incognito_request` forces incognito mode (always open fresh session) whenever `auth_provider == 'noauth'`. it will always got `noauth` when there is no OAuth env vars are configured. hence it will always activate incognito mode.

## Fix
Remove `auth_provider` check and rely only on `x-incognito`.

## Demo
- Before (http://100.94.233.124/mcp): https://screenrec.com/share/2E6VB1KsY8
- After (http://127.0.0.1:23456/mcp) : https://screenrec.com/share/oa1TJDHbrL