### PR TITLE
feat: add google sign-in phone QR pattern

### DIFF
--- a/getgather/mcp/patterns/google-signin-phone-qr.html
+++ b/getgather/mcp/patterns/google-signin-phone-qr.html
@@ -1,0 +1,19 @@
+<html gg-domain="google">
+  <head>
+    <title>Google Activity</title>
+  </head>
+  <body>
+    <span
+      style="text-align: center; display: block"
+      gg-match="//span[@jsname='Ud7fr' and contains(normalize-space(.), 'Scan the QR code with your phone')]"
+    ></span>
+    <div
+      style="display: flex; justify-content: center"
+      gg-match-html="//img[@jsname='OBb6qe']/.."
+    ></div>
+    <p gg-match="//div[contains(@class, 'dMNVAe')]"></p>
+
+    <input type="text" value="submit" name="submit" style="display: none" />
+    <button type="submit">I've done this</button>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add a new Google sign-in pattern for the phone QR authentication step.
- Capture the QR section and supporting prompt text for guided interaction.

<img width="1387" height="729" alt="image" src="https://github.com/user-attachments/assets/1d990887-2f08-4690-b381-81d6e80990b4" />

