### PR TITLE
fix: remove redundant gg-autoclick from submit controls

### DIFF
--- a/getgather/mcp/patterns/adidas-password.html
+++ b/getgather/mcp/patterns/adidas-password.html
@@ -12,7 +12,7 @@
       gg-match="input#password"
       placeholder="Password"
     />
-    <button type="submit" gg-autoclick gg-match="button#login-submit-button:not([disabled]) span">
+    <button type="submit" gg-match="button#login-submit-button:not([disabled]) span">
       Sign In
     </button>
   </body>

--- a/getgather/mcp/patterns/alltrails-signin.html
+++ b/getgather/mcp/patterns/alltrails-signin.html
@@ -6,7 +6,7 @@
     <p gg-optional gg-match="div[class*=serverError]"></p>
     <input type="email" gg-match="input#userEmail" placeholder="Email Address" name="email" />
     <input type="password" gg-match="input#userPassword" placeholder="Password" name="password" />
-    <button type="submit" gg-autoclick gg-match="button[data-testid='email-password-login-button']">
+    <button type="submit" gg-match="button[data-testid='email-password-login-button']">
       Sign in
     </button>
   </body>

--- a/getgather/mcp/patterns/amazon-email-not-found.html
+++ b/getgather/mcp/patterns/amazon-email-not-found.html
@@ -3,7 +3,7 @@
     <p>You do not have an account with this email, please try again with a different email.</p>
     <p gg-match-html="//h1[contains(., 'new to Amazon')]" style="display: none"></p>
     <input gg-match="input[name='email']" name="none" value="none" style="display: none" />
-    <button gg-autoclick type="submit" gg-match="a[href*='/ap/signin?']">
+    <button type="submit" gg-match="a[href*='/ap/signin?']">
       Sign in with another email or mobile
     </button>
   </body>

--- a/getgather/mcp/patterns/amazon-keep-hacker-out.html
+++ b/getgather/mcp/patterns/amazon-keep-hacker-out.html
@@ -4,6 +4,6 @@
   </head>
   <body>
     <h1 gg-match="//h1[contains(text(), 'Keep hackers out')]"></h1>
-    <div type="submit" gg-autoclick gg-match="//a[contains(text(), 'Not now')]"></div>
+    <div gg-autoclick gg-match="//a[contains(text(), 'Not now')]"></div>
   </body>
 </html>

--- a/getgather/mcp/patterns/ashley-login.html
+++ b/getgather/mcp/patterns/ashley-login.html
@@ -6,8 +6,6 @@
     <p gg-optional gg-match="div.notification.error"></p>
     <input type="email" name="email" placeholder="email" gg-match="input#email" />
     <input type="password" name="password" placeholder="password" gg-match="input#password" />
-    <button type="submit" gg-autoclick gg-match="form#login-form button[type=submit]">
-      Log in
-    </button>
+    <button type="submit" gg-match="form#login-form button[type=submit]">Log in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/bedbathandbeyond-signin.html
+++ b/getgather/mcp/patterns/bedbathandbeyond-signin.html
@@ -9,8 +9,6 @@
     ></p>
     <input type="email" gg-match="input#login-email" placeholder="Email" name="email" />
     <input type="password" gg-match="input#login-password" placeholder="Password" name="password" />
-    <button type="submit" gg-autoclick gg-match="form#login-form button[type=submit]">
-      Sign In
-    </button>
+    <button type="submit" gg-match="form#login-form button[type=submit]">Sign In</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/bestbuy-mfa-choices.html
+++ b/getgather/mcp/patterns/bestbuy-mfa-choices.html
@@ -42,6 +42,6 @@
         <label gg-optional for="sms-radio" gg-match="label[for=sms-radio]">Use email link</label>
       </div>
     </div>
-    <button type="submit" gg-autoclick gg-match="button[type=submit]">Continue</button>
+    <button type="submit" gg-match="button[type=submit]">Continue</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/bestbuy-signin-email.html
+++ b/getgather/mcp/patterns/bestbuy-signin-email.html
@@ -4,6 +4,6 @@
   </head>
   <body>
     <input autofocus name="email" type="email" placeholder="Email" gg-match="input[type=email]" />
