### PR TITLE
Remove unused `interactive` flag from distillation loop

### DIFF
--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -287,7 +287,6 @@ async def get_purchase_history_with_details(
             location=f"https://www.amazon.com/your-orders/orders?timeFilter={timeFilter}&startIndex={start_index}#pagination/${page_index}/time/${year}/",
             patterns=patterns,
             browser=browser,
-            interactive=False,
             timeout=10,  # need to increase timeout for business account pagination, since its SPA
             page=page,
             close_page=False,

--- a/getgather/mcp/amazonca.py
+++ b/getgather/mcp/amazonca.py
@@ -286,7 +286,6 @@ async def get_purchase_history_with_details(
             location=f"https://www.amazon.com/your-orders/orders?timeFilter={timeFilter}&startIndex={start_index}#pagination/${page_index}/time/${year}/",
             patterns=patterns,
             browser=browser,
-            interactive=False,
             timeout=10,  # need to increase timeout for business account pagination, since its SPA
             page=page,
             close_page=False,

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -129,7 +129,6 @@ async def _probe_page(
         patterns=patterns,
         browser=browser,
         timeout=timeout,
-        interactive=False,
         close_page=False,
         page=page,
     )
@@ -607,7 +606,6 @@ async def remote_zen_dpage_mcp_tool(
         patterns=patterns,
         browser=browser,
         timeout=timeout,
-        interactive=False,
         close_page=False,
         page=page,
         error_reporter=error_reporter,
@@ -705,7 +703,6 @@ async def remote_zen_dpage_with_action(
         patterns=patterns,
         browser=browser,
         timeout=timeout,
-        interactive=False,
         close_page=False,
         page=page,
         error_reporter=error_reporter,

--- a/getgather/mcp/garmin.py
+++ b/getgather/mcp/garmin.py
@@ -26,7 +26,6 @@ async def _garmin_add_activity_ids_action(tab: zd.Tab, browser: zd.Browser) -> d
         timeout=10,
         page=tab,
         close_page=False,
-        interactive=False,
     )
 
     activities = converted if converted else []

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -497,7 +497,6 @@ async def run_distillation_loop(
     patterns: list[Pattern],
     browser: zd.Browser,
     timeout: int = 15,
-    interactive: bool = True,
     close_page: bool = True,
     page: zd.Tab | None = None,
     error_reporter: ErrorReporter | None = None,
@@ -559,10 +558,6 @@ async def run_distillation_loop(
                     if close_page:
                         await safe_close_page(page)
                     return (True, distilled, converted)
-
-                if interactive:
-                    await autoclick(page, distilled, "[gg-autoclick]")
-                    await autoclick(page, distilled, "button[type=submit]")
 
                 current.distilled = distilled
 

--- a/tests/distillation/test_distill.py
+++ b/tests/distillation/test_distill.py
@@ -92,7 +92,6 @@ async def test_distillation_loop(location: str):
             patterns=patterns,
             browser=browser,
             timeout=30,
-            interactive=True,
         )
         result = converted if converted else distilled
         assert result, "No result found when one was expected."
@@ -384,7 +383,6 @@ async def test_distillation_captures_screenshot_without_pattern(
             patterns=patterns,
             browser=browser,
             timeout=2,
-            interactive=False,
             error_reporter=make_error_reporter(browser, f"{ACME_HOSTNAME}/random-info-page"),
         )
 


### PR DESCRIPTION
The `interactive` parameter on `run_distillation_loop` was always passed as `False`. When set to `True`, it triggered automatic clicking of some elements, this behavior  is now handled elsewhere. Remove the parameter and the dead branching logic, and clean up all callers.