### PR TITLE
change log level of best match pattern

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -463,7 +463,7 @@ async def distill(
         for item in result:
             logger.debug(f" - {item.name} with priority {item.priority}")
         match = result[0]
-        logger.debug(f"✓ Best match: {match.name}")
+        logger.info(f"✓ Best match: {match.name}")
 
         if reload_on_error and any(pattern in match.name for pattern in NETWORK_ERROR_PATTERNS):
             logger.info(f"Error pattern detected: {match.name}")


### PR DESCRIPTION
## Summary
- Promote distilled best-pattern match logging from `debug` to `info`.
- Make key distillation outcomes visible in standard logs without enabling debug mode.
- Improve observability when diagnosing pattern selection during extraction flows.

## Why
- The selected best match is a core signal in the distillation pipeline.

## Changes
- Updated `getgather/zen_distill.py`:
  - `logger.debug(f"✓ Best match: {match.name}")` -> `logger.info(f"✓ Best match: {match.name}")`