### PR TITLE
fix: fan out request bursts across machines via [http_service.concurrency]

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -13,6 +13,11 @@ primary_region = 'sjc'
   auto_start_machines = true
   min_machines_running = 0
 
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 5
+    hard_limit = 20
+
   [http_service.http_options]
     idle_timeout = 180
 


### PR DESCRIPTION
## Summary

Mirrors [gather-engineering/flyfleet#149](https://github.com/gather-engineering/flyfleet/pull/149) for `remotebrowser-prod`. Without an explicit `[http_service.concurrency]` block, Fly's proxy uses defaults (`soft_limit=20, hard_limit=25`), so a burst of concurrent MCP tool calls stacks on a single warm machine. Lowering `soft_limit` to 5 makes the proxy prefer (or auto-start) a peer once a machine has 5 in-flight requests.

## Why these numbers fit this app

- `type = "requests"` — getgather's MCP is streamable-HTTP, stateless ([getgather/mcp/main.py:254](https://github.com/remotebrowser/mcp/blob/main/getgather/mcp/main.py#L254) — `stateless_http=True`). Each tool call is a short request/response, not a long-lived SSE stream, so counting requests does not over-throttle.
- `soft_limit = 5` — per-request work is heavy (CDP setup + zen distillation polling up to 60s, [getgather/mcp/dpage.py:51](https://github.com/remotebrowser/mcp/blob/main/getgather/mcp/dpage.py#L51)). Eager fan-out is the right bias.
- `hard_limit = 20` — per-machine cap. With one uvicorn worker on `shared-cpu-8x` / 2GB, 20 concurrent CDP-driving requests is already aggressive.

## Differences from flyfleet#149

- No DB / connection pool here — the original failure mode (asyncpg pool exhaustion) does not exist on this service. Motivation is purely concentration of CPU/CDP work.
- `min_machines_running = 0` (vs flyfleet's 1). The first burst still lands on one cold-started machine; soft_limit lower than the burst size makes Fly auto-start a peer earlier.

## Out of scope

- Bumping `min_machines_running` — defer until evidence shows cold-start is masking the fan-out.
- DB / pool tuning — n/a on this service.

## Test plan

- [ ] Merge + `fly deploy` to `remotebrowser-prod`.
- [ ] Confirm config landed: `fly config show -a remotebrowser-prod | rg -A3 concurrency`.
- [ ] Drive a 10×-parallel MCP tool call burst (e.g. `tests/manual.py call-tool` in an `asyncio.gather` against `https://remotebrowser-prod.fly.dev/mcp-goodreads`).
- [ ] In Logfire, confirm ≥2 distinct `service_instance_id`s served the burst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)