### PR TITLE
fix: amazon get_browsing_history stuck

### DIFF
--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -144,13 +144,12 @@ async def get_browsing_history() -> dict[str, Any]:
 
         logger.info(f"Navigating to {current_url}")
 
-        await page.send(zd.cdp.page.reload())
-        logger.info("Page reloaded, waiting for browsing-history API response")
-
         browsing_history_api_url = None
         request_headers = None
         async with page.expect_response(".*browsing-history/.*") as response:
             logger.info("Waiting for browsing-history API response")
+            await page.send(zd.cdp.page.reload())
+            logger.info("Page reloaded, waiting for browsing-history API response")
             response_value = await response.value
             browsing_history_api_url = response_value.response.url
             logger.info(f"Found browsing history API URL: {browsing_history_api_url}")
@@ -313,13 +312,12 @@ async def remote_get_browsing_history() -> dict[str, Any]:
 
         logger.info(f"Navigating to {current_url}")
 
-        await page.send(zd.cdp.page.reload())
-        logger.info("Page reloaded, waiting for browsing-history API response")
-
         browsing_history_api_url = None
         request_headers = None
         async with page.expect_response(".*browsing-history/.*") as response:
             logger.info("Waiting for browsing-history API response")
+            await page.send(zd.cdp.page.reload())
+            logger.info("Page reloaded, waiting for browsing-history API response")
             response_value = await response.value
             browsing_history_api_url = response_value.response.url
             logger.info(f"Found browsing history API URL: {browsing_history_api_url}")


### PR DESCRIPTION
Re-applying fix from #1141 onto the `local-amazon` branch.

Fix where the code gets stuck on "Waiting for browsing-history API response". Caused by a race condition: the API has already completed on the browser side, but the listener that waits for the API starts listening afterward.

Move `page.reload()` inside the `expect_response` context manager so the listener is registered before the reload fires. Applied to both `get_browsing_history_action` occurrences in `amazon.py`.