### PR TITLE
feat: inject error code to dpage HTML result

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -27,8 +27,8 @@ from getgather.zen_distill import (
     Pattern,
     autoclick as zen_autoclick,
     capture_page_artifacts as zen_capture_page_artifacts,
-    check_error,
     distill as zen_distill,
+    get_error,
     get_new_page,
     get_selector,
     init_zendriver_browser,
@@ -248,8 +248,9 @@ def render(content: str, options: dict[str, str] | None = None) -> str:
 
     title = options.get("title", DEFAULT_TITLE)
     action = options.get("action", "")
+    error_message = options.get("error_message", None)
 
-    return render_form(content, title, action)
+    return render_form(content, title, action, error_message)
 
 
 # Since the browser can't redirect from GET to POST,
@@ -400,11 +401,12 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
         if await terminate(distilled):
             logger.info("Finished!")
 
-            error = await check_error(distilled)
-            if error:
+            error = await get_error(distilled)
+            if error is not None:
                 logger.info(
                     "Distillation reported page error pattern; sign-in still marked complete for polling."
                 )
+                options["error_message"] = error
 
             if not is_remote_browser(id):
                 completed_signins.add(id)

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -376,7 +376,7 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
         if not match:
             logger.info("No matched pattern found")
             continue
-        
+
         distilled = match.distilled
         document = BeautifulSoup(distilled, "html.parser")
 

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -248,9 +248,9 @@ def render(content: str, options: dict[str, str] | None = None) -> str:
 
     title = options.get("title", DEFAULT_TITLE)
     action = options.get("action", "")
-    error_message = options.get("error_message", None)
+    error_code = options.get("error_code", None)
 
-    return render_form(content, title, action, error_message)
+    return render_form(content, title, action, error_code)
 
 
 # Since the browser can't redirect from GET to POST,
@@ -376,7 +376,7 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
         if not match:
             logger.info("No matched pattern found")
             continue
-
+        
         distilled = match.distilled
         document = BeautifulSoup(distilled, "html.parser")
 
@@ -404,9 +404,9 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
             error = await get_error(distilled)
             if error is not None:
                 logger.info(
-                    "Distillation reported page error pattern; sign-in still marked complete for polling."
+                    f"Distillation reported page error pattern; sign-in still marked complete for polling. Pattern name: {match.name}"
                 )
-                options["error_message"] = error
+                options["error_code"] = error
 
             if not is_remote_browser(id):
                 completed_signins.add(id)

--- a/getgather/mcp/html_renderer.py
+++ b/getgather/mcp/html_renderer.py
@@ -4,7 +4,7 @@ DEFAULT_TITLE = "Sign In"
 
 
 def render_form(
-    content: str, title: str = DEFAULT_TITLE, action: str = "", error_message: str | None = None
+    content: str, title: str = DEFAULT_TITLE, action: str = "", error_code: str | None = None
 ) -> str:
     """Render HTML form with the given content and options."""
     return f"""<!doctype html>
@@ -12,6 +12,7 @@ def render_form(
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="error-message" content="{error_code if error_code else ""}" />
     <title>{title}</title>
     <style>
       :root {{
@@ -258,9 +259,6 @@ def render_form(
       <form method="POST" action="{action}">
         <div class="content-wrapper">
           {content}
-        </div>
-        <div class="error-message">
-          {error_message}
         </div>
       </form>
     </div>

--- a/getgather/mcp/html_renderer.py
+++ b/getgather/mcp/html_renderer.py
@@ -3,7 +3,9 @@
 DEFAULT_TITLE = "Sign In"
 
 
-def render_form(content: str, title: str = DEFAULT_TITLE, action: str = "") -> str:
+def render_form(
+    content: str, title: str = DEFAULT_TITLE, action: str = "", error_message: str | None = None
+) -> str:
     """Render HTML form with the given content and options."""
     return f"""<!doctype html>
 <html lang="en">
@@ -256,6 +258,9 @@ def render_form(content: str, title: str = DEFAULT_TITLE, action: str = "") -> s
       <form method="POST" action="{action}">
         <div class="content-wrapper">
           {content}
+        </div>
+        <div class="error-message">
+          {error_message}
         </div>
       </form>
     </div>

--- a/getgather/mcp/patterns/amazon-create-new-password-required.html
+++ b/getgather/mcp/patterns/amazon-create-new-password-required.html
@@ -5,7 +5,7 @@
   <body>
     <h1
       gg-stop
-      gg-error="reset_password"
+      gg-error="create_new_password"
       gg-match-html="//h1[contains(., 'Create new password')]"
     ></h1>
     <span gg-match="//span.a-button-inner[contains(., 'Save changes and Sign-In')]"></span>

--- a/getgather/mcp/patterns/doordash-cloudflare.html
+++ b/getgather/mcp/patterns/doordash-cloudflare.html
@@ -1,0 +1,10 @@
+<html gg-domain="doordash">
+  <head>
+    <title>Doordash Cloudflare</title>
+  </head>
+
+  <body>
+    <div gg-stop gg-error="captcha" gg-match="//h1[contains(text(), 'www.doordash.com')]"></div>
+    <div gg-match="//h2[contains(text(), 'Performing security verification')]"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/wayfair-bot-detection.html
+++ b/getgather/mcp/patterns/wayfair-bot-detection.html
@@ -2,8 +2,9 @@
   <head>
     <title>Bot Detected</title>
   </head>
+
   <body>
-    <div gg-stop gg-match-html="div.px-captcha-header"></div>
+    <div gg-stop gg-error="captcha" gg-match-html="div.px-captcha-header"></div>
     <div gg-match-html="div.px-captcha-message"></div>
   </body>
 </html>

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -211,13 +211,15 @@ async def terminate(distilled: str) -> bool:
     return False
 
 
-async def check_error(distilled: str) -> bool:
+async def get_error(distilled: str) -> str | None:
     document = BeautifulSoup(distilled, "html.parser")
-    errors = document.find_all(attrs={"gg-error": True})
-    if len(errors) > 0:
-        logger.info("Found error elements...")
-        return True
-    return False
+    error_element = document.find(attrs={"gg-error": True})
+    if error_element and isinstance(error_element, Tag):
+        error_value = error_element.get("gg-error")
+        logger.info(f"Found error element: {error_value}")
+        if isinstance(error_value, str):
+            return error_value
+    return None
 
 
 def load_distillation_patterns(path: str) -> list[Pattern]:


### PR DESCRIPTION
Previously, we can read the error pattern by reading the `check_signin` tool result. However, since [this PR](https://github.com/remotebrowser/mcp-getgather/pull/1095) removed the distillation result from the `check_signin` tool, we need a new approach to detect the error pattern.

In this PR, the error code is embedded inside the dpage HTML result.