### PR TITLE
fix: handle doordash error on phone form

### DIFF
--- a/getgather/mcp/patterns/doordash-signin-phonenumber.html
+++ b/getgather/mcp/patterns/doordash-signin-phonenumber.html
@@ -16,6 +16,14 @@
       placeholder="Phone Number"
       gg-match="form#guided-email-phone-form input[type=tel]"
     />
+
+    <p
+      id="error"
+      style="color: red"
+      gg-optional
+      gg-match="div[data-anchor-id=IdentityErrorBanner]"
+    />
+
     <button
       type="submit"
       gg-match="//form[@id='guided-email-phone-form']//button[normalize-space(.)='Continue']"


### PR DESCRIPTION
We haven’t created a selector for the phone input error, so as a result, the page loops infinitely until the tick times out (60s) and doesn’t provide the user with a proper error message.

[Related logs](https://logfire-us.pydantic.dev/getgather/getgather?q=trace_id%3D%27a59a1dc2b6e141f3b5a00e77b3feaaae%27+and+span_id%3D%27c0ac82fb5d37616b%27&spanId=c0ac82fb5d37616b&traceId=a59a1dc2b6e141f3b5a00e77b3feaaae&env=-clear-&since=2026-04-28T03%3A23%3A40.802625Z&until=2026-04-28T04%3A23%3A40.802625Z)

<img width="862" height="971" alt="Screenshot 2026-04-28 at 11 07 43" src="https://github.com/user-attachments/assets/226aaf79-aae2-4b14-a218-84d83516cb71" />

