### PR TITLE
feat: make "best match" logs queryable

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -1179,12 +1179,14 @@ async def distill(
             logger.debug(f" - {item.name} with priority {item.priority}")
         match = result[0]
 
+        browser_id = getattr(getattr(page, "browser", None), "id", None)
+
         logger.bind(
             event="distill_best_match",
             best_match_name=match.name,
             best_match_priority=match.priority,
             hostname=hostname,
-            browser_id=page.browser.id,  # type: ignore[attr-defined]
+            browser_id=browser_id,
         ).info("Best match selected")
 
         if reload_on_error and any(pattern in match.name for pattern in NETWORK_ERROR_PATTERNS):

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -1178,7 +1178,14 @@ async def distill(
         for item in result:
             logger.debug(f" - {item.name} with priority {item.priority}")
         match = result[0]
-        logger.debug(f"✓ Best match: {match.name}")
+
+        logger.bind(
+            event="distill_best_match",
+            best_match_name=match.name,
+            best_match_priority=match.priority,
+            hostname=hostname,
+            browser_id=page.browser.id,  # type: ignore[attr-defined]
+        ).info("Best match selected")
 
         if reload_on_error and any(pattern in match.name for pattern in NETWORK_ERROR_PATTERNS):
             logger.info(f"Error pattern detected: {match.name}")


### PR DESCRIPTION
Since we want to track distilled patterns, we need to adjust the logs to make them more “queryable.” Here are the results.

<img width="1008" height="778" alt="Screenshot 2026-05-05 at 11 45 48" src="https://github.com/user-attachments/assets/eb267563-f0e0-4dac-a407-59aee0da676c" />
