### PR TITLE
fix(amazon): create-password submit button selector

### DIFF
--- a/getgather/mcp/patterns/amazon-create-new-password-required.html
+++ b/getgather/mcp/patterns/amazon-create-new-password-required.html
@@ -8,6 +8,8 @@
       gg-error="create_new_password"
       gg-match-html="//h1[contains(., 'Create new password')]"
     ></h1>
-    <span gg-match="//span.a-button-inner[contains(., 'Save changes and Sign-In')]"></span>
+    <span
+      gg-match="//span[contains(@class, 'a-button-text') and contains(normalize-space(.), 'Save changes and Sign-In')]"
+    ></span>
   </body>
 </html>


### PR DESCRIPTION
## Overview
This updates the Amazon create-password distillation pattern to use a more robust XPath for the "Save changes and Sign-In" button, improving match reliability across UI variations.

## Testing
| screenshot |
|---|
| <img width="1162" height="995" alt="image" src="https://github.com/user-attachments/assets/058591ee-e33e-4e22-a395-ebaa6efe838c" /> |