### PR TITLE
fix: get ip address tool 

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -628,7 +628,7 @@ async def zen_dpage_mcp_tool(
     headers = get_http_headers(include_all=True)
     incognito = is_incognito_request(headers)
     signin_id = headers.get("x-signin-id") or None
-    
+
     if signin_id and is_remote_browser(signin_id):
         return await remote_zen_dpage_mcp_tool(initial_url, result_key, timeout, config)
 

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -628,6 +628,9 @@ async def zen_dpage_mcp_tool(
     headers = get_http_headers(include_all=True)
     incognito = is_incognito_request(headers)
     signin_id = headers.get("x-signin-id") or None
+    
+    if signin_id and is_remote_browser(signin_id):
+        return await remote_zen_dpage_mcp_tool(initial_url, result_key, timeout, config)
 
     if incognito:
         browser = await init_zendriver_browser(signin_id)


### PR DESCRIPTION
Fix failed to get browser IP when using remote browser.

<img width="1327" height="699" alt="Screenshot 2026-04-13 at 15 22 02" src="https://github.com/user-attachments/assets/4aa46b80-198d-496c-a54f-78f26246f435" />


Since `get_browser_ip_address` tools still used by non-remote browser, we cannot migrate it yet. And this is quick fix to handle that before we fully migrate it.