### PR TITLE
Send x-target-domains from initial_url

### DIFF
--- a/getgather/browser/chromefleet.py
+++ b/getgather/browser/chromefleet.py
@@ -80,7 +80,7 @@ async def _call_chromefleet_api(
     method: HTTP_METHOD,
     browser_id: str,
     *,
-    initial_url: str | None = None,
+    target_domains: list[str] | None = None,
     timeout: float = 120.0,
     retries: int = 3,
     raise_for_status: bool = True,
@@ -92,7 +92,6 @@ async def _call_chromefleet_api(
     url = f"{base_url}/api/v1/browsers/{browser_id}"
 
     mcp_headers = get_http_headers(include_all=True)
-    target_domain = urlparse(initial_url).hostname if initial_url else None
     headers = {
         "x-forwarded-for": mcp_headers.get("x-forwarded-for", None),
         "user-agent": mcp_headers.get("user-agent", None),
@@ -102,7 +101,7 @@ async def _call_chromefleet_api(
         "x-proxy-type": mcp_headers.get("x-proxy-type", None),
         "x-origin-ip": mcp_headers.get("x-origin-ip", None),
         "x-origin-ua": mcp_headers.get("x-origin-ua", None),
-        "x-target-domains": target_domain,
+        "x-target-domains": ",".join(target_domains) if target_domains else None,
     }
     headers = {k: v for k, v in headers.items() if v is not None}
 
@@ -151,13 +150,15 @@ async def get_remote_browser(browser_id: str) -> zd.Browser | None:
     return browser
 
 
-async def create_remote_browser(browser_id: str, *, initial_url: str | None = None) -> zd.Browser:
+async def create_remote_browser(
+    browser_id: str, *, target_domains: list[str] | None = None
+) -> zd.Browser:
     """
     Start a remote Chrome via ChromeFleet and connect via CDP.
     The browser_id must not already be in use.
     """
     logger.info(f"Starting new ChromeFleet browser: {browser_id}")
-    await _call_chromefleet_api("POST", browser_id, initial_url=initial_url)
+    await _call_chromefleet_api("POST", browser_id, target_domains=target_domains)
     cdp_base = settings.CHROMEFLEET_URL.replace("https://", "wss://").replace("http://", "ws://")
     cdp_websocket_url = f"{cdp_base}/cdp/{browser_id}"
     logger.debug(f"Connecting to ChromeFleet CDP at {cdp_websocket_url}")

--- a/getgather/browser/chromefleet.py
+++ b/getgather/browser/chromefleet.py
@@ -80,6 +80,7 @@ async def _call_chromefleet_api(
     method: HTTP_METHOD,
     browser_id: str,
     *,
+    initial_url: str | None = None,
     timeout: float = 120.0,
     retries: int = 3,
     raise_for_status: bool = True,
@@ -91,6 +92,7 @@ async def _call_chromefleet_api(
     url = f"{base_url}/api/v1/browsers/{browser_id}"
 
     mcp_headers = get_http_headers(include_all=True)
+    target_domain = urlparse(initial_url).hostname if initial_url else None
     headers = {
         "x-forwarded-for": mcp_headers.get("x-forwarded-for", None),
         "user-agent": mcp_headers.get("user-agent", None),
@@ -100,6 +102,7 @@ async def _call_chromefleet_api(
         "x-proxy-type": mcp_headers.get("x-proxy-type", None),
         "x-origin-ip": mcp_headers.get("x-origin-ip", None),
         "x-origin-ua": mcp_headers.get("x-origin-ua", None),
+        "x-target-domains": target_domain,
     }
     headers = {k: v for k, v in headers.items() if v is not None}
 
@@ -148,13 +151,13 @@ async def get_remote_browser(browser_id: str) -> zd.Browser | None:
     return browser
 
 
-async def create_remote_browser(browser_id: str) -> zd.Browser:
+async def create_remote_browser(browser_id: str, *, initial_url: str | None = None) -> zd.Browser:
     """
     Start a remote Chrome via ChromeFleet and connect via CDP.
     The browser_id must not already be in use.
     """
     logger.info(f"Starting new ChromeFleet browser: {browser_id}")
-    await _call_chromefleet_api("POST", browser_id)
+    await _call_chromefleet_api("POST", browser_id, initial_url=initial_url)
     cdp_base = settings.CHROMEFLEET_URL.replace("https://", "wss://").replace("http://", "ws://")
     cdp_websocket_url = f"{cdp_base}/cdp/{browser_id}"
     logger.debug(f"Connecting to ChromeFleet CDP at {cdp_websocket_url}")

--- a/getgather/browser/chromefleet.py
+++ b/getgather/browser/chromefleet.py
@@ -80,7 +80,6 @@ async def _call_chromefleet_api(
     method: HTTP_METHOD,
     browser_id: str,
     *,
-    initial_url: str | None = None,
     target_domains: list[str] | None = None,
     timeout: float = 120.0,
     retries: int = 3,
@@ -93,11 +92,7 @@ async def _call_chromefleet_api(
     url = f"{base_url}/api/v1/browsers/{browser_id}"
 
     mcp_headers = get_http_headers(include_all=True)
-    target_domains_header = (
-        ",".join(target_domains)
-        if target_domains is not None
-        else urlparse(initial_url).hostname if initial_url else None
-    )
+    target_domains_header = ",".join(target_domains) if target_domains is not None else None
     headers = {
         "x-forwarded-for": mcp_headers.get("x-forwarded-for", None),
         "user-agent": mcp_headers.get("user-agent", None),
@@ -158,8 +153,6 @@ async def get_remote_browser(browser_id: str) -> zd.Browser | None:
 
 async def create_remote_browser(
     browser_id: str,
-    *,
-    initial_url: str | None = None,
     target_domains: list[str] | None = None,
 ) -> zd.Browser:
     """
@@ -167,9 +160,7 @@ async def create_remote_browser(
     The browser_id must not already be in use.
     """
     logger.info(f"Starting new ChromeFleet browser: {browser_id}")
-    await _call_chromefleet_api(
-        "POST", browser_id, initial_url=initial_url, target_domains=target_domains
-    )
+    await _call_chromefleet_api("POST", browser_id, target_domains=target_domains)
     cdp_base = settings.CHROMEFLEET_URL.replace("https://", "wss://").replace("http://", "ws://")
     cdp_websocket_url = f"{cdp_base}/cdp/{browser_id}"
     logger.debug(f"Connecting to ChromeFleet CDP at {cdp_websocket_url}")

--- a/getgather/browser/chromefleet.py
+++ b/getgather/browser/chromefleet.py
@@ -80,7 +80,7 @@ async def _call_chromefleet_api(
     method: HTTP_METHOD,
     browser_id: str,
     *,
-    target_domains: list[str] | None = None,
+    target_domain: str = "",
     timeout: float = 120.0,
     retries: int = 3,
     raise_for_status: bool = True,
@@ -92,7 +92,6 @@ async def _call_chromefleet_api(
     url = f"{base_url}/api/v1/browsers/{browser_id}"
 
     mcp_headers = get_http_headers(include_all=True)
-    target_domains_header = ",".join(target_domains) if target_domains is not None else None
     headers = {
         "x-forwarded-for": mcp_headers.get("x-forwarded-for", None),
         "user-agent": mcp_headers.get("user-agent", None),
@@ -102,7 +101,7 @@ async def _call_chromefleet_api(
         "x-proxy-type": mcp_headers.get("x-proxy-type", None),
         "x-origin-ip": mcp_headers.get("x-origin-ip", None),
         "x-origin-ua": mcp_headers.get("x-origin-ua", None),
-        "x-target-domains": target_domains_header,
+        "x-target-domains": target_domain,
     }
     headers = {k: v for k, v in headers.items() if v is not None}
 
@@ -153,14 +152,14 @@ async def get_remote_browser(browser_id: str) -> zd.Browser | None:
 
 async def create_remote_browser(
     browser_id: str,
-    target_domains: list[str] | None = None,
+    target_domain: str = "",
 ) -> zd.Browser:
     """
     Start a remote Chrome via ChromeFleet and connect via CDP.
     The browser_id must not already be in use.
     """
     logger.info(f"Starting new ChromeFleet browser: {browser_id}")
-    await _call_chromefleet_api("POST", browser_id, target_domains=target_domains)
+    await _call_chromefleet_api("POST", browser_id, target_domain=target_domain)
     cdp_base = settings.CHROMEFLEET_URL.replace("https://", "wss://").replace("http://", "ws://")
     cdp_websocket_url = f"{cdp_base}/cdp/{browser_id}"
     logger.debug(f"Connecting to ChromeFleet CDP at {cdp_websocket_url}")

--- a/getgather/browser/chromefleet.py
+++ b/getgather/browser/chromefleet.py
@@ -80,6 +80,7 @@ async def _call_chromefleet_api(
     method: HTTP_METHOD,
     browser_id: str,
     *,
+    initial_url: str | None = None,
     target_domains: list[str] | None = None,
     timeout: float = 120.0,
     retries: int = 3,
@@ -92,6 +93,11 @@ async def _call_chromefleet_api(
     url = f"{base_url}/api/v1/browsers/{browser_id}"
 
     mcp_headers = get_http_headers(include_all=True)
+    target_domains_header = (
+        ",".join(target_domains)
+        if target_domains is not None
+        else urlparse(initial_url).hostname if initial_url else None
+    )
     headers = {
         "x-forwarded-for": mcp_headers.get("x-forwarded-for", None),
         "user-agent": mcp_headers.get("user-agent", None),
@@ -101,7 +107,7 @@ async def _call_chromefleet_api(
         "x-proxy-type": mcp_headers.get("x-proxy-type", None),
         "x-origin-ip": mcp_headers.get("x-origin-ip", None),
         "x-origin-ua": mcp_headers.get("x-origin-ua", None),
-        "x-target-domains": ",".join(target_domains) if target_domains else None,
+        "x-target-domains": target_domains_header,
     }
     headers = {k: v for k, v in headers.items() if v is not None}
 
@@ -151,14 +157,19 @@ async def get_remote_browser(browser_id: str) -> zd.Browser | None:
 
 
 async def create_remote_browser(
-    browser_id: str, *, target_domains: list[str] | None = None
+    browser_id: str,
+    *,
+    initial_url: str | None = None,
+    target_domains: list[str] | None = None,
 ) -> zd.Browser:
     """
     Start a remote Chrome via ChromeFleet and connect via CDP.
     The browser_id must not already be in use.
     """
     logger.info(f"Starting new ChromeFleet browser: {browser_id}")
-    await _call_chromefleet_api("POST", browser_id, target_domains=target_domains)
+    await _call_chromefleet_api(
+        "POST", browser_id, initial_url=initial_url, target_domains=target_domains
+    )
     cdp_base = settings.CHROMEFLEET_URL.replace("https://", "wss://").replace("http://", "ws://")
     cdp_websocket_url = f"{cdp_base}/cdp/{browser_id}"
     logger.debug(f"Connecting to ChromeFleet CDP at {cdp_websocket_url}")

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -84,9 +84,9 @@ def _signin_flow_response(dpage_id: str) -> dict[str, Any]:
     }
 
 
-def _target_domains_from_initial_url(initial_url: str) -> list[str]:
+def _target_domain_from_initial_url(initial_url: str) -> str:
     hostname = urllib.parse.urlparse(initial_url).hostname
-    return [hostname] if hostname else []
+    return hostname or ""
 
 
 async def _try_action_with_probe(
@@ -783,7 +783,7 @@ async def remote_zen_dpage_mcp_tool(
         prefix = "E"  # for Ephemeral
         browser_id = prefix + generate(FRIENDLY_CHARS, 7)
         browser = await create_remote_browser(
-            browser_id, target_domains=_target_domains_from_initial_url(initial_url)
+            browser_id, target_domain=_target_domain_from_initial_url(initial_url)
         )
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
@@ -794,7 +794,7 @@ async def remote_zen_dpage_mcp_tool(
         browser = await get_remote_browser(browser_id)
         if browser is None:
             browser = await create_remote_browser(
-                browser_id, target_domains=_target_domains_from_initial_url(initial_url)
+                browser_id, target_domain=_target_domain_from_initial_url(initial_url)
             )
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
@@ -877,7 +877,7 @@ async def remote_zen_dpage_with_action(
         prefix = "E"
         browser_id = prefix + generate(FRIENDLY_CHARS, 7)
         browser = await create_remote_browser(
-            browser_id, target_domains=_target_domains_from_initial_url(initial_url)
+            browser_id, target_domain=_target_domain_from_initial_url(initial_url)
         )
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
@@ -888,7 +888,7 @@ async def remote_zen_dpage_with_action(
         browser = await get_remote_browser(browser_id)
         if browser is None:
             browser = await create_remote_browser(
-                browser_id, target_domains=_target_domains_from_initial_url(initial_url)
+                browser_id, target_domain=_target_domain_from_initial_url(initial_url)
             )
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -777,7 +777,7 @@ async def remote_zen_dpage_mcp_tool(
     elif incognito:
         prefix = "E"  # for Ephemeral
         browser_id = prefix + generate(FRIENDLY_CHARS, 7)
-        browser = await create_remote_browser(browser_id)
+        browser = await create_remote_browser(browser_id, initial_url=initial_url)
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
         logger.info(f"Start with an ephemeral browser {browser_id}")
@@ -786,7 +786,7 @@ async def remote_zen_dpage_mcp_tool(
         browser_id: str = user_id
         browser = await get_remote_browser(browser_id)
         if browser is None:
-            browser = await create_remote_browser(browser_id)
+            browser = await create_remote_browser(browser_id, initial_url=initial_url)
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
         logger.info(f"For user {user_id}: using browser {browser_id}")
@@ -867,7 +867,7 @@ async def remote_zen_dpage_with_action(
     elif incognito:
         prefix = "E"
         browser_id = prefix + generate(FRIENDLY_CHARS, 7)
-        browser = await create_remote_browser(browser_id)
+        browser = await create_remote_browser(browser_id, initial_url=initial_url)
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
         logger.info(f"Start with ephemeral remote browser {browser_id}")
@@ -876,7 +876,7 @@ async def remote_zen_dpage_with_action(
         browser_id = user_id
         browser = await get_remote_browser(browser_id)
         if browser is None:
-            browser = await create_remote_browser(browser_id)
+            browser = await create_remote_browser(browser_id, initial_url=initial_url)
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
         logger.info(f"For user {user_id}: using remote browser {browser_id}")

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -84,6 +84,11 @@ def _signin_flow_response(dpage_id: str) -> dict[str, Any]:
     }
 
 
+def _target_domains_from_initial_url(initial_url: str) -> list[str]:
+    hostname = urllib.parse.urlparse(initial_url).hostname
+    return [hostname] if hostname else []
+
+
 async def _try_action_with_probe(
     browser: zd.Browser,
     initial_url: str,
@@ -777,7 +782,9 @@ async def remote_zen_dpage_mcp_tool(
     elif incognito:
         prefix = "E"  # for Ephemeral
         browser_id = prefix + generate(FRIENDLY_CHARS, 7)
-        browser = await create_remote_browser(browser_id, initial_url=initial_url)
+        browser = await create_remote_browser(
+            browser_id, target_domains=_target_domains_from_initial_url(initial_url)
+        )
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
         logger.info(f"Start with an ephemeral browser {browser_id}")
@@ -786,7 +793,9 @@ async def remote_zen_dpage_mcp_tool(
         browser_id: str = user_id
         browser = await get_remote_browser(browser_id)
         if browser is None:
-            browser = await create_remote_browser(browser_id, initial_url=initial_url)
+            browser = await create_remote_browser(
+                browser_id, target_domains=_target_domains_from_initial_url(initial_url)
+            )
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
         logger.info(f"For user {user_id}: using browser {browser_id}")
@@ -867,7 +876,9 @@ async def remote_zen_dpage_with_action(
     elif incognito:
         prefix = "E"
         browser_id = prefix + generate(FRIENDLY_CHARS, 7)
-        browser = await create_remote_browser(browser_id, initial_url=initial_url)
+        browser = await create_remote_browser(
+            browser_id, target_domains=_target_domains_from_initial_url(initial_url)
+        )
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
         logger.info(f"Start with ephemeral remote browser {browser_id}")
@@ -876,7 +887,9 @@ async def remote_zen_dpage_with_action(
         browser_id = user_id
         browser = await get_remote_browser(browser_id)
         if browser is None:
-            browser = await create_remote_browser(browser_id, initial_url=initial_url)
+            browser = await create_remote_browser(
+                browser_id, target_domains=_target_domains_from_initial_url(initial_url)
+            )
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
         logger.info(f"For user {user_id}: using remote browser {browser_id}")


### PR DESCRIPTION
## Summary

When creating a remote browser, this change derives x-target-domains from the initial_url hostname and forwards it to ChromeFleet.