### PR TITLE
fix: false alarm distillation error on non-custom action tool

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -789,6 +789,7 @@ async def remote_zen_dpage_mcp_tool(
 
     browser = None
     page = None
+    should_report_error = True
 
     if signin_id:
         browser_id, _ = signin_id.split("--")
@@ -799,6 +800,7 @@ async def remote_zen_dpage_mcp_tool(
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
     elif incognito:
+        should_report_error = False
         prefix = "E"  # for Ephemeral
         browser_id = prefix + generate(FRIENDLY_CHARS, 7)
         browser = await create_remote_browser(
@@ -830,7 +832,7 @@ async def remote_zen_dpage_mcp_tool(
         interactive=False,
         close_page=False,
         page=page,
-        report_error=signin_id is not None,
+        report_error=should_report_error,  # don't report error if we are hit this tool for the first time (for signin)
     )
     if terminated:
         await safe_close_page(page)

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -830,6 +830,7 @@ async def remote_zen_dpage_mcp_tool(
         interactive=False,
         close_page=False,
         page=page,
+        report_error=signin_id is not None,
     )
     if terminated:
         await safe_close_page(page)


### PR DESCRIPTION
Currently non custom actions tools always trigger distillation error report when user haven't signin yet. So we need to implement [this changes](https://github.com/remotebrowser/mcp-getgather/pull/1130) for non custom action tools.

Reducing false error alarm like [this one](https://heyario.sentry.io/issues/6960259670/?project=4509832551858176&query=is%3Aunresolved&referrer=issue-stream).