### PR TITLE
fix: add distillation loop for dpage_with_action

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -644,9 +644,13 @@ async def remote_zen_dpage_with_action(
     config: ElementConfig | None = None,
 ) -> dict[str, Any]:
     """Execute an action after signin completion with remote Zendriver."""
+    path = os.path.join(os.path.dirname(__file__), "patterns", "**/*.html")
+    patterns = load_distillation_patterns(path)
+
     headers = get_http_headers(include_all=True)
     signin_id = headers.get("x-signin-id") or None
     incognito = is_incognito_request(headers)
+    should_report_error = not incognito
 
     # Probe any existing browser for an authenticated session before opening dpage.
     probe_browser = None
@@ -696,6 +700,22 @@ async def remote_zen_dpage_with_action(
         logger.info(f"For user {user_id}: using remote browser {browser_id}")
 
     await zen_navigate_with_retry(page, initial_url)
+
+    terminated = await zen_run_distillation_loop(
+        location=initial_url,
+        patterns=patterns,
+        browser=browser,
+        timeout=timeout,
+        interactive=False,
+        close_page=False,
+        page=page,
+        report_error=should_report_error,
+    )
+    if terminated:
+        result = await action(page, browser)
+        await safe_close_page(page)
+        return result
+
     page.hostname = urllib.parse.urlparse(initial_url).hostname  # type: ignore[attr-defined]
 
     response = _signin_flow_response(dpage_id)

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -701,7 +701,7 @@ async def remote_zen_dpage_with_action(
 
     await zen_navigate_with_retry(page, initial_url)
 
-    terminated = await zen_run_distillation_loop(
+    terminated, _, _ = await zen_run_distillation_loop(
         location=initial_url,
         patterns=patterns,
         browser=browser,

--- a/getgather/mcp/youtube.py
+++ b/getgather/mcp/youtube.py
@@ -149,7 +149,7 @@ def convert_json(data: dict[str, Any], schema: dict[str, Any]) -> list[dict[str,
 
 
 YOUTUBE_BASE = "https://www.youtube.com"
-YOUTUBE_TIMEOUT_SECONDS = 15
+YOUTUBE_TIMEOUT_SECONDS = 2
 PATTERNS_DIR = os.path.join(os.path.dirname(__file__), "patterns")
 
 


### PR DESCRIPTION
## Overview
- Added a distillation loop to dpage_with_action to handle tools that don’t require sign-in.
- Reduce default YTBoard timeout to 2

## Demo
- Goodreads book details (doesn't require sign in)
  - before: https://screenrec.com/share/RF9kdCYiXP
  - after: https://screenrec.com/share/6A1iqLuomU
- YTBoard: https://screenrec.com/share/EJKyF5YxGo

<img width="506" height="402" alt="image" src="https://github.com/user-attachments/assets/43a05893-a023-4187-9fe1-0b30246e1bc9" />
