### PR TITLE
fix: don't re-create browser instance inside dpage check loop

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -175,6 +175,7 @@ async def dpage_check(id: str):
 
     is_remote = is_remote_browser(id)
     remote_parts = id.split("--", 1) if is_remote else None
+    browser: zd.Browser | None = None
 
     for iteration in range(max):
         logger.debug(f"Checking dpage {id}: {iteration + 1} of {max}")
@@ -188,7 +189,8 @@ async def dpage_check(id: str):
             continue
 
         browser_id, target_id = remote_parts
-        browser = await get_remote_browser(browser_id)
+        if browser is None:
+            browser = await get_remote_browser(browser_id)
         if browser is None:
             continue
 


### PR DESCRIPTION
Currently, in the `dpage_check` loop, we always re-create the browser instance. As a result, it takes a lot of time for the `dpage_check` function to finish (15-20 minutes). This is the memory consumption for 3 hits of `dpage_check`.

<img width="1134" height="581" alt="Screenshot 2026-04-13 at 14 25 42" src="https://github.com/user-attachments/assets/8cbca995-1d40-4337-bd85-9b49b4745ca5" />


After fix:
<img width="1634" height="832" alt="Screenshot 2026-04-13 at 14 27 19" src="https://github.com/user-attachments/assets/897ea23f-b890-47a7-b02f-e4c25b0dc11b" />

And somehow this changes also fix this issue: https://heyario.sentry.io/issues/7275157321/?project=4509832551858176&query=is%3Aunresolved&referrer=issue-stream
