### PR TITLE
refactor: remove unused close_page parameter from distillation

### DIFF
--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -289,7 +289,6 @@ async def get_purchase_history_with_details(
             browser=browser,
             timeout=10,  # need to increase timeout for business account pagination, since its SPA
             page=page,
-            close_page=False,
         )
         if orders is None:
             return {"amazon_purchase_history": []}

--- a/getgather/mcp/amazonca.py
+++ b/getgather/mcp/amazonca.py
@@ -288,7 +288,6 @@ async def get_purchase_history_with_details(
             browser=browser,
             timeout=10,  # need to increase timeout for business account pagination, since its SPA
             page=page,
-            close_page=False,
         )
         if orders is None:
             return {"amazonca_purchase_history": []}

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -129,7 +129,6 @@ async def _probe_page(
         patterns=patterns,
         browser=browser,
         timeout=timeout,
-        close_page=False,
         page=page,
     )
     return terminated
@@ -606,7 +605,6 @@ async def remote_zen_dpage_mcp_tool(
         patterns=patterns,
         browser=browser,
         timeout=timeout,
-        close_page=False,
         page=page,
         error_reporter=error_reporter,
     )
@@ -703,7 +701,6 @@ async def remote_zen_dpage_with_action(
         patterns=patterns,
         browser=browser,
         timeout=timeout,
-        close_page=False,
         page=page,
         error_reporter=error_reporter,
     )

--- a/getgather/mcp/garmin.py
+++ b/getgather/mcp/garmin.py
@@ -25,7 +25,6 @@ async def _garmin_add_activity_ids_action(tab: zd.Tab, browser: zd.Browser) -> d
         browser=browser,
         timeout=10,
         page=tab,
-        close_page=False,
     )
 
     activities = converted if converted else []

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -22,7 +22,6 @@ from getgather.browser import (
     get_new_page,
     page_batch_extract,
     page_query_selector,
-    safe_close_page,
     terminate_remote_browser,
     wait_for_ready_state,
     zen_navigate_with_retry,
@@ -497,7 +496,6 @@ async def run_distillation_loop(
     patterns: list[Pattern],
     browser: zd.Browser,
     timeout: int = 15,
-    close_page: bool = True,
     page: zd.Tab | None = None,
     error_reporter: ErrorReporter | None = None,
 ) -> tuple[bool, str, ConversionResult | None]:
@@ -555,8 +553,6 @@ async def run_distillation_loop(
 
                 if await terminate(distilled):
                     converted = await convert(distilled, pattern_path=match.name)
-                    if close_page:
-                        await safe_close_page(page)
                     return (True, distilled, converted)
 
                 current.distilled = distilled
@@ -571,8 +567,6 @@ async def run_distillation_loop(
             hostname=hostname,
             iteration=max,
         )
-    if close_page:
-        await safe_close_page(page)
     return (False, current.distilled, None)
 
 


### PR DESCRIPTION
The `close_page` parameter in `run_distillation_loop` and its callers was always passed as `False`, making it dead code.