### PR TITLE
Remove local vs remote browser branching

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -53,10 +53,6 @@ DEFAULT_DPAGE_POST_POLL_TIMEOUT = 60
 FRIENDLY_CHARS: str = "23456789abcdefghijkmnpqrstuvwxyz"
 
 
-def is_remote_browser(dpage_id: str) -> bool:
-    return "--" in dpage_id
-
-
 def _find_tab(browser: zd.Browser, target_id: str) -> zd.Tab | None:
     """Find a browser tab by its target ID."""
     for tab in browser.tabs:
@@ -155,8 +151,7 @@ async def dpage_check(id: str):
     TIMEOUT = 120  # seconds
     max = TIMEOUT // TICK
 
-    is_remote = is_remote_browser(id)
-    remote_parts = id.split("--", 1) if is_remote else None
+    remote_parts = id.split("--", 1)
     browser: zd.Browser | None = None
     path = os.path.join(os.path.dirname(__file__), "patterns", "**/*.html")
     probe_patterns = load_distillation_patterns(path)
@@ -168,9 +163,6 @@ async def dpage_check(id: str):
         if id in completed_signins:
             completed_signins.discard(id)
             return True
-
-        if not is_remote or remote_parts is None:
-            continue
 
         browser_id, target_id = remote_parts
         if browser is None:
@@ -197,11 +189,10 @@ async def dpage_check(id: str):
 
 
 async def dpage_finalize(id: str):
-    if is_remote_browser(id):
-        browser_id, _ = id.split("--")
-        if browser := await get_remote_browser(browser_id):
-            await terminate_remote_browser(browser)
-            return True
+    browser_id, _ = id.split("--")
+    if browser := await get_remote_browser(browser_id):
+        await terminate_remote_browser(browser)
+        return True
 
     raise ValueError(f"Browser profile for signin {id} not found in incognito browser profiles")
 
@@ -237,10 +228,7 @@ def redirect(id: str) -> HTMLResponse:
 @router.get("/{id}", response_class=HTMLResponse)
 async def get_dpage(id: str | None = None) -> HTMLResponse:
     if id:
-        if id in active_pages:
-            return redirect(id)
-        elif is_remote_browser(id):
-            return redirect(id)
+        return redirect(id)
 
     raise HTTPException(status_code=400, detail="Missing page id")
 
@@ -255,15 +243,14 @@ async def post_dpage(id: str, request: Request) -> HTMLResponse:
     if id in active_pages:
         page = active_pages[id]
 
-    if is_remote_browser(id):
-        browser_id, page_id = id.split("--")
-        browser = await get_remote_browser(browser_id)
-        if browser is None:
-            raise HTTPException(status_code=404, detail="Remote browser not found")
-        for tab in browser.tabs:
-            if tab.target_id == page_id:
-                page = tab
-                break
+    browser_id, page_id = id.split("--")
+    browser = await get_remote_browser(browser_id)
+    if browser is None:
+        raise HTTPException(status_code=404, detail="Remote browser not found")
+    for tab in browser.tabs:
+        if tab.target_id == page_id:
+            page = tab
+            break
 
     if page is None:
         raise HTTPException(status_code=404, detail="Page not found")
@@ -370,9 +357,6 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                 )
                 options["error_code"] = error
 
-            if not is_remote_browser(id):
-                completed_signins.add(id)
-                await dpage_close(id)
             return HTMLResponse(render(FINISHED_MSG, options))
 
         names: list[str] = []
@@ -683,7 +667,7 @@ async def remote_zen_dpage_with_action(
 
     # Probe any existing browser for an authenticated session before opening dpage.
     probe_browser = None
-    if signin_id and is_remote_browser(signin_id):
+    if signin_id:
         probe_browser = await get_remote_browser(signin_id.split("--")[0])
     elif not incognito:
         probe_browser = await get_remote_browser(str(get_auth_user().user_id))
@@ -694,7 +678,7 @@ async def remote_zen_dpage_with_action(
 
     # Create interactive sign-in flow (client retries tool after check_signin)
     page = None
-    if signin_id and is_remote_browser(signin_id):
+    if signin_id:
         browser_id, page_id = signin_id.split("--")
         dpage_id = signin_id
         browser = await get_remote_browser(browser_id)

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -21,7 +21,6 @@ from nanoid import generate
 from zendriver.core.connection import ProtocolException
 
 from getgather.browser.chromefleet import create_remote_browser, terminate_remote_browser
-from getgather.browser.proxy import setup_proxy
 from getgather.browser.resource_blocker import (
     blocked_domains,
     images_allowed_for_request_url,
@@ -29,7 +28,6 @@ from getgather.browser.resource_blocker import (
     should_be_blocked,
 )
 from getgather.config import FRIENDLY_CHARS, settings
-from getgather.request_info import request_info
 
 
 @dataclass
@@ -440,10 +438,6 @@ async def zen_navigate_with_retry(page: zd.Tab, url: str, wait_for_ready: bool =
     raise last_error or Exception(f"Failed to navigate to {url}")
 
 
-def is_local_browser(browser: zd.Browser) -> bool:
-    return browser.config.host is None or browser.config.host in ("127.0.0.1", "localhost")
-
-
 async def get_new_page(browser: zd.Browser) -> zd.Tab:
     page = await browser.get("about:blank", new_tab=True)
 
@@ -520,18 +514,6 @@ async def get_new_page(browser: zd.Browser) -> zd.Tab:
             source=_CREDENTIALS_BLOCK_SCRIPT, run_immediately=True
         )
     )
-
-    if is_local_browser(browser):
-        id = cast(str, browser.id)  # type: ignore[attr-defined]
-        proxy = await setup_proxy(id, request_info.get())
-        proxy_username = None
-        proxy_password = None
-        if proxy:
-            proxy_username = proxy["username"]
-            proxy_password = proxy["password"]
-            if proxy_username or proxy_password:
-                logger.debug("Setting up proxy authentication...")
-                await install_proxy_handler(proxy_username or "", proxy_password or "", page)
 
     return page
 


### PR DESCRIPTION
Remove `is_local_browser` and `is_remote_browser` helper functions. Both functions assumed a mixed local/remote world. With all browsers now remote, `is_remote_browser()` is always true and `is_local_browser()` is always false. Removed both, unwrapped the dead branches at every call site, and dropped some unused imports.

Depends on #1149.
Part of #1117.