### PR TITLE
fix: close remote browser sign-in tab after check_signin confirms completion

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -198,6 +198,7 @@ async def dpage_check(id: str):
         try:
             terminated = await _probe_page(page=page, browser=browser, timeout=2)
             if terminated:
+                await safe_close_page(page)
                 return True
         except Exception as e:
             logger.warning(f"Remote probe failed for {id}: {e}")


### PR DESCRIPTION
## Summary

- `dpage_check` was probing the remote chromefleet sign-in tab but never closing it when sign-in was confirmed (`terminated = True`)
- Added `await safe_close_page(page)` before returning `True` in the remote probe path of `dpage_check`

## Root cause

Commit #1123 kept the sign-in tab alive so `dpage_check` could probe it for termination patterns. That fix introduced a leak: once probing confirmed sign-in, the tab was abandoned open. The cleanup responsibility belongs to `dpage_check` since it is the one detecting completion.

## Test plan

- [ ] Run a sign-in flow against a remote chromefleet browser
- [ ] Confirm the sign-in tab is closed once `check_signin` returns `True` (tab count drops)
- [ ] Confirm the downstream MCP tool retry still works (action executes on a fresh tab)
