### PR TITLE
fix(youtube): use playlistVideoRenderer schema for liked videos extraction

### DIFF
--- a/getgather/mcp/patterns/youtube-liked-videos-script.json
+++ b/getgather/mcp/patterns/youtube-liked-videos-script.json
@@ -1,38 +1,36 @@
 {
-  "rows": "contents.twoColumnBrowseResultsRenderer.tabs.0.tabRenderer.content.sectionListRenderer.contents.0.itemSectionRenderer.contents",
-  "row_key": "lockupViewModel",
+  "rows": "contents.twoColumnBrowseResultsRenderer.tabs.0.tabRenderer.content.sectionListRenderer.contents.0.itemSectionRenderer.contents.0.playlistVideoListRenderer.contents",
+  "row_key": "playlistVideoRenderer",
   "columns": [
     {
       "name": "title",
-      "path": "metadata.lockupMetadataViewModel.title.content"
+      "path": "title.runs.0.text"
     },
     {
       "name": "url",
-      "path": "contentId",
+      "path": "videoId",
       "prefix": "/watch?v="
     },
     {
       "name": "thumbnail",
-      "path": "contentImage.thumbnailViewModel.image.sources.0.url"
+      "path": "thumbnail.thumbnails.0.url"
     },
     {
       "name": "channel",
-      "path": "metadata.lockupMetadataViewModel.metadata.contentMetadataViewModel.metadataRows.0.metadataParts.0.text.content"
+      "path": "shortBylineText.runs.0.text"
     },
     {
       "name": "channel_url",
-      "path": "metadata.lockupMetadataViewModel.image.decoratedAvatarViewModel.rendererContext.commandContext.onTap.innertubeCommand.browseEndpoint.canonicalBaseUrl",
-      "fallback_path": "metadata.lockupMetadataViewModel.metadata.contentMetadataViewModel.metadataRows.0.metadataParts.0.text.commandRuns.0.onTap.innertubeCommand.commandMetadata.webCommandMetadata.url"
+      "path": "shortBylineText.runs.0.navigationEndpoint.browseEndpoint.canonicalBaseUrl"
     },
     {
       "name": "views_and_date",
-      "path": "metadata.lockupMetadataViewModel.metadata.contentMetadataViewModel.metadataRows.1.metadataParts",
-      "join_path": "text.content",
-      "join_separator": " | "
+      "path": "videoInfo.runs",
+      "join": "text"
     },
     {
       "name": "duration",
-      "path": "contentImage.thumbnailViewModel.overlays.0.thumbnailBottomOverlayViewModel.badges.0.thumbnailBadgeViewModel.text"
+      "path": "lengthText.simpleText"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `youtube_get_liked_videos` was returning `[]` because the schema assumed the old `lockupViewModel` shape under `sectionListRenderer → itemSectionRenderer`.
- Live capture of `window.ytInitialData` from `/playlist?list=LL` confirmed the page uses the same shape as watch-later: `playlistVideoListRenderer.contents` with `playlistVideoRenderer` items.
- Schema rewritten to walk the real path and map columns against `playlistVideoRenderer` fields (`title.runs.0.text`, `videoId`, `thumbnail.thumbnails.0.url`, `shortBylineText.runs.0.…`, `videoInfo.runs` joined on `text`, `lengthText.simpleText`).

<img width="624" height="357" alt="Screenshot 2026-04-24 at 18 09 16" src="https://github.com/user-attachments/assets/53128dee-efaa-4835-8582-cd45bbf0b03e" />


## Test plan
- [x] Sign in, call `youtube_get_liked_videos` — expect non-empty list with all 7 fields populated per item