### PR TITLE
fixed: YTBoard liked videos extraction patterns

### DIFF
--- a/getgather/mcp/patterns/youtube-liked-videos-script.json
+++ b/getgather/mcp/patterns/youtube-liked-videos-script.json
@@ -1,0 +1,38 @@
+{
+  "rows": "contents.twoColumnBrowseResultsRenderer.tabs.0.tabRenderer.content.sectionListRenderer.contents.0.itemSectionRenderer.contents",
+  "row_key": "lockupViewModel",
+  "columns": [
+    {
+      "name": "title",
+      "path": "metadata.lockupMetadataViewModel.title.content"
+    },
+    {
+      "name": "url",
+      "path": "contentId",
+      "prefix": "/watch?v="
+    },
+    {
+      "name": "thumbnail",
+      "path": "contentImage.thumbnailViewModel.image.sources.0.url"
+    },
+    {
+      "name": "channel",
+      "path": "metadata.lockupMetadataViewModel.metadata.contentMetadataViewModel.metadataRows.0.metadataParts.0.text.content"
+    },
+    {
+      "name": "channel_url",
+      "path": "metadata.lockupMetadataViewModel.image.decoratedAvatarViewModel.rendererContext.commandContext.onTap.innertubeCommand.browseEndpoint.canonicalBaseUrl",
+      "fallback_path": "metadata.lockupMetadataViewModel.metadata.contentMetadataViewModel.metadataRows.0.metadataParts.0.text.commandRuns.0.onTap.innertubeCommand.commandMetadata.webCommandMetadata.url"
+    },
+    {
+      "name": "views_and_date",
+      "path": "metadata.lockupMetadataViewModel.metadata.contentMetadataViewModel.metadataRows.1.metadataParts",
+      "join_path": "text.content",
+      "join_separator": " | "
+    },
+    {
+      "name": "duration",
+      "path": "contentImage.thumbnailViewModel.overlays.0.thumbnailBottomOverlayViewModel.badges.0.thumbnailBadgeViewModel.text"
+    }
+  ]
+}

--- a/getgather/mcp/patterns/youtube-liked-videos.html
+++ b/getgather/mcp/patterns/youtube-liked-videos.html
@@ -1,0 +1,6 @@
+<html gg-domain="youtube">
+  <body>
+    <div gg-match="yt-section-list-renderer" gg-stop></div>
+    <div gg-match-html="yt-section-list-renderer" gg-stop></div>
+  </body>
+</html>

--- a/getgather/mcp/youtube.py
+++ b/getgather/mcp/youtube.py
@@ -47,13 +47,23 @@ def _extract_column(row: dict[str, Any], col: dict[str, Any]) -> str:
         if isinstance(value, str) and "fallback_strip_prefix" in col:
             value = value.removeprefix(col["fallback_strip_prefix"])
 
-    if isinstance(value, list) and "join" in col:
-        join_key = cast(str, col["join"])
-        value = "".join(
-            cast(dict[str, Any], item).get(join_key, "")
-            for item in cast(list[Any], value)
-            if isinstance(item, dict)
-        )
+    if isinstance(value, list) and ("join" in col or "join_path" in col):
+        join_key = cast(str | None, col.get("join"))
+        join_path = cast(str | None, col.get("join_path"))
+        join_separator = cast(str, col.get("join_separator", ""))
+        parts: list[str] = []
+        for item in cast(list[Any], value):
+            if not isinstance(item, dict):
+                continue
+            item_dict = cast(dict[str, Any], item)
+            part = (
+                _resolve_json_path(item_dict, join_path)
+                if join_path
+                else item_dict.get(join_key or "", "")
+            )
+            if part:
+                parts.append(str(part))
+        value = join_separator.join(parts)
 
     if value and "prefix" in col:
         value = col["prefix"] + str(cast(Any, value))
@@ -211,7 +221,7 @@ async def get_liked_videos() -> dict[str, Any]:
     return await _yt_extract(
         "https://www.youtube.com/playlist?list=LL",
         "youtube_liked_videos",
-        "youtube-playlist-videos-script.json",
+        "youtube-liked-videos-script.json",
     )
 
 


### PR DESCRIPTION
## Summary
- add extraction patterns for YouTube liked videos pages
- update `youtube.py` to use the new liked videos pattern
- support joined metadata fields like views and publish date

## Demo
<img width="802" height="620" alt="image" src="https://github.com/user-attachments/assets/07a52159-6670-4687-89e6-0ad84ccebf3f" />

<img width="767" height="535" alt="image" src="https://github.com/user-attachments/assets/f59c0052-569c-4521-abda-8ab102462499" />
