### PR TITLE
docs: add AGENTS.md with architecture and dev guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,98 @@
+# AGENTS Instructions
+
+This file provides guidance when working with code in this repository.
+
+## Overview
+
+A FastAPI + FastMCP server (`getgather`) that exposes MCP tools for extracting personal data from many web services (Amazon, Garmin, YouTube, Goodreads, Zillow, Wayfair, Kroger, etc.). It drives a remote [Chrome Fleet](https://github.com/remotebrowser/chromefleet) instance via [zendriver](https://github.com/stephanlensky/zendriver) (CDP). The server itself is stateless; browser sessions live in the Chrome Fleet backend identified by `browser_id`.
+
+**`CHROMEFLEET_URL` is required** — the server exits on startup if unset.
+
+## Common Commands
+
+```bash
+# Dev server (requires CHROMEFLEET_URL)
+npm run dev                      # uvicorn on :23456, --reload
+# or: uv run -m uvicorn getgather.main:app --port 23456
+
+# Static analysis (matches CI + pre-push hook)
+npm run check:all                # all of the below
+npm run backend:check:format     # ruff check + ruff format --check
+npm run backend:format           # ruff format + ruff check --fix
+npm run backend:check:type-safety # pyright . (strict mode)
+npm run frontend:check:format    # prettier check on html/js/ts/css/json/md
+npm run yaml:check:format        # yamlfix --check (skips mcp-tools.yaml)
+
+# Tests (markers: mcp, distill; anything else = unit)
+uv run pytest -m "not api and not webui and not mcp and not distill"  # unit tests (CI)
+uv run pytest -m "mcp" -s -p no:xdist                                  # integration vs live server
+uv run pytest -m "distill" -s -p no:xdist                              # distillation vs Chrome Fleet
+uv run pytest tests/mcp/test_goodreads.py                              # single test file
+uv run pytest tests/mcp/test_goodreads.py::test_goodreads_login_and_get_book_list
+
+# Manual MCP client (fastmcp client against running server)
+uv run python tests/manual.py call-tool --mcp media --tool bbc_get_saved_articles
+```
+
+## Architecture
+
+### MCP app composition
+
+`getgather.main` mounts FastAPI app. `getgather.mcp.main.create_mcp_apps()` builds several MCP ASGI apps from one brand registry:
+
+- `/mcp` — all brands mounted (`type="all"`)
+- `/mcp-<brand_id>` — one app per brand (e.g. `/mcp-amazon`)
+- `/mcp-<category>` — category bundles defined in `MCP_BUNDLES` (media, books, shopping, sports, food)
+
+Each brand registers itself at import time by instantiating `GatherMCP(brand_id=..., name=...)` in `getgather/mcp/<brand>.py`. The constructor inserts into `GatherMCP.registry`. The parent MCP app then `mount()`s each brand MCP with its brand*id as namespace, so tools appear as `<brand_id>*<tool_name>`(e.g.`goodreads_get_book_list`).
+
+Adding a new brand requires two steps: (1) create the module with a `GatherMCP` instance and `@<brand>_mcp.tool` functions, (2) add an import to `_brand_modules` in `getgather/mcp/main.py`.
+
+### Declarative vs imperative brands
+
+Simple brands (one URL → one distilled result) are declared in YAML at `getgather/mcp/mcp-tools.yaml` and auto-registered via `declarative_mcp.create_declarative_mcp_tools()`. Two tool kinds:
+
+- default: `remote_zen_dpage_mcp_tool(url, result_key, timeout)` — full sign-in flow via dpage
+- `short_lived: true`: `short_lived_mcp_tool(location, pattern_wildcard, result_key, hostname)` — one-off scrape for public pages (CNN, ESPN, Ground News, NPR, NYTimes)
+
+Brands needing custom logic (post-signin actions, JSON response interception, multi-page flows) have their own `.py` module (amazon, blinds, goodreads, tokopedia, youtube, etc.) using `remote_zen_dpage_with_action(initial_url, action)` where `action` is an `async (page, browser) -> dict`.
+
+### Distillation engine (`zen_distill.py`)
+
+The extraction approach: HTML pattern files in `getgather/mcp/patterns/*.html` contain minimal skeletons with `gg-match="<selector>"` attributes. For each page load, `distill()` batch-extracts all selectors via CDP, finds the best-matching pattern by priority, and renders a "distilled" form. Key markers:
+
+- `gg-match="selector"` — required selector
+- `gg-match-html="selector"` — capture inner HTML instead of text
+- `gg-optional` — don't fail the pattern if missing
+- `gg-priority="N"` — lower wins
+- `gg-domain="example.com"` — only try this pattern on matching hostnames
+- `gg-stop` — pattern signals the flow is finished (terminate)
+- `gg-error="code"` — pattern signals a known error
+- `gg-autoclick` — after fields fill, auto-click
+- `gg-convert="file.json"` — point at a sibling JSON converter for structured output
+- An inline `<script type="application/json">` in the pattern can also define the converter (`rows` selector + `columns` list)
+
+The polling loop (`run_distillation_loop` / `zen_post_dpage`) re-distills repeatedly, autofilling inputs (mapped by `name` to form fields) and submitting when all expected fields are set, until a `gg-stop` pattern matches or timeout.
+
+### dpage sign-in flow
+
+When a tool is called and the user isn't signed in, `remote_zen_dpage_mcp_tool` returns `{url, signin_id, message}`. The client opens the URL in a browser, which renders `dpage/{id}` — a server-proxied form driven by distillation patterns. After sign-in completes (a pattern with `gg-stop` matches), `check_signin` returns SUCCESS and the original tool can be re-called to fetch data. `x-incognito: 1` header opens an ephemeral browser; `x-signin-id` header resumes a specific sign-in browser.
+
+Browser identity: `browser_id` is derived from the auth user (`{sub}-{auth_provider}`) so each user has one persistent remote browser. Incognito browsers get an `E`-prefixed random ID.
+
+### Tracing
+
+`getgather/tracing.py` configures Logfire (if `LOGFIRE_TOKEN` set) and a custom `MCPSessionTraceMiddleware` that reparents per-request OTel spans under a session-root span keyed by `mcp-session-id`. The session ID doubles as the trace ID, so it can be pasted into Logfire. This middleware wraps the FastAPI app last so it runs before OTel's FastAPI instrumentation.
+
+### MCP Apps UI (experimental)
+
+Some tools expose a UI resource via the `io.modelcontextprotocol/ui` extension. `ToolUI` / `ResourceUI` in `getgather/mcp/ui.py` carry CSP/permissions metadata. The parent MCP app wraps `ReadResourceRequest` to attach `_meta.ui` (e.g. CSP) to returned resource contents. See `goodreads.py` for the pattern.
+
+## Conventions
+
+- Python 3.11+, pyright **strict** mode — avoid `Any` drift, annotate returns
+- ruff lint selects `I, UP045, UP006, UP007` (isort + modern typing) with `line-length = 100`
+- `mcp-tools.yaml` is intentionally excluded from yamlfix — edit it hand-formatted
+- Pre-push hook runs `npm run check:all`; don't bypass with `--no-verify`
+- Pattern files live beside patterns at `getgather/mcp/patterns/` — keep them minimal; they're parsed by BeautifulSoup, not rendered
+- Settings via pydantic `BaseSettings` reads `.env`; see `.env.template` for keys

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Adds a comprehensive AGENTS.md covering overview, common commands, architecture (MCP composition, declarative vs imperative brands, distillation engine, dpage sign-in flow, tracing, UI extension), and code conventions.

CLAUDE.md delegates to it via @AGENTS.md.