### PR TITLE
fix: deepcopy pattern tree per distill call to prevent mutation

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -335,8 +335,9 @@ async def distill(
 
     for item in patterns:
         name = item.name
+        pattern = deepcopy(item.pattern)
 
-        root = item.pattern.find("html")
+        root = pattern.find("html")
         gg_priority = root.get("gg-priority", "-1") if isinstance(root, Tag) else "-1"
         try:
             priority = int(str(gg_priority).lstrip("= "))
@@ -350,7 +351,6 @@ async def distill(
                 logger.trace(f"Skipping {name} due to mismatched domain {domain}")
                 continue
 
-        pattern = deepcopy(item.pattern)
         logger.debug(f"Checking {name} with priority {priority}")
 
         targets = pattern.find_all(attrs={"gg-match": True}) + pattern.find_all(

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import urllib.parse
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
 from glob import glob
@@ -334,9 +335,8 @@ async def distill(
 
     for item in patterns:
         name = item.name
-        pattern = item.pattern
 
-        root = pattern.find("html")
+        root = item.pattern.find("html")
         gg_priority = root.get("gg-priority", "-1") if isinstance(root, Tag) else "-1"
         try:
             priority = int(str(gg_priority).lstrip("= "))
@@ -350,6 +350,7 @@ async def distill(
                 logger.trace(f"Skipping {name} due to mismatched domain {domain}")
                 continue
 
+        pattern = deepcopy(item.pattern)
         logger.debug(f"Checking {name} with priority {priority}")
 
         targets = pattern.find_all(attrs={"gg-match": True}) + pattern.find_all(


### PR DESCRIPTION
## Problem

`distill()` in `zen_distill.py` reuses the same `Pattern.pattern` BeautifulSoup tree across every polling tick in `run_distillation_loop`. The second loop mutates `Tag` objects in-place:

- `target.extract()` — removes optional nodes permanently from the tree
- `target.string = raw_text` — overwrites text content
- `target.clear()` / `target.append()` — replaces children for html targets

After the first iteration, subsequent calls to `distill()` see a corrupted tree: optional nodes are gone, text is filled with stale values from the previous tick.

## Root cause

Introduced in #1143 (`0468d1b5`) when `target.extract()` was added for optional elements. Before that, optional nodes were skipped but left in the tree, so the other mutations (`.string`, `.clear`) were less visibly destructive. The `target.extract()` line made the shared-state bug impossible to ignore — `gg-optional` nodes would permanently disappear from the pattern skeleton after the first non-matching tick, causing the pattern to match incorrectly (or not at all) on every subsequent tick.

## Fix

`deepcopy(item.pattern)` at the start of each pattern iteration. Every call to `distill()` operates on a fresh copy of the tree; the source `Pattern.pattern` is never mutated.

```python
# before
pattern = item.pattern

# after
pattern = deepcopy(item.pattern)
```

One import, one line change. All three mutation types are covered. No logic changes.

## Impact

- Fixes `gg-optional` elements disappearing from patterns across polling ticks
- Fixes stale text/html leaking into pattern matching from previous iterations
- Affects all patterns that use `gg-optional` — most visibly `google-signin-choose-method.html`