### PR TITLE
Remove unnecessary blocklists support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -512,9 +512,5 @@ frontend/__generated__/
 
 .claude/
 
-# Additional blocklists
-blocklists-*.txt
-!blocklists-basic.txt
-
 # local dev configuration files
 /tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,6 @@ COPY .jwmrc /app/.jwmrc
 # Install the workspace package
 RUN uv sync --no-dev
 
-# Grab additional blocklists
-RUN curl -o /app/blocklists-analytics.txt https://raw.githubusercontent.com/hectorm/hmirror/master/data/mozilla-shavar-analytics/list.txt
-RUN curl -o /app/blocklists-ads.txt https://raw.githubusercontent.com/hectorm/hmirror/master/data/mozilla-shavar-advertising/list.txt
-RUN curl -o /app/blocklists-privacy.txt https://raw.githubusercontent.com/hectorm/hmirror/master/data/easyprivacy/list.txt
-RUN curl -o /app/blocklists-adguard.txt https://raw.githubusercontent.com/hectorm/hmirror/master/data/adguard-simplified/list.txt
-
 # Stage 2: Final image
 FROM mirror.gcr.io/library/python:3.13-slim-bookworm
 
@@ -89,7 +83,6 @@ COPY --from=builder /app/getgather /app/getgather
 COPY --from=builder /app/tests /app/tests
 COPY --from=builder /app/entrypoint.sh /app/entrypoint.sh
 COPY --from=builder /app/.jwmrc /app/.jwmrc
-COPY --from=builder /app/blocklists-*.txt /app/
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONFAULTHANDLER=1 \

--- a/blocklists-basic.txt
+++ b/blocklists-basic.txt
@@ -1,7 +1,0 @@
-adnxs.com
-doubleclick.net
-googlesyndication.com
-growthbook.io
-osano.com
-rubiconproject.com
-taboola.com


### PR DESCRIPTION
`blocklist-basic.txt` and blocklist-related Dockerfile/gitignore entries are safe to remove, since the resource_blocker was already gone in #1155.

Part of #1117.