### PR TITLE
Remove unused BROWSER_SESSION_AGE setting

### DIFF
--- a/getgather/config.py
+++ b/getgather/config.py
@@ -25,9 +25,6 @@ class Settings(AuthSettings, BaseSettings):
     SENTRY_DSN: str = ""
     LOGFIRE_TOKEN: str = ""
 
-    # Max session age, in minutes
-    BROWSER_SESSION_AGE: int = 60
-
     @property
     def data_dir(self) -> Path:
         path = Path(self.DATA_DIR).resolve() if self.DATA_DIR else PROJECT_DIR / "data"


### PR DESCRIPTION
No code references this config value, it was left over from local browser session management (e.g. `cleanup_incognito_browsers`) which has been removed.

Part of #1117.