### PR TITLE
Remove unused profiles_dir property

### DIFF
--- a/getgather/config.py
+++ b/getgather/config.py
@@ -40,11 +40,5 @@ class Settings(AuthSettings, BaseSettings):
         path.mkdir(parents=True, exist_ok=True)
         return path
 
-    @property
-    def profiles_dir(self) -> Path:
-        path = self.data_dir / "profiles"
-        path.mkdir(parents=True, exist_ok=True)
-        return path
-
 
 settings = Settings()


### PR DESCRIPTION
`profiles_dir` was never referenced outside of config.py.

Part of #1117.