### PR TITLE
refactor: rename GatherMCP to MCPTool

### DIFF
--- a/getgather/mcp/alfagift.py
+++ b/getgather/mcp/alfagift.py
@@ -3,10 +3,10 @@ from typing import Any
 import zendriver as zd
 
 from getgather.mcp.dpage import remote_zen_dpage_with_action
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 from getgather.zen_actions import parse_response_json
 
-alfagift_mcp = GatherMCP(brand_id="alfagift", name="Alfagift MCP")
+alfagift_mcp = MCPTool(brand_id="alfagift", name="Alfagift MCP")
 
 
 @alfagift_mcp.tool

--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -12,14 +12,14 @@ from getgather.mcp.dpage import (
     remote_zen_dpage_mcp_tool,
     remote_zen_dpage_with_action,
 )
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 from getgather.zen_distill import (
     convert,
     load_distillation_patterns,
     run_distillation_loop,
 )
 
-amazon_mcp = GatherMCP(brand_id="amazon", name="Amazon MCP")
+amazon_mcp = MCPTool(brand_id="amazon", name="Amazon MCP")
 
 
 def normalize_order_id(order_id: str | list[str] | None) -> str | list[str] | None:

--- a/getgather/mcp/amazonca.py
+++ b/getgather/mcp/amazonca.py
@@ -12,14 +12,14 @@ from getgather.mcp.dpage import (
     remote_zen_dpage_mcp_tool,
     remote_zen_dpage_with_action,
 )
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 from getgather.zen_distill import (
     convert,
     load_distillation_patterns,
     run_distillation_loop,
 )
 
-amazonca_mcp = GatherMCP(brand_id="amazonca", name="Amazon CA MCP")
+amazonca_mcp = MCPTool(brand_id="amazonca", name="Amazon CA MCP")
 
 
 def normalize_order_id(order_id: str | list[str] | None) -> str | list[str] | None:

--- a/getgather/mcp/americanairlines.py
+++ b/getgather/mcp/americanairlines.py
@@ -3,10 +3,10 @@ from typing import Any
 import zendriver as zd
 
 from getgather.mcp.dpage import remote_zen_dpage_with_action
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 from getgather.zen_actions import parse_response_json
 
-americanairlines_mcp = GatherMCP(brand_id="americanairlines", name="American Airlines MCP")
+americanairlines_mcp = MCPTool(brand_id="americanairlines", name="American Airlines MCP")
 
 
 @americanairlines_mcp.tool

--- a/getgather/mcp/blinds.py
+++ b/getgather/mcp/blinds.py
@@ -9,10 +9,10 @@ from getgather.mcp.dpage import (
     remote_zen_dpage_mcp_tool,
     remote_zen_dpage_with_action,
 )
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 from getgather.zen_actions import parse_response_json
 
-blinds_mcp = GatherMCP(brand_id="blinds", name="Blinds MCP")
+blinds_mcp = MCPTool(brand_id="blinds", name="Blinds MCP")
 
 # Element configuration for typing delays
 blinds_config = ElementConfig(typing_clear_delay=0.75)

--- a/getgather/mcp/blindster.py
+++ b/getgather/mcp/blindster.py
@@ -11,10 +11,10 @@ from getgather.mcp.dpage import (
     remote_zen_dpage_mcp_tool,
     remote_zen_dpage_with_action,
 )
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 from getgather.zen_actions import parse_response_json
 
-blindster_mcp = GatherMCP(brand_id="blindster", name="Blindster MCP")
+blindster_mcp = MCPTool(brand_id="blindster", name="Blindster MCP")
 
 
 @blindster_mcp.tool

--- a/getgather/mcp/calendar.py
+++ b/getgather/mcp/calendar.py
@@ -6,10 +6,10 @@ from zoneinfo import ZoneInfo
 
 from fastmcp import Context
 
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 
 # Create a generic calendar MCP
-calendar_mcp = GatherMCP(brand_id="calendar", name="Calendar MCP")
+calendar_mcp = MCPTool(brand_id="calendar", name="Calendar MCP")
 
 
 def escape_ics_text(value: str) -> str:

--- a/getgather/mcp/declarative_mcp.py
+++ b/getgather/mcp/declarative_mcp.py
@@ -7,7 +7,7 @@ import yaml
 from pydantic import BaseModel
 
 from getgather.mcp.dpage import remote_zen_dpage_mcp_tool
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 from getgather.zen_distill import short_lived_mcp_tool
 
 YAML_CONFIG_PATH = Path(__file__).parent / "mcp-tools.yaml"
