### PR TITLE
feat(amazon): add new sign-in distillation patterns

### DIFF
--- a/getgather/mcp/patterns/amazon-approve-notification.html
+++ b/getgather/mcp/patterns/amazon-approve-notification.html
@@ -1,0 +1,15 @@
+<html gg-domain="amazon">
+  <head>
+    <title>Approve notification</title>
+  </head>
+  <body>
+    <h2
+      gg-match="//span[contains(@class, 'transaction-approval-word-break') and contains(normalize-space(.), 'approve the notification sent to')]"
+    >
+      Approve the notification sent to
+    </h2>
+    <div gg-match-html="#channelDetailsWithImprovedLayout"></div>
+    <input type="text" value="submit" name="submit" style="display: none" />
+    <button type="submit">I've done this</button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/amazon-zip-code-required.html
+++ b/getgather/mcp/patterns/amazon-zip-code-required.html
@@ -1,0 +1,13 @@
+<html gg-domain="amazon">
+  <head>
+    <title>ZIP code required</title>
+  </head>
+  <body>
+    <h2 gg-match="//h1[contains(normalize-space(.), 'Almost done!')]">Almost done!</h2>
+    <p gg-match-html="//p[contains(normalize-space(.), 'ZIP code')]"></p>
+
+    <label>ZIP code</label>
+    <input gg-match="#ap_zip" type="text" name="zipCode" />
+    <button gg-match="#continue" type="submit">Continue</button>
+  </body>
+</html>


### PR DESCRIPTION
## Overview
Adds two Amazon sign-in patterns to handle approve-notification and ZIP-code-required flows, improving login coverage in the distillation process.

## Testing

| screenshot |
|---|
| <img width="1195" height="991" alt="image" src="https://github.com/user-attachments/assets/36617502-2260-44d3-b959-98a2e3c1f978" /> |
| <img width="1221" height="989" alt="image" src="https://github.com/user-attachments/assets/50310de0-e507-4db0-8c36-8ce48f70bbc4" /> |