### PR TITLE
improvement: Google multiple 2FA flow

### DIFF
--- a/getgather/mcp/patterns/google-signin-2fa-authenticator-wrong-code.html
+++ b/getgather/mcp/patterns/google-signin-2fa-authenticator-wrong-code.html
@@ -3,9 +3,7 @@
     <title>Google Activity</title>
   </head>
   <body>
-    <div
-      gg-match="div[jsname='B34EJ']"
-    ></div>
+    <div gg-match="div[jsname='B34EJ']"></div>
     <input
       autofocus
       name="totpPin"

--- a/getgather/mcp/patterns/google-signin-2fa-authenticator-wrong-code.html
+++ b/getgather/mcp/patterns/google-signin-2fa-authenticator-wrong-code.html
@@ -1,10 +1,10 @@
-<html gg-domain="google" gg-priority="3">
+<html gg-domain="google" gg-priority="2">
   <head>
     <title>Google Activity</title>
   </head>
   <body>
     <div
-      gg-match="//div[@class='dMNVAe' and contains(normalize-space(.), 'Google Authenticator')]"
+      gg-match="div[jsname='B34EJ']"
     ></div>
     <input
       autofocus

--- a/getgather/mcp/patterns/google-signin-2fa-wait-recovery-phone.html
+++ b/getgather/mcp/patterns/google-signin-2fa-wait-recovery-phone.html
@@ -1,0 +1,13 @@
+<html gg-domain="google">
+  <head>
+    <title>Google Activity</title>
+  </head>
+  <body>
+    <div
+      gg-match="//div[@jsname='ScNLcb' and contains(normalize-space(.), 'Google will send a notification to your phones to verify it')]"
+    ></div>
+
+    <input type="text" value="submit" name="submit" style="display: none" />
+    <button gg-autoclick gg-match="button[jsname='LgbsSe']">I've done this</button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/google-signin-2fa-wait.html
+++ b/getgather/mcp/patterns/google-signin-2fa-wait.html
@@ -3,9 +3,8 @@
     <title>Google Activity</title>
   </head>
   <body>
-    <span gg-match="//span[contains(normalize-space(.), '2-Step Verification')]"></span>
     <div
-      gg-match-html="//div[@class='dMNVAe' and contains(normalize-space(.), 'Google sent a notification to your')]"
+      gg-match="//div[@jsname='MZArnb' and contains(normalize-space(.), 'Google sent a notification to your')]"
     ></div>
 
     <input type="text" value="submit" name="submit" style="display: none" />

--- a/getgather/mcp/patterns/google-signin-choose-method.html
+++ b/getgather/mcp/patterns/google-signin-choose-method.html
@@ -3,12 +3,50 @@
     <title>Google Activity</title>
   </head>
   <body>
-    <div gg-match="//span[contains(normalize-space(.), 'Choose how you want to sign in:')]"></div>
-    <div
-      gg-autoclick
-      gg-match="//li//div//div[contains(normalize-space(.), 'Enter your password')]"
+    <div gg-match="//span[@jsname='I74d0c']"></div>
+
+    <!-- Tap Yes on phone or tablet -->
+    <button
+      name="button"
+      type="submit"
+      value="phone-tap-yes"
+      gg-optional
+      gg-match="//div[@jsname='EBHGs'][not(@aria-disabled='true')][@data-challengetype='39'][.//div[@jsname='fmcmS'][not(contains(., 'recovery'))]]"
     >
