### PR TITLE
Add Browser Fleet API E2E tests and CI workflow

### DIFF
--- a/.github/workflows/browser-api-e2e-test.yml
+++ b/.github/workflows/browser-api-e2e-test.yml
@@ -1,0 +1,26 @@
+name: Browser API E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+jobs:
+  browser-api-e2e-tests:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+
+      - run: uv run -m uvicorn getgather.main:app --port 23456 &
+
+      - name: Run the health check validation
+        run: while ! curl -s 'http://localhost:23456/health' | grep 'OK'; do sleep 1; done
+        timeout-minutes: 3
+
+      - name: Run the browser API E2E tests
+        run: uv run pytest -v -s tests/test_browser_api_e2e.py

--- a/tests/test_browser_api_e2e.py
+++ b/tests/test_browser_api_e2e.py
@@ -1,0 +1,119 @@
+import asyncio
+import os
+from collections.abc import Generator
+
+import httpx
+import pytest
+import websockets
+
+REMOTEBROWSER_URL = os.getenv("REMOTEBROWSER_URL", "http://localhost:23456")
+
+
+@pytest.fixture(scope="module")
+def client():
+    with httpx.Client(base_url=REMOTEBROWSER_URL, timeout=30.0) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+async def async_client():
+    async with httpx.AsyncClient(base_url=REMOTEBROWSER_URL, timeout=30.0) as c:
+        yield c
+
+
+@pytest.mark.api
+class TestHealthEndpoint:
+    def test_health_returns_ok(self, client: httpx.Client) -> None:
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert "OK" in response.text
+
+
+@pytest.mark.api
+class TestBrowserLifecycle:
+    def __init__(self) -> None:
+        self.browser_ids: list[str] = []
+
+    @pytest.fixture(autouse=True)
+    def cleanup(self, client: httpx.Client) -> Generator[None, None, None]:
+        self.browser_ids = []
+        yield
+        for browser_id in self.browser_ids:
+            try:
+                client.delete(f"/api/v1/browsers/{browser_id}")
+            except Exception:
+                pass
+
+    def test_create_browser(self, client: httpx.Client) -> None:
+        response = client.post("/api/v1/browsers/test01")
+        assert response.status_code == 200
+        self.browser_ids.append("test01")
+        data = response.json()
+        assert data["status"] == "created"
+
+    def test_get_browser(self, client: httpx.Client) -> None:
+        client.post("/api/v1/browsers/test02")
+        self.browser_ids.append("test02")
+        response = client.get("/api/v1/browsers/test02")
+        assert response.status_code == 200
+        data = response.json()
+        assert "last_activity_timestamp" in data
+
+    def test_get_nonexistent_browser(self, client: httpx.Client) -> None:
+        response = client.get("/api/v1/browsers/nonexistent-browser")
+        assert response.status_code == 404
+
+    def test_delete_browser(self, client: httpx.Client) -> None:
+        client.post("/api/v1/browsers/test03")
+        self.browser_ids.append("test03")
+        response = client.delete("/api/v1/browsers/test03")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "deleted"
+        self.browser_ids.remove("test03")
+
+    def test_delete_nonexistent_browser(self, client: httpx.Client) -> None:
+        response = client.delete("/api/v1/browsers/nonexistent-browser")
+        assert response.status_code == 404
+
+
+@pytest.mark.api
+class TestBrowserListing:
+    def test_list_browsers(self, client: httpx.Client) -> None:
+        response = client.get("/api/v1/browsers")
+        assert response.status_code == 200
+        assert isinstance(response.json(), list)
+
+
+@pytest.mark.api
+class TestAutoStart:
+    def __init__(self) -> None:
+        self.browser_ids: list[str] = []
+
+    @pytest.fixture(autouse=True)
+    def cleanup(self, client: httpx.Client) -> Generator[None, None, None]:
+        self.browser_ids = []
+        yield
+        for browser_id in self.browser_ids:
+            try:
+                client.delete(f"/api/v1/browsers/{browser_id}")
+            except Exception:
+                pass
+
+    def test_cdp_websocket_autostart(self, client: httpx.Client) -> None:
+        browser_id = "test-autostart"
+        self.browser_ids.append(browser_id)
+
+        # Ensure the container does not already exist
+        client.delete(f"/api/v1/browsers/{browser_id}")
+
+        ws_base = REMOTEBROWSER_URL.replace("http://", "ws://").replace("https://", "wss://")
+
+        async def connect_and_verify():
+            async with websockets.connect(f"{ws_base}/cdp/{browser_id}", open_timeout=60):
+                pass  # successful connection confirms the container was auto-started
+
+        asyncio.run(connect_and_verify())
+
+        response = client.get(f"/api/v1/browsers/{browser_id}")
+        assert response.status_code == 200


### PR DESCRIPTION
Introduces end-to-end tests for the Browser Fleet API covering health checks, browser lifecycle (create/get/delete), listing, and CDP websocket auto-start. Includes a GitHub Actions workflow to run them on push/PR with backend startup and health validation.

To try, first run as usual with `npm run dev`, and then launch the tests with:

```bash
uv run pytest tests/test_browser_api_e2e.py
```