### PR TITLE
feat(amazon): added new pattern for blocked signin flow

### DIFF
--- a/getgather/mcp/patterns/amazon-error-acc-temporary-onhold.html
+++ b/getgather/mcp/patterns/amazon-error-acc-temporary-onhold.html
@@ -1,0 +1,14 @@
+<html gg-domain="amazon">
+  <head>
+    <title>Account on hold temporarily</title>
+  </head>
+  <body>
+    <h2
+      gg-stop
+      gg-error="reset_password"
+      gg-match-html="//h4[contains(normalize-space(.), 'Account on hold temporarily')]"
+    >
+      Account on hold temporarily
+    </h2>
+  </body>
+</html>

--- a/getgather/mcp/patterns/amazon-error-billing-details.html
+++ b/getgather/mcp/patterns/amazon-error-billing-details.html
@@ -1,0 +1,14 @@
+<html gg-domain="amazon">
+  <head>
+    <title>Enter your billing details</title>
+  </head>
+  <body>
+    <h2
+      gg-stop
+      gg-error="reset_password"
+      gg-match-html="//h4[contains(normalize-space(.), 'Enter billing details')]"
+    >
+      Enter billing details
+    </h2>
+  </body>
+</html>

--- a/getgather/mcp/patterns/amazon-error-billing-verif.html
+++ b/getgather/mcp/patterns/amazon-error-billing-verif.html
@@ -1,0 +1,14 @@
+<html gg-domain="amazon">
+  <head>
+    <title>Billing verification required</title>
+  </head>
+  <body>
+    <h2
+      gg-stop
+      gg-error="reset_password"
+      gg-match-html="//h4[contains(normalize-space(.), 'Billing verification required')]"
+    >
+      Billing verification required
+    </h2>
+  </body>
+</html>

--- a/getgather/mcp/patterns/amazon-error-document-submission.html
+++ b/getgather/mcp/patterns/amazon-error-document-submission.html
@@ -1,0 +1,14 @@
+<html gg-domain="amazon">
+  <head>
+    <title>Document submission required</title>
+  </head>
+  <body>
+    <h2
+      gg-stop
+      gg-error="reset_password"
+      gg-match-html="//h4[contains(normalize-space(.), 'Document submission required')]"
+    >
+      Document submission required
+    </h2>
+  </body>
+</html>

--- a/getgather/mcp/patterns/amazon-error-temporary-locked.html
+++ b/getgather/mcp/patterns/amazon-error-temporary-locked.html
@@ -1,0 +1,14 @@
+<html gg-domain="amazon">
+  <head>
+    <title>Account locked temporarily</title>
+  </head>
+  <body>
+    <h2
+      gg-stop
+      gg-error="reset_password"
+      gg-match-html="//h4[contains(normalize-space(.), 'Account locked temporarily')]"
+    >
+      Account locked temporarily
+    </h2>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add 5 new Amazon error distillation patterns under `getgather/mcp/patterns/` to detect blocked sign-in/account-recovery states.
- Cover these states: account on hold temporarily, account locked temporarily, billing verification required, enter billing details, and document submission required.
- Mark each pattern with `gg-stop` and `gg-error="reset_password"` so flows terminate early with a consistent actionable error instead of hanging in sign-in loops.

## Testing
| screenshot |
|---|
| <img width="1391" height="762" alt="image" src="https://github.com/user-attachments/assets/ca84189f-9ba0-4583-b28a-71ac49b01a7d" /> |
 | <img width="1353" height="709" alt="image" src="https://github.com/user-attachments/assets/6ccb704d-5797-4e26-a229-8bdde0083be7" /> |
 | <img width="1354" height="710" alt="image" src="https://github.com/user-attachments/assets/7e33e7f6-142d-480c-92c3-4c691de7c15b" /> |
 | <img width="1332" height="627" alt="image" src="https://github.com/user-attachments/assets/f37fc4d9-f00a-4f4f-8104-089fd6a9c086" /> |
| <img width="1352" height="737" alt="image" src="https://github.com/user-attachments/assets/e84da80f-2b05-42a9-a157-a79777627d3a" /> |