### PR TITLE
perf: reduce span and log noise in dpage_check polling loop

### DIFF
--- a/getgather/browser/chromefleet.py
+++ b/getgather/browser/chromefleet.py
@@ -134,7 +134,7 @@ async def _call_chromefleet_api(
 
 
 async def get_remote_browser(browser_id: str) -> zd.Browser | None:
-    logger.info(f"Finding the ChromeFleet browser: {browser_id}")
+    logger.debug(f"Finding the ChromeFleet browser: {browser_id}")
     try:
         await _call_chromefleet_api("GET", browser_id)
     except Exception:

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -24,6 +24,7 @@ from getgather.mcp.html_renderer import DEFAULT_TITLE, render_form
 from getgather.zen_distill import (
     ElementConfig,
     Match,
+    Pattern,
     autoclick as zen_autoclick,
     capture_page_artifacts as zen_capture_page_artifacts,
     check_error,
@@ -116,10 +117,16 @@ async def _try_action_with_probe(
 
 
 async def _probe_page(
-    *, location: str | None = None, page: zd.Tab, browser: zd.Browser, timeout: int = 2
+    *,
+    location: str | None = None,
+    page: zd.Tab,
+    browser: zd.Browser,
+    timeout: int = 2,
+    patterns: list[Pattern] | None = None,
 ) -> bool:
-    path = os.path.join(os.path.dirname(__file__), "patterns", "**/*.html")
-    patterns = load_distillation_patterns(path)
+    if patterns is None:
+        path = os.path.join(os.path.dirname(__file__), "patterns", "**/*.html")
+        patterns = load_distillation_patterns(path)
     terminated, _, _ = await zen_run_distillation_loop(
         location=location,
         patterns=patterns,
@@ -178,6 +185,11 @@ async def dpage_check(id: str):
     browser: zd.Browser | None = None
 
     browser: zd.Browser | None = None
+    probe_patterns = None
+
+    if is_remote:
+        path = os.path.join(os.path.dirname(__file__), "patterns", "**/*.html")
+        probe_patterns = load_distillation_patterns(path)
 
     for iteration in range(max):
         logger.debug(f"Checking dpage {id}: {iteration + 1} of {max}")
@@ -198,16 +210,18 @@ async def dpage_check(id: str):
 
         page = _find_tab(browser, target_id)
         if page is None:
-            browser = None  # tab gone, re-fetch next tick
+            browser = None
             continue
 
         try:
-            terminated = await _probe_page(page=page, browser=browser, timeout=2)
+            terminated = await _probe_page(
+                page=page, browser=browser, timeout=2, patterns=probe_patterns
+            )
             if terminated:
                 return True
         except Exception as e:
             logger.warning(f"Remote probe failed for {id}: {e}")
-            browser = None  # reset on error, re-fetch next tick
+            browser = None
 
     return None
 

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -177,6 +177,8 @@ async def dpage_check(id: str):
     remote_parts = id.split("--", 1) if is_remote else None
     browser: zd.Browser | None = None
 
+    browser: zd.Browser | None = None
+
     for iteration in range(max):
         logger.debug(f"Checking dpage {id}: {iteration + 1} of {max}")
         await asyncio.sleep(TICK)
@@ -196,6 +198,7 @@ async def dpage_check(id: str):
 
         page = _find_tab(browser, target_id)
         if page is None:
+            browser = None  # tab gone, re-fetch next tick
             continue
 
         try:
@@ -204,6 +207,7 @@ async def dpage_check(id: str):
                 return True
         except Exception as e:
             logger.warning(f"Remote probe failed for {id}: {e}")
+            browser = None  # reset on error, re-fetch next tick
 
     return None
 

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -183,8 +183,6 @@ async def dpage_check(id: str):
     is_remote = is_remote_browser(id)
     remote_parts = id.split("--", 1) if is_remote else None
     browser: zd.Browser | None = None
-
-    browser: zd.Browser | None = None
     probe_patterns = None
 
     if is_remote:

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -183,11 +183,8 @@ async def dpage_check(id: str):
     is_remote = is_remote_browser(id)
     remote_parts = id.split("--", 1) if is_remote else None
     browser: zd.Browser | None = None
-    probe_patterns = None
-
-    if is_remote:
-        path = os.path.join(os.path.dirname(__file__), "patterns", "**/*.html")
-        probe_patterns = load_distillation_patterns(path)
+    path = os.path.join(os.path.dirname(__file__), "patterns", "**/*.html")
+    probe_patterns = load_distillation_patterns(path)
 
     for iteration in range(max):
         logger.debug(f"Checking dpage {id}: {iteration + 1} of {max}")


### PR DESCRIPTION
## Problem

A single `check_signin` request was generating excessive spans and log entries, making logfire traces noisy and hard to read.

## Changes

| File | Change |
|------|--------|
| `dpage.py` | Cache browser object for the duration of the poll; reset to `None` when tab is gone or probe throws so it re-fetches on the next tick |
| `dpage.py` | Load distillation patterns once before the loop and pass them down to `_probe_page`, avoiding redundant disk I/O on every tick |
| `chromefleet.py` | Demote `get_remote_browser` log from INFO to DEBUG to reduce log noise |

## Notes

- `report_error` param for `run_distillation_loop` was merged separately as #1130
- Browser caching fix (tab creation) was merged separately as #1132