### PR TITLE
Use an optional error reporter callback in the main distillation loop

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -36,6 +36,7 @@ from getgather.zen_distill import (
     get_error,
     get_selector,
     load_distillation_patterns,
+    make_error_reporter,
     run_distillation_loop as zen_run_distillation_loop,
     terminate,
     zen_report_distill_error,
@@ -131,7 +132,6 @@ async def _probe_page(
         interactive=False,
         close_page=False,
         page=page,
-        report_error=False,
     )
     return terminated
 
@@ -568,7 +568,6 @@ async def remote_zen_dpage_mcp_tool(
 
     browser = None
     page = None
-    should_report_error = True
 
     if signin_id:
         browser_id, _ = signin_id.split("--")
@@ -579,7 +578,6 @@ async def remote_zen_dpage_mcp_tool(
         page = await get_new_page(browser)
         dpage_id = f"{browser_id}--{page.target_id}"
     elif incognito:
-        should_report_error = False
         prefix = "E"  # for Ephemeral
         browser_id = prefix + generate(FRIENDLY_CHARS, 7)
         browser = await create_remote_browser(
@@ -603,6 +601,7 @@ async def remote_zen_dpage_mcp_tool(
     logger.info(f"Navigating remote browser to {initial_url}")
     await zen_navigate_with_retry(page, initial_url)
 
+    error_reporter = make_error_reporter(browser, initial_url) if not incognito else None
     terminated, distilled, converted = await zen_run_distillation_loop(
         location=initial_url,
         patterns=patterns,
@@ -611,7 +610,7 @@ async def remote_zen_dpage_mcp_tool(
         interactive=False,
         close_page=False,
         page=page,
-        report_error=should_report_error,  # don't report error if we are hit this tool for the first time (for signin)
+        error_reporter=error_reporter,
     )
     if terminated:
         await safe_close_page(page)
@@ -650,7 +649,6 @@ async def remote_zen_dpage_with_action(
     headers = get_http_headers(include_all=True)
     signin_id = headers.get("x-signin-id") or None
     incognito = is_incognito_request(headers)
-    should_report_error = not incognito
 
     # Probe any existing browser for an authenticated session before opening dpage.
     probe_browser = None
@@ -701,6 +699,7 @@ async def remote_zen_dpage_with_action(
 
     await zen_navigate_with_retry(page, initial_url)
 
+    error_reporter = make_error_reporter(browser, initial_url) if not incognito else None
     terminated, _, _ = await zen_run_distillation_loop(
         location=initial_url,
         patterns=patterns,
@@ -709,7 +708,7 @@ async def remote_zen_dpage_with_action(
         interactive=False,
         close_page=False,
         page=page,
-        report_error=should_report_error,
+        error_reporter=error_reporter,
     )
     if terminated:
         result = await action(page, browser)

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from glob import glob
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Callable, Coroutine, cast
 from urllib.parse import urlunparse
 
 import sentry_sdk
@@ -44,6 +44,8 @@ class Match:
 
 
 ConversionResult = list[dict[str, str | list[str]]]
+
+ErrorReporter = Callable[..., Coroutine[Any, Any, None]]
 
 NETWORK_ERROR_PATTERNS = (
     "err-timed-out",
@@ -301,6 +303,28 @@ async def zen_report_distill_error(
             sentry_sdk.capture_exception(error)
 
 
+def make_error_reporter(browser: zd.Browser, location: str | None = None) -> ErrorReporter:
+    profile_id = cast(str, browser.id)  # type: ignore[attr-defined]
+
+    async def _report(
+        *,
+        error: Exception,
+        page: zd.Tab | None,
+        hostname: str,
+        iteration: int,
+    ) -> None:
+        await zen_report_distill_error(
+            error=error,
+            page=page,
+            profile_id=profile_id,
+            location=location or "",
+            hostname=hostname,
+            iteration=iteration,
+        )
+
+    return _report
+
+
 async def distill(
     hostname: str | None, page: zd.Tab, patterns: list[Pattern], reload_on_error: bool = True
 ) -> Match | None:
@@ -476,7 +500,7 @@ async def run_distillation_loop(
     interactive: bool = True,
     close_page: bool = True,
     page: zd.Tab | None = None,
-    report_error: bool = True,
+    error_reporter: ErrorReporter | None = None,
 ) -> tuple[bool, str, ConversionResult | None]:
     """Run the distillation loop with zendriver.
 
@@ -498,15 +522,13 @@ async def run_distillation_loop(
             try:
                 await zen_navigate_with_retry(page, location)
             except Exception as error:
-                # Error already logged by retry wrapper, just report and re-raise
-                await zen_report_distill_error(
-                    error=error,
-                    page=page,
-                    profile_id=browser.id,  # type: ignore[attr-defined]
-                    location=location,
-                    hostname=hostname,
-                    iteration=0,
-                )
+                if error_reporter is not None:
+                    await error_reporter(
+                        error=error,
+                        page=page,
+                        hostname=hostname,
+                        iteration=0,
+                    )
                 raise ValueError(f"Failed to navigate to {location}: {error}")
 
     TICK = 1  # seconds
@@ -547,12 +569,10 @@ async def run_distillation_loop(
         else:
             logger.debug(f"No matched pattern found")
 
-    if report_error:
-        await zen_report_distill_error(
+    if error_reporter is not None:
+        await error_reporter(
             error=ValueError("No matched pattern found"),
             page=page,
-            profile_id=browser.id,  # type: ignore[attr-defined]
-            location=location or "",
             hostname=hostname,
             iteration=max,
         )

--- a/tests/distillation/test_distill.py
+++ b/tests/distillation/test_distill.py
@@ -26,6 +26,7 @@ from getgather.zen_distill import (
     Pattern,
     distill,
     load_distillation_patterns,
+    make_error_reporter,
     run_distillation_loop,
 )
 
@@ -384,6 +385,7 @@ async def test_distillation_captures_screenshot_without_pattern(
             browser=browser,
             timeout=2,
             interactive=False,
+            error_reporter=make_error_reporter(browser, f"{ACME_HOSTNAME}/random-info-page"),
         )
 
         assert not terminated, "Expected not to terminate when no pattern matches."


### PR DESCRIPTION
This is refactoring only, no behavior change at all. It's a follow-up improvement to PR #1130.

Replace the `report_error: bool` parameter with an optional `error_reporter` callback, improving the semantics of the core distillation loop. Callers now explicitly opt in to error reporting by passing a reporter function, rather than relying on a boolean flag.

Add `make_error_reporter()` helper that wraps `zen_report_distill_error` with browser/location context, and an `ErrorReporter` type alias.