### PR TITLE
change log level of page close

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -352,7 +352,7 @@ async def safe_close_page(page: zd.Tab) -> None:
             await page.send(zd.cdp.target.close_target(target_id=normalized_target_id))
         else:
             await page.close()
-        logger.warning("Page closed successfully")
+        logger.info("Page closed successfully")
     except Exception as e:
         logger.warning(f"Error closing page: {e}")
 


### PR DESCRIPTION
## Summary
- Adjust log severity in `safe_close_page()` from `warning` to `info` when page close succeeds.
- Reduce noisy warning logs and improve signal quality for monitoring and triage.

## Why
- Successful page closure is expected behavior and should not emit a warning.
- Warning-level success logs can create false alarms and obscure actionable warnings.

## Changes
- Updated `getgather/browser.py`:
  - `logger.warning("Page closed successfully")` -> `logger.info("Page closed successfully")`