-    <button type="submit" gg-autoclick gg-match="button[type=submit]">Continue</button>
+    <button type="submit" gg-match="button[type=submit]">Continue</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/bestbuy-signin-password.html
+++ b/getgather/mcp/patterns/bestbuy-signin-password.html
@@ -12,6 +12,6 @@
       placeholder="Password"
       gg-match="input[type=password]"
     />
-    <button type="submit" gg-autoclick gg-match="form[novalidate] [type=submit]">Sign in</button>
+    <button type="submit" gg-match="form[novalidate] [type=submit]">Sign in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/bestbuy-verification-code.html
+++ b/getgather/mcp/patterns/bestbuy-verification-code.html
@@ -14,6 +14,6 @@
       placeholder="Verification Code"
       gg-match="input#verificationCode"
     />
-    <button type="submit" gg-autoclick gg-match="button[type=submit]">Confirm</button>
+    <button type="submit" gg-match="button[type=submit]">Confirm</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/chewy-email-not-found.html
+++ b/getgather/mcp/patterns/chewy-email-not-found.html
@@ -5,6 +5,6 @@
       "Cancel" to go back to the previous page.
     </p>
     <input gg-match="input#fullName" name="none" value="none" style="display: none" />
-    <button gg-autoclick type="submit" gg-match="a#register-cancel-button">Cancel</button>
+    <button type="submit" gg-match="a#register-cancel-button">Cancel</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/cnn-signin.html
+++ b/getgather/mcp/patterns/cnn-signin.html
@@ -16,8 +16,6 @@
       placeholder="Password"
       gg-match="input#login-password-input"
     />
-    <button type="submit" gg-autoclick gg-match="button[type=submit]:not([aria-disabled=true])">
-      Sign in
-    </button>
+    <button type="submit" gg-match="button[type=submit]:not([aria-disabled=true])">Sign in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/ebay-signin-password.html
+++ b/getgather/mcp/patterns/ebay-signin-password.html
@@ -5,6 +5,6 @@
   <body>
     <p gg-optional gg-match="p#signin-error-msg"></p>
     <input autofocus name="pass" type="password" gg-match="input#pass" placeholder="Password" />
-    <button type="submit" gg-autoclick gg-match="//button[@id='sgnBt']">Sign in</button>
+    <button type="submit" gg-match="//button[@id='sgnBt']">Sign in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/gofood-login.html
+++ b/getgather/mcp/patterns/gofood-login.html
@@ -14,6 +14,6 @@
         placeholder="Phone number"
       />
     </div>
-    <button type="submit" gg-autoclick gg-match="button[type=submit]">Continue</button>
+    <button type="submit" gg-match="button[type=submit]">Continue</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/gofood-otp.html
+++ b/getgather/mcp/patterns/gofood-otp.html
@@ -10,6 +10,6 @@
       <label gg-match="p.gf-label-m">Enter code</label>
       <input name="otp" type="tel" gg-match="input[name='data.otp']" placeholder="4-digit OTP" />
     </div>
-    <button type="submit" gg-autoclick gg-match="button[type=submit]">Continue</button>
+    <button type="submit" gg-match="button[type=submit]">Continue</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/google-signin-2fa-wait.html
+++ b/getgather/mcp/patterns/google-signin-2fa-wait.html
@@ -8,6 +8,6 @@
     ></div>
 
     <input type="text" value="submit" name="submit" style="display: none" />
-    <button type="submit" gg-autoclick>I've done this</button>
+    <button type="submit">I've done this</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/google-signin-tap-yes.html
+++ b/getgather/mcp/patterns/google-signin-tap-yes.html
@@ -7,6 +7,6 @@
       Yes
     </div>
     <input type="text" value="submit" name="submit" style="display: none" />
-    <button gg-autoclick type="submit">I've done this</button>
+    <button type="submit">I've done this</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/hardcover-signin.html
+++ b/getgather/mcp/patterns/hardcover-signin.html
@@ -18,7 +18,7 @@
         type="password"
         gg-match="form input[type='password']"
       />
