### PR TITLE
fix: DoorDash OTP layout on mobile

### DIFF
--- a/getgather/mcp/html_renderer.py
+++ b/getgather/mcp/html_renderer.py
@@ -179,6 +179,10 @@ def render_form(content: str, title: str = DEFAULT_TITLE, action: str = "") -> s
     }}
 
       @media (max-width: 640px) {{
+        body {{
+          padding: 0;
+        }}
+
         .card {{
           padding: 1.5rem;
           max-width: 100%;

--- a/getgather/mcp/patterns/doordash-signin-otc.html
+++ b/getgather/mcp/patterns/doordash-signin-otc.html
@@ -3,6 +3,15 @@
     <title>Doordash Sign In Code</title>
   </head>
   <body>
+    <!-- dpage splices only this <body> into html_renderer; <head> is omitted, so pattern CSS must live here. -->
+    <style>
+      @media (max-width: 768px) {
+        #doordash-otc input {
+          padding-left: 0;
+          padding-right: 0;
+        }
+      }
+    </style>
     <p id="message" gg-optional gg-match="form#otc-submit-form span:nth-child(2)" />
     <div
       id="doordash-otc"


### PR DESCRIPTION
<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="401" height="861" alt="image" src="https://github.com/user-attachments/assets/d981cd08-c987-4b4b-b43d-b38a9b1e4ce6" /></td>
      <td><img width="399" height="859" alt="Firefox Developer Edition 2026-04-14 18 52 59" src="https://github.com/user-attachments/assets/fa0f0eba-52ad-4558-9c7c-92cf7574426e" /></td>
    </tr>
  </tbody>
</table>