-      Enter your password
-    </div>
+      Tap Yes on your phone or tablet
+    </button>
+
+    <!-- Google Authenticator -->
+    <button
+      name="button"
+      type="submit"
+      value="authenticator"
+      gg-optional
+      gg-match="//div[@jsname='EBHGs'][not(@aria-disabled='true')][@data-challengetype='6']"
+    >
+      Get a verification code from the Google Authenticator app
+    </button>
+
+    <!-- SMS verification code -->
+    <button
+      name="button"
+      type="submit"
+      value="sms"
+      gg-optional
+      gg-match="//div[@jsname='EBHGs'][not(@aria-disabled='true')][@data-challengetype='9']"
+    >
+      Get a verification code at your phone
+    </button>
+
+    <!-- Tap Yes on recovery email device -->
+    <button
+      name="button"
+      type="submit"
+      value="recovery-email-tap"
+      gg-optional
+      gg-match="//div[@jsname='EBHGs'][not(@aria-disabled='true')][@data-challengetype='39'][.//div[@jsname='fmcmS'][contains(., 'recovery')]]"
+    >
+      Tap Yes on your recovery email device
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/google-signin-try-phone.html
+++ b/getgather/mcp/patterns/google-signin-try-phone.html
@@ -1,4 +1,4 @@
-<html gg-domain="google" gg-priority="2">
+<html gg-domain="google" gg-priority="-2">
   <head>
     <title>Google Activity</title>
   </head>

--- a/getgather/mcp/patterns/google-signin-try-phone.html
+++ b/getgather/mcp/patterns/google-signin-try-phone.html
@@ -1,4 +1,4 @@
-<html gg-domain="google" gg-priority="-2">
+<html gg-domain="google" gg-priority="2">
   <head>
     <title>Google Activity</title>
   </head>

--- a/getgather/mcp/patterns/youtube-channel-subscriptions-empty.html
+++ b/getgather/mcp/patterns/youtube-channel-subscriptions-empty.html
@@ -1,0 +1,8 @@
+<html gg-domain="youtube">
+  <body>
+    <div
+      gg-stop
+      gg-match="ytd-section-list-renderer[page-subtype='subscriptions-channels']"
+    ></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/youtube-channel-subscriptions-empty.html
+++ b/getgather/mcp/patterns/youtube-channel-subscriptions-empty.html
@@ -1,8 +1,5 @@
 <html gg-domain="youtube">
   <body>
-    <div
-      gg-stop
-      gg-match="ytd-section-list-renderer[page-subtype='subscriptions-channels']"
-    ></div>
+    <div gg-stop gg-match="ytd-section-list-renderer[page-subtype='subscriptions-channels']"></div>
   </body>
 </html>

--- a/getgather/mcp/patterns/youtube-channel-subscriptions.html
+++ b/getgather/mcp/patterns/youtube-channel-subscriptions.html
@@ -1,4 +1,4 @@
-<html gg-domain="youtube">
+<html gg-domain="youtube" gg-priority="-2">
   <body>
     <h1 gg-match="ytd-channel-renderer"></h1>
     <div

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -1038,6 +1038,7 @@ async def distill(
 
             if optional:
                 logger.debug(f"Optional {selector} has no match")
+                target.extract()
                 continue
             found = False
 


### PR DESCRIPTION
 ## Summary

 - `google-signin-choose-method.html` — Replaced auto-click on "Enter your password" with a user-selectable method list. Available sign-in methods (phone tap, Google Authenticator, SMS, recovery email) are shown as clickable buttons. Disabled options (aria-disabled="true") are shown as non-interactive greyed-out buttons. Only options present on the live page are rendered via gg-optional.
 - `zen_distill.py` — Fixed `gg-optional` element handling: unmatched optional elements are now removed from the
 pattern DOM (target.extract()) instead of staying with their fallback text. Previously, both the enabled and
 disabled versions of an option would always render regardless of what was on the page.
 - **New**: google-signin-2fa-authenticator.html — Pattern for the Google Authenticator TOTP code input page.
 - **New**: google-signin-2fa-authenticator-wrong-code.html — Same page after a wrong code is entered (higher
 priority gg-priority="2"), re-prompts for a new code.
 - **New**: google-signin-2fa-wait-recovery-phone.html — Matches the "Google will send a notification to your
 phones" wait page and auto-clicks the Yes button (button[jsname='LgbsSe']).
 - **New**: youtube-channel-subscriptions-empty.html — Handles the empty subscribed channels state. Updated youtube-channel-subscriptions.html to not match this case.

## Demo
https://screenrec.com/share/NF6bx19j5X

<img width="457" height="402" alt="image" src="https://github.com/user-attachments/assets/5470ce13-9af7-463a-8440-b484ddcce3ee" />