@@ -42,13 +42,13 @@ DECLARATIVE_MCP_CONFIG: list[McpConfig] = _load_mcp_config()
 def create_declarative_mcp_tools() -> None:
     """Create and register MCP tools from configuration array.
 
-    This function generates GatherMCP instances and their tools dynamically
+    This function generates MCPTool instances and their tools dynamically
     from the DECLARATIVE_MCP_CONFIG array. Tools can be either remote zen dpage tools
     or short-lived tools.
     """
 
     for config in DECLARATIVE_MCP_CONFIG:
-        gather_mcp = GatherMCP(brand_id=config.id, name=config.name)
+        gather_mcp = MCPTool(brand_id=config.id, name=config.name)
 
         for tool_config in config.tools:
             function_name: str = tool_config.function_name

--- a/getgather/mcp/doordash.py
+++ b/getgather/mcp/doordash.py
@@ -9,9 +9,9 @@ from getgather.mcp.dpage import (
     remote_zen_dpage_mcp_tool,
     remote_zen_dpage_with_action,
 )
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 
-doordash_mcp = GatherMCP(brand_id="doordash", name="Doordash MCP")
+doordash_mcp = MCPTool(brand_id="doordash", name="Doordash MCP")
 
 
 @doordash_mcp.tool

--- a/getgather/mcp/garmin.py
+++ b/getgather/mcp/garmin.py
@@ -6,13 +6,13 @@ import zendriver as zd
 from loguru import logger
 
 from getgather.mcp.dpage import remote_zen_dpage_with_action
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 from getgather.zen_actions import parse_response_json
 from getgather.zen_distill import load_distillation_patterns, run_distillation_loop
 
 GARMIN_TIMEOUT_SECONDS = 15
 
-garmin_mcp = GatherMCP(brand_id="garmin", name="Garmin MCP")
+garmin_mcp = MCPTool(brand_id="garmin", name="Garmin MCP")
 
 
 async def _garmin_add_activity_ids_action(tab: zd.Tab, browser: zd.Browser) -> dict[str, Any]:

--- a/getgather/mcp/goodreads.py
+++ b/getgather/mcp/goodreads.py
@@ -10,7 +10,7 @@ from getgather.mcp.dpage import (
     remote_zen_dpage_mcp_tool,
     remote_zen_dpage_with_action,
 )
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 from getgather.mcp.ui import UI_MIME_TYPE, ResourceCSP, ToolUI
 
 GOODREADS_UI_URI = "ui://list/data?brand=goodreads"
@@ -23,7 +23,7 @@ goodreads_app_ui = ToolUI(
     ),
 )
 
