### PR TITLE
Unify MCP tool registration through YAML + declarative_mcp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,18 +44,19 @@ uv run python tests/manual.py call-tool --mcp media --tool bbc_get_saved_article
 - `/mcp-<brand_id>` — one app per brand (e.g. `/mcp-amazon`)
 - `/mcp-<category>` — category bundles defined in `MCP_BUNDLES` (media, books, shopping, sports, food)
 
-Each brand registers itself at import time by instantiating `GatherMCP(brand_id=..., name=...)` in `getgather/mcp/<brand>.py`. The constructor inserts into `GatherMCP.registry`. The parent MCP app then `mount()`s each brand MCP with its brand*id as namespace, so tools appear as `<brand_id>*<tool_name>`(e.g.`goodreads_get_book_list`).
+All brands are registered in `getgather/mcp/mcp-tools.yaml`. `declarative_mcp.py` creates `MCPTool` instances from the YAML config at import time (module-level), populating `MCPTool.registry`. The parent MCP app then `mount()`s each brand MCP with its `brand_id` as namespace, so tools appear as `<brand_id>_<tool_name>` (e.g. `goodreads_get_book_list`).
 
-Adding a new brand requires two steps: (1) create the module with a `GatherMCP` instance and `@<brand>_mcp.tool` functions, (2) add an import to `_brand_modules` in `getgather/mcp/main.py`.
+Adding a new brand requires: (1) add a YAML entry in `mcp-tools.yaml` with `id`, `name`, and `tools` list, plus `custom: true` and `module: <module_name>` if it has a custom Python module, (2) if custom, the module must look up its MCPTool via `MCPTool.registry["<brand_id>"]` and register tools with `@brand_mcp.tool`.
 
 ### Declarative vs imperative brands
 
-Simple brands (one URL → one distilled result) are declared in YAML at `getgather/mcp/mcp-tools.yaml` and auto-registered via `declarative_mcp.create_declarative_mcp_tools()`. Two tool kinds:
+All brands are declared in YAML at `getgather/mcp/mcp-tools.yaml`. `declarative_mcp.create_declarative_mcp_tools()` runs at module level and creates `MCPTool` instances from YAML for every brand. Two registration modes:
 
-- default: `remote_zen_dpage_mcp_tool(url, result_key, timeout)` — full sign-in flow via dpage
-- `short_lived: true`: `short_lived_mcp_tool(location, pattern_wildcard, result_key, hostname)` — one-off scrape for public pages (CNN, ESPN, Ground News, NPR, NYTimes)
+- **Declarative** (no `custom: true`): tools are auto-generated from YAML config. Two tool kinds:
+  - default: `remote_zen_dpage_mcp_tool(url, result_key, timeout)` — full sign-in flow via dpage
+  - `short_lived: true`: `short_lived_mcp_tool(location, pattern_wildcard, result_key, hostname)` — one-off scrape for public pages (CNN, ESPN, Ground News, NPR, NYTimes)
 
-Brands needing custom logic (post-signin actions, JSON response interception, multi-page flows) have their own `.py` module (amazon, blinds, goodreads, tokopedia, youtube, etc.) using `remote_zen_dpage_with_action(initial_url, action)` where `action` is an `async (page, browser) -> dict`.
+- **Custom** (`custom: true`, `module: <name>`): declarative_mcp creates the MCPTool, then dynamically imports the brand module. The module looks up `MCPTool.registry["<brand_id>"]` and uses `@brand_mcp.tool` to register tools with custom logic (post-signin actions, JSON response interception, multi-page flows) via `remote_zen_dpage_with_action(initial_url, action)` where `action` is an `async (page, browser) -> dict`.
 
 ### Distillation engine (`zen_distill.py`)
 

--- a/getgather/mcp/alfagift.py
+++ b/getgather/mcp/alfagift.py
@@ -6,7 +6,7 @@ from getgather.mcp.dpage import remote_zen_dpage_with_action
 from getgather.mcp.registry import MCPTool
 from getgather.zen_actions import parse_response_json
 
-alfagift_mcp = MCPTool(brand_id="alfagift", name="Alfagift MCP")
+alfagift_mcp = MCPTool.registry["alfagift"]
 
 
 @alfagift_mcp.tool

--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -19,7 +19,7 @@ from getgather.zen_distill import (
     run_distillation_loop,
 )
 