-      <button gg-autoclick type="submit" gg-match="//form//button[@type='submit' and not(.//svg)]">
+      <button type="submit" gg-match="//form//button[@type='submit' and not(.//svg)]">
         Sign in
       </button>
     </div>

--- a/getgather/mcp/patterns/lenspure-signin.html
+++ b/getgather/mcp/patterns/lenspure-signin.html
@@ -3,6 +3,6 @@
     <span gg-optional gg-match="ul.woocommerce-error li"></span>
     <input autofocus placeholder="Email" gg-match="input#username" type="text" name="userId" />
     <input placeholder="Password" gg-match="input#password" type="password" name="password" />
-    <button type="submit" gg-autoclick gg-match="input[type=submit]">Login</button>
+    <button type="submit" gg-match="input[type=submit]">Login</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/linkedin-signin.html
+++ b/getgather/mcp/patterns/linkedin-signin.html
@@ -6,8 +6,6 @@
     <span gg-optional gg-match="div#error-for-password"></span>
     <input autofocus name="email" type="email" placeholder="Email" gg-match="input#username" />
     <input name="password" type="password" placeholder="Password" gg-match="input#password" />
-    <button type="submit" gg-autoclick gg-match="button[data-litms-control-urn=login-submit]">
-      Sign in
-    </button>
+    <button type="submit" gg-match="button[data-litms-control-urn=login-submit]">Sign in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/sephora-basket-signin-modal.html
+++ b/getgather/mcp/patterns/sephora-basket-signin-modal.html
@@ -25,7 +25,7 @@
       gg-match="div#modal-root input#signin_ssi"
       style="display: none"
     />
-    <button type="submit" gg-autoclick gg-match="div#modal-root button[data-at='sign_in_button']">
+    <button type="submit" gg-match="div#modal-root button[data-at='sign_in_button']">
       Sign In
     </button>
   </body>

--- a/getgather/mcp/patterns/shopee-verification-link-wa-wait.html
+++ b/getgather/mcp/patterns/shopee-verification-link-wa-wait.html
@@ -7,6 +7,6 @@
     <span gg-match="//div[contains(text(), 'Link verifikasi telah dikirim')]"></span>
     <span gg-match="//div[contains(text(), '+62')]"></span>
     <input type="text" value="submit" name="submit" style="display: none" />
-    <button type="submit" gg-autoclick>Sudah Verifikasi</button>
+    <button type="submit">Sudah Verifikasi</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/thriftbooks-signin.html
+++ b/getgather/mcp/patterns/thriftbooks-signin.html
@@ -16,8 +16,6 @@
       gg-match="input#ExistingAccount_Password"
       placeholder="Password"
     />
-    <button type="submit" gg-autoclick gg-match="div.LoginBox-submitArea input.Button">
-      Log In
-    </button>
+    <button type="submit" gg-match="div.LoginBox-submitArea input.Button">Log In</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/traveloka-signin-username.html
+++ b/getgather/mcp/patterns/traveloka-signin-username.html
@@ -9,6 +9,6 @@
       gg-match="input[data-testid='auth-username']"
       placeholder="Email or phone number"
     />
-    <button type="submit" gg-autoclick>Continue</button>
+    <button type="submit">Continue</button>
   </body>
 </html>


### PR DESCRIPTION
## Issue
https://github.com/remotebrowser/mcp/pull/1209#discussion_r3155096306

## Summary
- Removes redundant `gg-autoclick` from pattern elements that already use `type="submit"` across 24 HTML pattern files.
- Keeps behavior explicit and unambiguous by relying on type="submit" as the canonical submit trigger in those flows.
- Fixes one special-case pattern by removing meaningless type="submit" from a <div> while preserving gg-autoclick in getgather/mcp/patterns/amazon-keep-hacker-out.html.

## Why
- Using both type="submit" and gg-autoclick on the same element is redundant and can imply conflicting/double-submit behavior.
- This cleanup improves readability and makes intent clearer for future pattern maintenance.