### PR TITLE
fix(amazon): add sign-in error patterns for blocked account flows

### DIFF
--- a/getgather/mcp/patterns/amazon-error-choose-payment.html
+++ b/getgather/mcp/patterns/amazon-error-choose-payment.html
@@ -1,0 +1,14 @@
+<html gg-domain="amazon">
+  <head>
+    <title>Choose payment card to verify</title>
+  </head>
+  <body>
+    <h2
+      gg-stop
+      gg-error="reset_password"
+      gg-match="//div[@id='card_selection_title']//span[contains(normalize-space(.), 'Choose payment card to verify')]"
+    >
+      Choose payment card to verify
+    </h2>
+  </body>
+</html>

--- a/getgather/mcp/patterns/amazon-error-multiple-email.html
+++ b/getgather/mcp/patterns/amazon-error-multiple-email.html
@@ -1,0 +1,14 @@
+<html gg-domain="amazon">
+  <head>
+    <title>Multiple accounts use the email</title>
+  </head>
+  <body>
+    <h2
+      gg-stop
+      gg-error="reset_password"
+      gg-match-html="//h4[contains(normalize-space(.), 'Multiple accounts use the email')]"
+    >
+      Multiple accounts use the email
+    </h2>
+  </body>
+</html>

--- a/getgather/mcp/patterns/amazon-error-policy-violation.html
+++ b/getgather/mcp/patterns/amazon-error-policy-violation.html
@@ -1,0 +1,14 @@
+<html gg-domain="amazon">
+  <head>
+    <title>Return Policy Violation</title>
+  </head>
+  <body>
+    <h2
+      gg-stop
+      gg-error="reset_password"
+      gg-match="//h4[contains(@class, 'a-alert-heading') and normalize-space(.)='Return Policy Violation']"
+    >
+      Return Policy Violation
+    </h2>
+  </body>
+</html>

--- a/getgather/mcp/patterns/amazon-error-security-code.html
+++ b/getgather/mcp/patterns/amazon-error-security-code.html
@@ -5,7 +5,7 @@
   <body>
     <h2
       gg-stop
-      gg-error="security_code"
+      gg-error="reset_password"
       gg-match="//span[contains(@class, 'a-size-large') and contains(@class, 'a-text-bold') and contains(normalize-space(.), 'security code')]"
     >
       Enter your card's security code

--- a/getgather/mcp/patterns/amazon-error-security-code.html
+++ b/getgather/mcp/patterns/amazon-error-security-code.html
@@ -1,0 +1,14 @@
+<html gg-domain="amazon">
+  <head>
+    <title>Enter card security code</title>
+  </head>
+  <body>
+    <h2
+      gg-stop
+      gg-error="security_code"
+      gg-match="//span[contains(@class, 'a-size-large') and contains(@class, 'a-text-bold') and contains(normalize-space(.), 'security code')]"
+    >
+      Enter your card's security code
+    </h2>
+  </body>
+</html>


### PR DESCRIPTION
## Overview
This PR adds three Amazon distillation error patterns so blocked/verification sign-in states are detected earlier and surfaced as structured MCP errors instead of stalling the flow.

## Testing
| screenshot |
|---|
| <img width="1204" height="986" alt="image" src="https://github.com/user-attachments/assets/379378ea-089b-4fcd-8f78-826459d479b4" /> |
| <img width="1178" height="985" alt="image" src="https://github.com/user-attachments/assets/1f31fec5-965c-4095-a3a5-29732da5ebfd" /> |
| <img width="1216" height="990" alt="image" src="https://github.com/user-attachments/assets/9217aff4-f801-4adf-9586-5c94d517d35b" /> |
| <img width="1207" height="992" alt="image" src="https://github.com/user-attachments/assets/664dfada-4825-4cc2-9d20-fbf02e9e7279" /> |