### PR TITLE
chore: remove unused IP_CHECK_URL constant

### DIFF
--- a/getgather/main.py
+++ b/getgather/main.py
@@ -2,7 +2,7 @@ import ast
 import asyncio
 from contextlib import AsyncExitStack, asynccontextmanager
 from datetime import datetime
-from typing import Awaitable, Callable, Final
+from typing import Awaitable, Callable
 
 from fastapi import FastAPI, Request
 from fastapi.responses import (
@@ -71,9 +71,6 @@ def health():
     return PlainTextResponse(
         content=f"OK {int(datetime.now().timestamp())} GIT_REV: {settings.GIT_REV}"
     )
-
-
-IP_CHECK_URL: Final[str] = "https://ip.fly.dev/ip"
 
 
 @app.get("/extended-health")


### PR DESCRIPTION
## Summary
Drops the dead `IP_CHECK_URL: Final[str] = "https://ip.fly.dev/ip"` constant in `getgather/main.py` (and the now-unused `Final` import). The only caller, `extended_health()`, hardcodes the URL literal directly, and nothing else references the name. 