-goodreads_mcp = GatherMCP(
+goodreads_mcp = MCPTool(
     brand_id="goodreads",
     name="Goodreads MCP",
     app_ui=goodreads_app_ui,

--- a/getgather/mcp/kroger.py
+++ b/getgather/mcp/kroger.py
@@ -3,9 +3,9 @@ from typing import Any
 from getgather.mcp.dpage import (
     remote_zen_dpage_mcp_tool,
 )
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 
-kroger_mcp = GatherMCP(
+kroger_mcp = MCPTool(
     brand_id="kroger",
     name="Kroger MCP",
 )

--- a/getgather/mcp/main.py
+++ b/getgather/mcp/main.py
@@ -56,7 +56,7 @@ from getgather.mcp.dpage import (
     dpage_finalize,
     remote_zen_dpage_mcp_tool,
 )
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 from getgather.mcp.ui import UI_MIME_TYPE, ui_to_meta_dict
 
 
@@ -179,10 +179,10 @@ def create_mcp_apps() -> list[MCPApp]:
             name="all",
             type="all",
             route="/mcp",
-            brand_ids=list(GatherMCP.registry.keys()),
+            brand_ids=list(MCPTool.registry.keys()),
         )
     )
-    # Add individual brand MCPs from GatherMCP registry
+    # Add individual brand MCPs from MCPTool registry
     apps.extend([
         MCPApp(
             name=brand_id,
@@ -190,7 +190,7 @@ def create_mcp_apps() -> list[MCPApp]:
             route=f"/mcp-{brand_id}",
             brand_ids=[brand_id],
         )
-        for brand_id in GatherMCP.registry.keys()
+        for brand_id in MCPTool.registry.keys()
     ])
     apps.extend([
         MCPApp(
@@ -258,8 +258,8 @@ def _create_mcp_app(bundle_name: str, brand_ids: list[str]):
 
     for brand_id in brand_ids:
         brand_id_str = brand_id
-        if brand_id_str in GatherMCP.registry:
-            gather_mcp = GatherMCP.registry[brand_id_str]
+        if brand_id_str in MCPTool.registry:
+            gather_mcp = MCPTool.registry[brand_id_str]
             logger.info(
                 f"Mounting {gather_mcp.name} (distillation-based) to MCP bundle {bundle_name}"
             )
@@ -273,7 +273,7 @@ def _create_mcp_app(bundle_name: str, brand_ids: list[str]):
                 logger.info(f"MCP App UI enabled for {brand_id_str}: {resource_uri}")
                 app_ui_content_meta[str(resource_uri)] = {"ui": ui_to_meta_dict(app_ui)}
 
-                def _make_ui_resource(server: GatherMCP, ui_uri: str):
+                def _make_ui_resource(server: MCPTool, ui_uri: str):
                     async def _read() -> str | bytes | ResourceResult:
                         resource = await server.get_resource(ui_uri)
                         return await resource.read()  # pyright: ignore[reportOptionalMemberAccess]

--- a/getgather/mcp/nordstrom.py
+++ b/getgather/mcp/nordstrom.py
@@ -5,10 +5,10 @@ from loguru import logger
 
 from getgather.browser import page_query_selector, retry_with_navigation, zen_navigate_with_retry
 from getgather.mcp.dpage import remote_zen_dpage_with_action
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 from getgather.zen_actions import parse_response_json
 
-nordstrom_mcp = GatherMCP(brand_id="nordstrom", name="Nordstrom MCP")
+nordstrom_mcp = MCPTool(brand_id="nordstrom", name="Nordstrom MCP")
 
 
 async def get_order_details_with_retry(

--- a/getgather/mcp/registry.py
+++ b/getgather/mcp/registry.py
@@ -6,8 +6,8 @@ from loguru import logger
 from getgather.mcp.ui import ToolUI, ui_to_meta_dict
 
 
-class GatherMCP(FastMCP[Context]):
-    registry: ClassVar[dict[str, "GatherMCP"]] = {}
+class MCPTool(FastMCP[Context]):
+    registry: ClassVar[dict[str, "MCPTool"]] = {}
 
     def __init__(
         self,
@@ -19,8 +19,8 @@ class GatherMCP(FastMCP[Context]):
         super().__init__(name=name)  # type: ignore[reportUnknownMemberType]
         self.brand_id = brand_id
         self.app_ui = app_ui
-        GatherMCP.registry[self.brand_id] = self
-        logger.debug(f"Registered GatherMCP with brand_id '{brand_id}' and name '{name}'")
+        MCPTool.registry[self.brand_id] = self
+        logger.debug(f"Registered MCPTool with brand_id '{brand_id}' and name '{name}'")
 
     def app_ui_tool_meta(self) -> dict[str, dict[str, str]]:
         """Return meta for tool registration (MCP Apps spec).

--- a/getgather/mcp/shopee.py
+++ b/getgather/mcp/shopee.py
@@ -1,11 +1,11 @@
 from typing import Any
 
 from getgather.mcp.dpage import remote_zen_dpage_mcp_tool
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 
 SHOPEE_TIMEOUT_SECONDS = 15
 
-shopee_mcp = GatherMCP(brand_id="shopee", name="Shopee MCP")
+shopee_mcp = MCPTool(brand_id="shopee", name="Shopee MCP")
 
 
 @shopee_mcp.tool

--- a/getgather/mcp/tokopedia.py
+++ b/getgather/mcp/tokopedia.py
@@ -11,10 +11,10 @@ from getgather.mcp.dpage import (
     remote_zen_dpage_mcp_tool,
     remote_zen_dpage_with_action,
 )
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 from getgather.zen_actions import parse_response_json
 
-tokopedia_mcp = GatherMCP(brand_id="tokopedia", name="Tokopedia MCP")
+tokopedia_mcp = MCPTool(brand_id="tokopedia", name="Tokopedia MCP")
 
 
 @tokopedia_mcp.tool

--- a/getgather/mcp/wayfair.py
+++ b/getgather/mcp/wayfair.py
@@ -1,9 +1,9 @@
 from typing import Any
 
 from getgather.mcp.dpage import remote_zen_dpage_mcp_tool
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 
-wayfair_mcp = GatherMCP(brand_id="wayfair", name="Wayfair MCP")
+wayfair_mcp = MCPTool(brand_id="wayfair", name="Wayfair MCP")
 
 
 @wayfair_mcp.tool

--- a/getgather/mcp/youtube.py
+++ b/getgather/mcp/youtube.py
@@ -8,9 +8,9 @@ from loguru import logger
 
 from getgather.browser import get_url
 from getgather.mcp.dpage import remote_zen_dpage_with_action
-from getgather.mcp.registry import GatherMCP
+from getgather.mcp.registry import MCPTool
 
-youtube_mcp = GatherMCP(brand_id="youtube", name="YouTube MCP")
+youtube_mcp = MCPTool(brand_id="youtube", name="YouTube MCP")
 
 
 def _resolve_json_path(obj: dict[str, Any] | list[Any] | None, path: str) -> Any:


### PR DESCRIPTION
Moving away from `Gather` moniker.
Pure identifier swap with no behavioral changes.