### PR TITLE
fix: increase zendriver ws timeout

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -47,10 +47,10 @@ def _traced_websocket_connect(*args: Any, **kwargs: Any) -> Any:
     kwargs.setdefault("open_timeout", settings.CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS)
 
     logger.info(
-        "CDP websocket headers attached: target_domain={}, open_timeout={}s, keys={}",
-        merged.get("x-target-domains"),
-        kwargs.get("open_timeout"),
-        sorted(merged.keys()),
+        "CDP websocket headers attached",
+        target_domain=merged.get("x-target-domains"),
+        open_timeout=kwargs.get("open_timeout"),
+        keys=sorted(merged.keys()),
     )
     return _original_websockets_connect(*args, **kwargs)
 

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -44,10 +44,12 @@ def _traced_websocket_connect(*args: Any, **kwargs: Any) -> Any:
     if carrier:
         merged.update(carrier)
     kwargs["additional_headers"] = merged
+    kwargs.setdefault("open_timeout", settings.CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS)
 
     logger.info(
-        "CDP websocket headers attached: target_domain={}, keys={}",
+        "CDP websocket headers attached: target_domain={}, open_timeout={}s, keys={}",
         merged.get("x-target-domains"),
+        kwargs.get("open_timeout"),
         sorted(merged.keys()),
     )
     return _original_websockets_connect(*args, **kwargs)

--- a/getgather/config.py
+++ b/getgather/config.py
@@ -19,6 +19,7 @@ class Settings(AuthSettings, BaseSettings):
     DATA_DIR: str = ""
 
     CHROMEFLEET_URL: str = ""
+    CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS: float = 30.0
 
     @property
     def effective_chromefleet_url(self) -> str:


### PR DESCRIPTION
## Summary
- Increase the CDP websocket opening handshake timeout from the default 10s behavior to a configurable value.
- Reduce flaky remote browser connection failures during ChromeFleet cold starts or slow websocket upgrades.

## Why
- We observed consistent failures at exactly 10 seconds with:
  - `TimeoutError: timed out during opening handshake` ([logs](https://logfire-us.pydantic.dev/getgather/remote-browser-dev?q=trace_id%3D%27146bcc95abdb6fcfc12c1fe62ded26a3%27+and+span_id%3D%2710a5b8341f8adb23%27&spanId=10a5b8341f8adb23&traceId=146bcc95abdb6fcfc12c1fe62ded26a3&env=-clear-&since=2026-05-04T09%3A22%3A43.318259Z&until=2026-05-04T10%3A22%3A43.318259Z))
- That pattern indicates the `websockets.connect` default `open_timeout` was being hit before ChromeFleet completed the upgrade.

## Changes
- Updated `getgather/config.py`:
  - Added `CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS: float = 30.0`
- Updated `getgather/browser.py`:
  - In `_traced_websocket_connect(...)`, set:
    - `kwargs.setdefault("open_timeout", settings.CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS)`
  - Extended CDP connection logging to include the effective `open_timeout`.

## Impact
- CDP websocket handshake now waits up to 30s by default before failing.
- Timeout remains override-friendly: explicit `open_timeout` passed by callers still takes precedence.
- No behavior change for request/read/write timeouts elsewhere.

## Test Plan
- [ ] Run a remote browser flow against ChromeFleet (cold and warm starts).
- [ ] Verify handshake no longer fails at 10s by default.
- [ ] If needed, set `CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS=60` and verify longer tolerance.
- [ ] Run checks: `npm run backend:check:format` and `npm run backend:check:type-safety`
