### PR TITLE
fix: amazon get_browsing_history stuck

### DIFF
--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -98,13 +98,12 @@ async def get_browsing_history() -> dict[str, Any]:
 
         logger.info(f"Navigating to {current_url}")
 
-        await page.send(zd.cdp.page.reload())
-        logger.info("Page reloaded, waiting for browsing-history API response")
-
         browsing_history_api_url = None
         request_headers = None
         async with page.expect_response(".*browsing-history/.*") as response:
             logger.info("Waiting for browsing-history API response")
+            await page.send(zd.cdp.page.reload())
+            logger.info("Page reloaded, waiting for browsing-history API response")
             response_value = await response.value
             browsing_history_api_url = response_value.response.url
             logger.info(f"Found browsing history API URL: {browsing_history_api_url}")


### PR DESCRIPTION
Fix [this issue](https://logfire-us.pydantic.dev/getgather/getgather?traceId=019d8a5761cdeaa15bb42b1396019db1&spanId=9757d408e96a653e&q=trace_id%3D%27019d8a5761cdeaa15bb42b1396019db1%27+and+span_id%3D%279757d408e96a653e%27&since=2026-04-14T04%3A25%3A06.619430Z&until=2026-04-14T05%3A25%3A06.619430Z), where the code gets stuck on “Waiting for browsing-history API response". It is probably caused by a race condition: the API has already completed on the browser side, but the listener that waits for the API starts listening afterward.

Test result:
<img width="912" height="461" alt="Screenshot 2026-04-14 at 14 03 06" src="https://github.com/user-attachments/assets/158aaab6-3877-42c1-800c-cc74eab4a21a" />
