### PR TITLE
feat(zen_distill): add report_error param to run_distillation_loop

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -128,6 +128,7 @@ async def _probe_page(
         interactive=False,
         close_page=False,
         page=page,
+        report_error=False,
     )
     return terminated
 

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -1220,6 +1220,7 @@ async def run_distillation_loop(
     interactive: bool = True,
     close_page: bool = True,
     page: zd.Tab | None = None,
+    report_error: bool = True,
 ) -> tuple[bool, str, ConversionResult | None]:
     """Run the distillation loop with zendriver.
 
@@ -1290,14 +1291,15 @@ async def run_distillation_loop(
         else:
             logger.debug(f"No matched pattern found")
 
-    await zen_report_distill_error(
-        error=ValueError("No matched pattern found"),
-        page=page,
-        profile_id=browser.id,  # type: ignore[attr-defined]
-        location=location or "",
-        hostname=hostname,
-        iteration=max,
-    )
+    if report_error:
+        await zen_report_distill_error(
+            error=ValueError("No matched pattern found"),
+            page=page,
+            profile_id=browser.id,  # type: ignore[attr-defined]
+            location=location or "",
+            hostname=hostname,
+            iteration=max,
+        )
     if close_page:
         await safe_close_page(page)
     return (False, current.distilled, None)


### PR DESCRIPTION
## Summary

- Add `report_error: bool = True` parameter to `run_distillation_loop`
- When `False`, skips calling `zen_report_distill_error` on timeout — useful for polling probes where a no-match is expected and not an actual error

## Context

Extracted from #1128, which passes `report_error=False` from `_probe_page` to suppress the 182 false error reports generated during a normal `check_signin` flow.