### PR TITLE
fix(browser): surface CDP WS close/timeout instead of hanging forever

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -148,9 +148,32 @@ async def _create_browser_from_cdp_websocket(
             instance.connection.handlers[zd.cdp.target.TargetCrashed] = [  # type: ignore[reportUnknownMemberType]
                 _safe_handle_target_update
             ]
-            await instance.connection.send(zd.cdp.target.set_discover_targets(discover=True))
+            try:
+                await asyncio.wait_for(
+                    instance.connection.send(zd.cdp.target.set_discover_targets(discover=True)),
+                    timeout=30.0,
+                )
+            except websockets.ConnectionClosedError as e:
+                raise ConnectionError(
+                    f"CDP WebSocket closed by remote (code={e.rcvd.code if e.rcvd else 'unknown'},"
+                    f" reason={e.rcvd.reason if e.rcvd else ''!r}): browser_id={browser_id}"
+                ) from e
+            except asyncio.TimeoutError:
+                raise ConnectionError(
+                    f"CDP WebSocket handshake timed out after 30s: browser_id={browser_id}"
+                )
 
-        await instance.update_targets()
+        try:
+            await asyncio.wait_for(instance.update_targets(), timeout=30.0)
+        except websockets.ConnectionClosedError as e:
+            raise ConnectionError(
+                f"CDP WebSocket closed by remote (code={e.rcvd.code if e.rcvd else 'unknown'},"
+                f" reason={e.rcvd.reason if e.rcvd else ''!r}): browser_id={browser_id}"
+            ) from e
+        except asyncio.TimeoutError:
+            raise ConnectionError(
+                f"CDP WebSocket update_targets timed out after 30s: browser_id={browser_id}"
+            )
     util.get_registered_instances().add(instance)
 
     async def browser_atexit() -> None:


### PR DESCRIPTION
## Summary

[Logs](https://logfire-us.pydantic.dev/getgather/remote-browser-dev?q=trace_id%3D%27ab8bff6a9c12391dc986c290c50a7955%27+and+span_id%3D%271e76b652c8693003%27&spanId=1e76b652c8693003&traceId=ab8bff6a9c12391dc986c290c50a7955&env=-clear-&since=2026-05-04T09%3A25%3A31.428789Z&until=2026-05-04T10%3A25%3A31.428789Z)

- When ChromeFleet closes the CDP WebSocket after the upgrade (e.g. code 4502 — failed to get debugger URL), zendriver's `send` / `update_targets` blocked indefinitely with no error surfaced on the getgather side
- Wrap both `set_discover_targets` send and `update_targets` with `asyncio.wait_for(timeout=30s)`
- Catch `websockets.ConnectionClosedError` and raise `ConnectionError` with the close code and reason
- Catch `asyncio.TimeoutError` and raise `ConnectionError` with a clear timeout message

## Root cause

`websockets.connect()` succeeds (WebSocket upgrade completes — hence "CDP websocket headers attached" in logs), but ChromeFleet then closes the socket before sending any CDP frames. Zendriver's first `.send()` waits for a response that never arrives, with no timeout or close-event handling in the calling code.

## Test plan

- [ ] Simulate ChromeFleet returning 4502 — getgather should now raise `ConnectionError` immediately with close code in message rather than hanging
- [ ] Normal CDP connect flow unaffected