-amazon_mcp = MCPTool(brand_id="amazon", name="Amazon MCP")
+amazon_mcp = MCPTool.registry["amazon"]
 
 
 def normalize_order_id(order_id: str | list[str] | None) -> str | list[str] | None:

--- a/getgather/mcp/amazonca.py
+++ b/getgather/mcp/amazonca.py
@@ -19,7 +19,7 @@ from getgather.zen_distill import (
     run_distillation_loop,
 )
 
-amazonca_mcp = MCPTool(brand_id="amazonca", name="Amazon CA MCP")
+amazonca_mcp = MCPTool.registry["amazonca"]
 
 
 def normalize_order_id(order_id: str | list[str] | None) -> str | list[str] | None:

--- a/getgather/mcp/americanairlines.py
+++ b/getgather/mcp/americanairlines.py
@@ -6,7 +6,7 @@ from getgather.mcp.dpage import remote_zen_dpage_with_action
 from getgather.mcp.registry import MCPTool
 from getgather.zen_actions import parse_response_json
 
-americanairlines_mcp = MCPTool(brand_id="americanairlines", name="American Airlines MCP")
+americanairlines_mcp = MCPTool.registry["americanairlines"]
 
 
 @americanairlines_mcp.tool

--- a/getgather/mcp/blinds.py
+++ b/getgather/mcp/blinds.py
@@ -12,7 +12,7 @@ from getgather.mcp.dpage import (
 from getgather.mcp.registry import MCPTool
 from getgather.zen_actions import parse_response_json
 
-blinds_mcp = MCPTool(brand_id="blinds", name="Blinds MCP")
+blinds_mcp = MCPTool.registry["blinds"]
 
 # Element configuration for typing delays
 blinds_config = ElementConfig(typing_clear_delay=0.75)

--- a/getgather/mcp/blindster.py
+++ b/getgather/mcp/blindster.py
@@ -14,7 +14,7 @@ from getgather.mcp.dpage import (
 from getgather.mcp.registry import MCPTool
 from getgather.zen_actions import parse_response_json
 
-blindster_mcp = MCPTool(brand_id="blindster", name="Blindster MCP")
+blindster_mcp = MCPTool.registry["blindster"]
 
 
 @blindster_mcp.tool

--- a/getgather/mcp/calendar.py
+++ b/getgather/mcp/calendar.py
@@ -9,7 +9,7 @@ from fastmcp import Context
 from getgather.mcp.registry import MCPTool
 
 # Create a generic calendar MCP
-calendar_mcp = MCPTool(brand_id="calendar", name="Calendar MCP")
+calendar_mcp = MCPTool.registry["calendar"]
 
 
 def escape_ics_text(value: str) -> str:

--- a/getgather/mcp/declarative_mcp.py
+++ b/getgather/mcp/declarative_mcp.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 from typing import Any
 
 import yaml
+from loguru import logger
 from pydantic import BaseModel
 
 from getgather.mcp.dpage import remote_zen_dpage_mcp_tool
@@ -16,7 +18,7 @@ YAML_CONFIG_PATH = Path(__file__).parent / "mcp-tools.yaml"
 class ToolConfig(BaseModel):
     function_name: str
     description: str
-    result_key: str
+    result_key: str | None = None
     url: str | None = None
     timeout: int | None = None
     short_lived: bool = False
@@ -27,7 +29,9 @@ class ToolConfig(BaseModel):
 class McpConfig(BaseModel):
     id: str
     name: str
-    tools: list[ToolConfig]
+    tools: list[ToolConfig] = []
+    custom: bool = False
+    module: str | None = None
 
 
 def _load_mcp_config() -> list[McpConfig]:
@@ -43,12 +47,28 @@ def create_declarative_mcp_tools() -> None:
     """Create and register MCP tools from configuration array.
 
     This function generates MCPTool instances and their tools dynamically
-    from the DECLARATIVE_MCP_CONFIG array. Tools can be either remote zen dpage tools
-    or short-lived tools.
+    from the DECLARATIVE_MCP_CONFIG array. Tools can be either remote zen dpage tools,
+    short-lived tools, or custom-code modules.
+
+    For custom-code entries (custom: true), the MCPTool is created and then the
+    Python module is imported so its @<id>_mcp.tool decorators register tools.
+    This function is idempotent — calling it again is a no-op if all entries
+    already exist in the registry.
     """
 
     for config in DECLARATIVE_MCP_CONFIG:
+        if config.id in MCPTool.registry:
+            logger.debug(f"MCPTool '{config.id}' already registered, skipping")
+            continue
+
         gather_mcp = MCPTool(brand_id=config.id, name=config.name)
+
+        if config.custom:
+            module_name: str = config.module or config.id
+            import_path = f"getgather.mcp.{module_name}"
+            logger.info(f"Loading custom-code module: {import_path}")
+            importlib.import_module(import_path)
+            continue
 
         for tool_config in config.tools:
             function_name: str = tool_config.function_name
@@ -58,7 +78,7 @@ def create_declarative_mcp_tools() -> None:
             if short_lived:
                 url: str = tool_config.url or ""
                 pattern_wildcard: str = tool_config.pattern_wildcard or ""
-                result_key: str = tool_config.result_key
+                result_key: str = tool_config.result_key or ""
                 hostname: str = tool_config.hostname or ""
 
                 def make_short_lived_tool_fn(
@@ -84,7 +104,7 @@ def create_declarative_mcp_tools() -> None:
 
             else:
                 url: str = tool_config.url or ""
-                result_key: str = tool_config.result_key
+                result_key: str = tool_config.result_key or ""
                 timeout: int = tool_config.timeout if tool_config.timeout is not None else 2
 
                 def make_remote_tool_fn(
@@ -102,3 +122,8 @@ def create_declarative_mcp_tools() -> None:
             tool_func.__name__ = function_name
             tool_func.__doc__ = description
             gather_mcp.tool(tool_func)
+
+
+# Run at import time so custom-code modules can look up MCPTool.registry
+# (called again from create_mcp_apps() as a safety net; idempotent)
+create_declarative_mcp_tools()

--- a/getgather/mcp/doordash.py
+++ b/getgather/mcp/doordash.py
@@ -10,7 +10,7 @@ from getgather.mcp.dpage import (
 )
 from getgather.mcp.registry import MCPTool
 
-doordash_mcp = MCPTool(brand_id="doordash", name="Doordash MCP")
+doordash_mcp = MCPTool.registry["doordash"]
 
 
 @doordash_mcp.tool

--- a/getgather/mcp/garmin.py
+++ b/getgather/mcp/garmin.py
@@ -12,7 +12,7 @@ from getgather.zen_distill import load_distillation_patterns, run_distillation_l
 
 GARMIN_TIMEOUT_SECONDS = 15
 
-garmin_mcp = MCPTool(brand_id="garmin", name="Garmin MCP")
+garmin_mcp = MCPTool.registry["garmin"]
 
 
 async def _garmin_add_activity_ids_action(tab: zd.Tab, browser: zd.Browser) -> dict[str, Any]:

--- a/getgather/mcp/goodreads.py
+++ b/getgather/mcp/goodreads.py
@@ -23,11 +23,8 @@ goodreads_app_ui = ToolUI(
     ),
 )
 
-goodreads_mcp = MCPTool(
-    brand_id="goodreads",
-    name="Goodreads MCP",
-    app_ui=goodreads_app_ui,
-)
+goodreads_mcp = MCPTool.registry["goodreads"]
+goodreads_mcp.app_ui = goodreads_app_ui
 
 
 async def _goodreads_book_details_action(tab: zd.Tab, _browser: zd.Browser) -> dict[str, Any]:

--- a/getgather/mcp/kroger.py
+++ b/getgather/mcp/kroger.py
@@ -5,10 +5,7 @@ from getgather.mcp.dpage import (
 )
 from getgather.mcp.registry import MCPTool
 
-kroger_mcp = MCPTool(
-    brand_id="kroger",
-    name="Kroger MCP",
-)
+kroger_mcp = MCPTool.registry["kroger"]
 
 
 @kroger_mcp.tool

--- a/getgather/mcp/main.py
+++ b/getgather/mcp/main.py
@@ -1,4 +1,3 @@
-# ruff: noqa: F401
 from dataclasses import dataclass
 from functools import cache, cached_property
 from typing import Any, Literal, cast
@@ -12,44 +11,7 @@ from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from loguru import logger
 from pydantic import BaseModel
 
-from getgather.mcp import (
-    alfagift,
-    amazon,
-    amazonca,
-    americanairlines,
-    blinds,
-    blindster,
-    calendar,
-    doordash,
-    garmin,
-    goodreads,
-    kroger,
-    nordstrom,
-    shopee,
-    tokopedia,
-    wayfair,
-    youtube,
-)
-
-_brand_modules = (
-    alfagift,
-    amazon,
-    amazonca,
-    americanairlines,
-    blinds,
-    blindster,
-    calendar,
-    doordash,
-    garmin,
-    goodreads,
-    nordstrom,
-    shopee,
-    tokopedia,
-    wayfair,
-    youtube,
-    kroger,
-)
-
+import getgather.mcp.declarative_mcp  # noqa: F401  # pyright: ignore[reportUnusedImport]
 from getgather.auth.auth import get_auth_user
 from getgather.mcp.dpage import (
     dpage_check,
@@ -169,10 +131,6 @@ class MCPApp:
 
 @cache
 def create_mcp_apps() -> list[MCPApp]:
-    from getgather.mcp.declarative_mcp import create_declarative_mcp_tools
-
-    create_declarative_mcp_tools()
-
     apps: list[MCPApp] = []
     apps.append(
         MCPApp(

--- a/getgather/mcp/mcp-tools.yaml
+++ b/getgather/mcp/mcp-tools.yaml
@@ -14,6 +14,16 @@
       url: https://www.agoda.com/account/bookings.html?sort=BookingStartDate&state=Completed&page=1
       result_key: agoda_complete_bookings
 
+- id: alfagift
+  name: Alfagift MCP
+  custom: true
+  module: alfagift
+  tools:
+    - function_name: get_cart
+      description: Get cart alfagift.
+    - function_name: get_order_done
+      description: Get order done alfagift.
+
 - id: aliexpress
   name: AliExpress MCP
   tools:
@@ -38,6 +48,62 @@
       description: Get the list of items in the cart from Amain Hobbies
       url: https://www.amainhobbies.com/cart
       result_key: amain_cart
+
+- id: amazon
+  name: Amazon MCP
+  custom: true
+  module: amazon
+  tools:
+    - function_name: get_browsing_history
+      description: Get browsing history from amazon.
+    - function_name: get_prime_library
+      description: Get Prime Video purchases and rentals library from Amazon.
+    - function_name: get_purchase_history
+      description: Get purchase/order history of amazon.
+    - function_name: get_purchase_history_with_details
+      description: Get purchase/order history of amazon with details.
+    - function_name: get_watch_history
+      description: Get video watch history from Amazon.
+    - function_name: get_watchlist
+      description: Get Prime Video watchlist from Amazon.
+    - function_name: search_product
+      description: Search product on amazon.
+    - function_name: search_purchase_history
+      description: Search purchase history from amazon.
+    - function_name: signin
+      description: Signin to amazon.
+
+- id: amazonca
+  name: Amazon CA MCP
+  custom: true
+  module: amazonca
+  tools:
+    - function_name: get_browsing_history
+      description: Get browsing history from Amazon Canada.
+    - function_name: get_prime_library
+      description: Get Prime Video purchases and rentals library from Amazon Canada.
+    - function_name: get_purchase_history
+      description: Get purchase/order history of Amazon Canada.
+    - function_name: get_purchase_history_with_details
+      description: Get purchase/order history of Amazon Canada with details.
+    - function_name: get_watch_history
+      description: Get video watch history from Amazon Canada Prime Video.
+    - function_name: get_watchlist
+      description: Get Prime Video watchlist from Amazon Canada.
+    - function_name: search_product
+      description: Search product on Amazon Canada.
+    - function_name: search_purchase_history
+      description: Search purchase history from Amazon Canada.
+
+- id: americanairlines
+  name: American Airlines MCP
+  custom: true
+  module: americanairlines
+  tools:
+    - function_name: get_recent_activity
+      description: Get recent activity (purchase history) of americanairlines.
+    - function_name: get_upcoming_flights
+      description: Get upcoming flights of americanairlines.
 
 - id: ashley
   name: Ashley MCP
@@ -75,6 +141,26 @@
       url: https://www.bedbathandbeyond.com/cart
       result_key: bedbathandbeyond_cart
 
+- id: blinds
+  name: Blinds MCP
+  custom: true
+  module: blinds
+  tools:
+    - function_name: get_favorites
+      description: Get favorites of blinds.
+    - function_name: get_orders
+      description: Get orders of blinds.
+
+- id: blindster
+  name: Blindster MCP
+  custom: true
+  module: blindster
+  tools:
+    - function_name: get_carts
+      description: Get carts of blindster.
+    - function_name: get_orders
+      description: Get orders of blindster.
+
 - id: booking
   name: Booking MCP
   tools:
@@ -82,6 +168,14 @@
       description: Get past trip of booking.com.
       url: https://secure.booking.com/mytrips.html
       result_key: booking_past_trips
+
+- id: calendar
+  name: Calendar MCP
+  custom: true
+  module: calendar
+  tools:
+    - function_name: create_calendar_event
+      description: Generate a generic calendar event with datetime and timezone support.
 
 - id: chewy
   name: Chewy MCP
@@ -118,6 +212,16 @@
       url: https://www.delta.com/mytrips
       result_key: delta_trips
 
+- id: doordash
+  name: Doordash MCP
+  custom: true
+  module: doordash
+  tools:
+    - function_name: get_orders
+      description: Get the orders from a user's Doordash account.
+    - function_name: get_orders_with_pagination
+      description: Get the order history from a user's Doordash account with pagination.
+
 - id: ebay
   name: Ebay MCP
   tools:
@@ -145,6 +249,20 @@
       url: https://www.expedia.com/mytrips
       result_key: expedia_past_trips
 
+- id: garmin
+  name: Garmin MCP
+  custom: true
+  module: garmin
+  tools:
+    - function_name: calculate_calories_burned
+      description: Calculate calories burned for a specific activity.
+    - function_name: calculate_tss
+      description: Calculate the TSS for a specific activity.
+    - function_name: get_activities
+      description: Get the activity history from a user's account.
+    - function_name: get_activity_stats
+      description: Get the stats for a specific activity.
+
 - id: gofood
   name: Gofood MCP
   tools:
@@ -153,6 +271,16 @@
       url: https://gofood.co.id/en/orders
       result_key: gofood_purchase_history
       timeout: 15
+
+- id: goodreads
+  name: Goodreads MCP
+  custom: true
+  module: goodreads
+  tools:
+    - function_name: get_book_details
+      description: Get details (title, author, rating, description) of a book on Goodreads.
+    - function_name: get_book_list
+      description: Get the book list from a user's Goodreads account.
 
 - id: google
   name: Google MCP
@@ -229,6 +357,14 @@
       url: https://www.amazon.com/hz/mycd/digital-console/contentlist/booksAll/dateDsc/
       result_key: kindle_book_list
 
+- id: kroger
+  name: Kroger MCP
+  custom: true
+  module: kroger
+  tools:
+    - function_name: get_purchases
+      description: Get purchases from a user Kroger account.
+
 - id: lazada
   name: Lazada MCP
   tools:
@@ -285,6 +421,14 @@
       description: Get orders of nike.
       url: https://www.nike.com/orders
       result_key: nike_orders
+
+- id: nordstrom
+  name: Nordstrom MCP
+  custom: true
+  module: nordstrom
+  tools:
+    - function_name: get_order_history
+      description: Get the details of an order from Nordstrom.
 
 - id: npr
   name: NPR MCP
@@ -364,6 +508,16 @@
       url: https://us.shein.com/my/orders.html
       result_key: shein_orders
 
+- id: shopee
+  name: Shopee MCP
+  custom: true
+  module: shopee
+  tools:
+    - function_name: get_purchase_history
+      description: Get purchase history of shopee.
+    - function_name: search_product
+      description: Search product on shopee.
+
 - id: starbucks
   name: Starbucks MCP
   tools:
@@ -380,6 +534,28 @@
       url: https://www.thriftbooks.com/cart
       result_key: thriftbooks_cart
 
+- id: tokopedia
+  name: Tokopedia MCP
+  custom: true
+  module: tokopedia
+  tools:
+    - function_name: get_cart
+      description: Get cart of tokopedia.
+    - function_name: get_product_details
+      description: Get product details from tokopedia.
+    - function_name: get_purchase_history
+      description: Get purchase history of tokopedia.
+    - function_name: get_shop_details
+      description: Get store details from tokopedia.
+    - function_name: get_wishlist
+      description: Get wishlist from tokopedia.
+    - function_name: remote_action_product_in_cart
+      description: Action a product in cart of tokopedia.
+    - function_name: search_product
+      description: Search products on Tokopedia.
+    - function_name: search_shop
+      description: Search shop on tokopedia.
+
 - id: traveloka
   name: Traveloka MCP
   tools:
@@ -387,6 +563,36 @@
       description: Get the saved list from Traveloka
       url: https://www.traveloka.com/en-id/user/saved/list
       result_key: traveloka_saved_list
+
+- id: wayfair
+  name: Wayfair MCP
+  custom: true
+  module: wayfair
+  tools:
+    - function_name: get_cart
+      description: Get cart of wayfair.
+    - function_name: get_order_history
+      description: Get order history of wayfair.
+    - function_name: get_order_history_details
+      description: Get order history details of wayfair.
+    - function_name: get_wishlist_details
+      description: Get wishlist details of wayfair.
+    - function_name: get_wishlists
+      description: Get wishlists of wayfair.
+
+- id: youtube
+  name: YouTube MCP
+  custom: true
+  module: youtube
+  tools:
+    - function_name: get_channel_subscriptions
+      description: Get channel subscriptions from YouTube.
+    - function_name: get_liked_videos
+      description: Get liked videos from YouTube.
+    - function_name: get_watch_history
+      description: Get watch history from YouTube.
+    - function_name: get_watch_later
+      description: Get watch later playlist from YouTube.
 
 - id: zillow
   name: Zillow MCP

--- a/getgather/mcp/nordstrom.py
+++ b/getgather/mcp/nordstrom.py
@@ -8,7 +8,7 @@ from getgather.mcp.dpage import remote_zen_dpage_with_action
 from getgather.mcp.registry import MCPTool
 from getgather.zen_actions import parse_response_json
 
-nordstrom_mcp = MCPTool(brand_id="nordstrom", name="Nordstrom MCP")
+nordstrom_mcp = MCPTool.registry["nordstrom"]
 
 
 async def get_order_details_with_retry(

--- a/getgather/mcp/shopee.py
+++ b/getgather/mcp/shopee.py
@@ -5,7 +5,7 @@ from getgather.mcp.registry import MCPTool
 
 SHOPEE_TIMEOUT_SECONDS = 15
 
-shopee_mcp = MCPTool(brand_id="shopee", name="Shopee MCP")
+shopee_mcp = MCPTool.registry["shopee"]
 
 
 @shopee_mcp.tool

--- a/getgather/mcp/tokopedia.py
+++ b/getgather/mcp/tokopedia.py
@@ -14,7 +14,7 @@ from getgather.mcp.dpage import (
 from getgather.mcp.registry import MCPTool
 from getgather.zen_actions import parse_response_json
 
-tokopedia_mcp = MCPTool(brand_id="tokopedia", name="Tokopedia MCP")
+tokopedia_mcp = MCPTool.registry["tokopedia"]
 
 
 @tokopedia_mcp.tool

--- a/getgather/mcp/wayfair.py
+++ b/getgather/mcp/wayfair.py
@@ -3,7 +3,7 @@ from typing import Any
 from getgather.mcp.dpage import remote_zen_dpage_mcp_tool
 from getgather.mcp.registry import MCPTool
 
-wayfair_mcp = MCPTool(brand_id="wayfair", name="Wayfair MCP")
+wayfair_mcp = MCPTool.registry["wayfair"]
 
 
 @wayfair_mcp.tool

--- a/getgather/mcp/youtube.py
+++ b/getgather/mcp/youtube.py
@@ -10,7 +10,7 @@ from getgather.browser import get_url
 from getgather.mcp.dpage import remote_zen_dpage_with_action
 from getgather.mcp.registry import MCPTool
 
-youtube_mcp = MCPTool(brand_id="youtube", name="YouTube MCP")
+youtube_mcp = MCPTool.registry["youtube"]
 
 
 def _resolve_json_path(obj: dict[str, Any] | list[Any] | None, path: str) -> Any:


### PR DESCRIPTION
All 16 custom MCP tools now have entries in `mcp-tools.yaml` with `custom: true` and module fields. `declarative_mcp.py` runs at import time, creating MCPTool instances from YAML and dynamically importing custom modules. Custom modules look up their MCPTool from `MCPTool.registry` instead of instantiating directly, and `_brand_modules` in `main.py` is removed.