### PR TITLE
Remove unneeded x-location header

### DIFF
--- a/getgather/mcp/main.py
+++ b/getgather/mcp/main.py
@@ -1,4 +1,3 @@
-import json
 from dataclasses import dataclass
 from functools import cache, cached_property
 from typing import Any, Literal, cast
@@ -95,27 +94,9 @@ class LocationProxyMiddleware(Middleware):
         if browser_session_id:
             log_context["browser_session_id"] = browser_session_id
 
-        # Initialize request_info data
-        info_data: dict[str, str | None] = {}
-
-        # Handle x-location header (contains city, state, country, postal_code)
-        location = headers.get("x-location", None)
-        if location is not None:
-            try:
-                location_data: dict[str, str | None] = json.loads(location)
-                info_data.update(location_data)
-            except json.JSONDecodeError:
-                with logger.contextualize(**log_context):
-                    logger.warning(f"Failed to parse x-location header as JSON, {location}")
-
-        # Handle x-proxy-type header (e.g., "proxy-0", "proxy-1", etc.)
         proxy_type = headers.get("x-proxy-type", None)
         if proxy_type is not None:
-            info_data["proxy_type"] = proxy_type
-
-        # Set request_info if we have any data
-        if info_data:
-            request_info.set(RequestInfo(**info_data))  # type: ignore[arg-type]
+            request_info.set(RequestInfo(proxy_type=proxy_type))
 
         tool = await context.fastmcp_context.fastmcp.get_tool(context.message.name)  # type: ignore
 

--- a/getgather/request_info.py
+++ b/getgather/request_info.py
@@ -6,18 +6,9 @@ from pydantic import BaseModel, Field
 class RequestInfo(BaseModel):
     """Information about the request that initiated the auth flow."""
 
-    city: str | None = Field(description="The city of the client.", default=None)
-    state: str | None = Field(description="The state of the client.", default=None)
-    country: str | None = Field(description="The country of the client.", default=None)
-    postal_code: str | None = Field(description="The postal code of the client.", default=None)
-    timezone: str | None = Field(description="The timezone of the client.", default=None)
     proxy_type: str | None = Field(
         description="The proxy type to use (e.g., 'proxy-0', 'proxy-1')", default=None
     )
-
-    def is_empty(self) -> bool:
-        """Check if all fields in RequestInfo are None."""
-        return all(not getattr(self, field_name) for field_name in RequestInfo.model_fields.keys())
 
 
 request_info: ContextVar[RequestInfo | None] = ContextVar("request_info", default=None)

--- a/tests/test_request_info.py
+++ b/tests/test_request_info.py
@@ -3,112 +3,21 @@ from getgather.request_info import RequestInfo, request_info
 
 class TestRequestInfo:
     def test_empty_request_info(self):
-        """Test creating RequestInfo with all defaults."""
         info = RequestInfo()
-        assert info.city is None
-        assert info.state is None
-        assert info.country is None
-        assert info.postal_code is None
-        assert info.timezone is None
         assert info.proxy_type is None
 
-    def test_full_request_info(self):
-        """Test creating RequestInfo with all fields."""
-        info = RequestInfo(
-            city="San Francisco",
-            state="CA",
-            country="US",
-            postal_code="94102",
-            timezone="America/Los_Angeles",
-            proxy_type="proxy-0",
-        )
-        assert info.city == "San Francisco"
-        assert info.state == "CA"
-        assert info.country == "US"
-        assert info.postal_code == "94102"
-        assert info.timezone == "America/Los_Angeles"
+    def test_request_info_with_proxy_type(self):
+        info = RequestInfo(proxy_type="proxy-0")
         assert info.proxy_type == "proxy-0"
-
-    def test_partial_request_info(self):
-        """Test creating RequestInfo with some fields."""
-        info = RequestInfo(city="New York", country="US")
-        assert info.city == "New York"
-        assert info.state is None
-        assert info.country == "US"
-        assert info.postal_code is None
-        assert info.timezone is None
-        assert info.proxy_type is None
-
-    def test_request_info_serialization(self):
-        """Test RequestInfo can be serialized to dict."""
-        info = RequestInfo(city="Austin", state="TX", country="US")
-        data = info.model_dump()
-        assert data == {
-            "city": "Austin",
-            "state": "TX",
-            "country": "US",
-            "postal_code": None,
-            "timezone": None,
-            "proxy_type": None,
-        }
-
-    def test_request_info_deserialization(self):
-        """Test RequestInfo can be deserialized from dict."""
-        data = {
-            "city": "Seattle",
-            "state": "WA",
-            "country": "US",
-            "postal_code": "98101",
-            "timezone": "America/Los_Angeles",
-        }
-        info = RequestInfo.model_validate(data)
-        assert info.city == "Seattle"
-        assert info.state == "WA"
-        assert info.country == "US"
-        assert info.postal_code == "98101"
-        assert info.timezone == "America/Los_Angeles"
-        assert info.proxy_type is None
-
-    def test_is_empty_request_info(self):
-        empty_info = RequestInfo()
-
-        assert empty_info.is_empty()
-
-    def test_is_not_empty_request_info(self):
-        non_empty_info = RequestInfo(city="Miami", country="US")
-        assert not non_empty_info.is_empty()
-
-    def test_is_empty_request_info_with_all_fields_none(self):
-        all_fields_none = RequestInfo(
-            city=None, state=None, country=None, postal_code=None, timezone=None, proxy_type=None
-        )
-        assert all_fields_none.is_empty()
-
-    def test_is_empty_request_info_with_empty_string_proxy_type(self):
-        different_empty = RequestInfo(
-            city=None, state=None, country=None, postal_code=None, timezone=None, proxy_type=""
-        )
-        assert different_empty.is_empty()
 
 
 class TestRequestInfoContextVar:
     def test_context_var_default_is_none(self):
-        """Test that request_info context var defaults to None."""
         assert request_info.get() is None
 
     def test_context_var_can_be_set_and_retrieved(self):
-        """Test that request_info context var can be set and retrieved."""
-        info = RequestInfo(city="Boston", state="MA")
+        info = RequestInfo(proxy_type="proxy-0")
         token = request_info.set(info)
         assert request_info.get() is info
-        request_info.reset(token)
-        assert request_info.get() is None
-
-    def test_context_var_isolation(self):
-        """Test that context var changes don't affect the default."""
-        info = RequestInfo(country="CA")
-        token = request_info.set(info)
-        assert request_info.get() is info
-        assert info.country == "CA"
         request_info.reset(token)
         assert request_info.get() is None


### PR DESCRIPTION
This also leads to the simplification of RequestInfo to only proxy_type, eliminating the need for location fields.

Part of #1117.