### PR TITLE
docs: rewrite README as project overview, add Dokku deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,26 @@
-An MCP server for extracting personal data from many services: Amazon order history, Garmin activity stats, Zillow favorites, and more.
+# Remote Browser
 
-It works with [Claude Code](https://claude.ai/code), [LM Studio](https://lmstudio.ai), [Gemini CLI](https://google-gemini.github.io/gemini-cli), and many more.
+[![PyPI](https://img.shields.io/pypi/v/remotebrowser)](https://pypi.org/project/remotebrowser/)
+
+Remote Browser is an open-source, self-hosted browser orchestration system for AI agent [harness engineering](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents).
+
+It launches and manages multiple isolated, containerized Chrome instances with CDP ([Chrome Devtools Protocol](https://chromedevtools.github.io/devtools-protocol/)) support for scalable web automation. Remote Browser is designed to integrate with AI agent runtimes and browser tools, and works with [OpenClaw](https://openclaw.ai), [Hermes Agent](https://hermes-agent.nousresearch.com), etc.
+
+It also bundles an MCP server for extracting personal data from many services: Amazon order history, Garmin activity stats, Zillow favorites, and more. This MCP server works with [Claude Code](https://claude.ai/code), [LM Studio](https://lmstudio.ai), [Gemini CLI](https://google-gemini.github.io/gemini-cli), and many more.
 
 ![Screenshot of Claude Code using Remote Browser MCP](claude-code-remotebrowser-mcp.png)
 
-### Quickstart
+## Quickstart
 
-Run [Chrome Fleet](https://github.com/remotebrowser/chromefleet), note its service address (e.g. `http://192.168.1.2:8300`), set it as `CHROMEFLEET_URL`, then start this MCP server:
-
-```bash
-export CHROMEFLEET_URL=http://192.168.1.1:8300
-docker run -p 23456:23456 -e CHROMEFLEET_URL ghcr.io/remotebrowser/mcp
-```
-
-Alternative ways to run it:
-
-<details>
-<summary>Docker Compose</summary>
-
-```yaml
-services:
-  remotebrowser-mcp:
-    image: ghcr.io/remotebrowser/mcp
-    ports:
-      - "23456:23456"
-    environment:
-      - CHROMEFLEET_URL
-    restart: unless-stopped
-```
-
-</details>
-
-<details>
-<summary>Inline podman</summary>
+Remote Browser is a Python app. To run it, you need [uv](https://docs.astral.sh/uv) and [Podman](https://podman.io):
 
 ```bash
-export CHROMEFLEET_URL=http://192.168.1.1:8300
-podman run -p 23456:23456 -e CHROMEFLEET_URL ghcr.io/remotebrowser/mcp
+uvx remotebrowser
 ```
 
-</details>
+Then open `http://localhost:23456`.
 
-<details>
-<summary>Run with Python</summary>
-
-You'll need [uv](https://docs.astral.sh/uv) with [Python](https://python.org) >= 3.11. After cloning this repo:
-
-```bash
-uv run -m uvicorn getgather.main:app --port 23456
-```
-
-</details>
-
-### Connect to MCP clients
+## MCP
 
 **Standard config** works with most tools:
 
@@ -104,3 +72,59 @@ Go to `Program` in the right sidebar -> `Install` -> `Edit mcp.json`. Use the st
 Follow the MCP install [guide](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server), use the standard config above.
 
 </details>
+
+## API
+
+### Start a new browser
+
+`POST /api/v1/browsers/{browser_id}` creates a new browser with the specified `browser_id`. The browser runs in a container.
+
+_Example_: `curl -X POST localhost:8300/api/v1/browsers/xyz123` creates a container named `chromium-xyz123` and returns:
+
+```json
+{ "container_name": "chromium-xyz123", "status": "created" }
+```
+
+### Stop a browser
+
+`DELETE /api/v1/browsers/{browser_id}` terminates the browser with the specified `browser_id` and returns the container name. Returns HTTP 404 if the browser ID is not found.
+
+_Example_: `curl -X DELETE localhost:8300/api/v1/browsers/xyz123` terminates the container named `chromium-xyz123` and returns:
+
+```json
+{ "container_name": "chromium-xyz123", "status": "deleted" }
+```
+
+### Query a browser
+
+`GET /api/v1/browsers/{browser_id}` returns information about the browser with the specified `browser_id`. Returns HTTP 404 if the browser is not found.
+
+_Example_: `curl localhost:8300/api/v1/browsers/xyz123` returns:
+
+```json
+{ "last_activity_timestamp": 1772069081 }
+```
+
+### List all browsers
+
+`GET /api/v1/browsers` returns a JSON array of all running browser IDs.
+
+_Example_: `curl localhost:8300/api/v1/browsers` returns:
+
+```json
+["xyz123", "abc234"]
+```
+
+## Development
+
+To run the development version, clone this repository and run:
+
+```bash
+uv run -m uvicorn getgather.main:app --port 23456
+```
+
+## Deployment
+
+Supported deployment:
+
+- [Deploy using Dokku](deploy-dokku.md)

--- a/deploy-dokku.md
+++ b/deploy-dokku.md
@@ -1,0 +1,187 @@
+# Dokku Deployment
+
+Install [Podman](https://podman.io) and verify it:
+
+```
+sudo apt install -y podman
+sudo podman run hello-world
+```
+
+Enable the Podman systemd socket and verify it:
+
+```
+sudo systemctl enable --now podman.socket
+systemctl status podman.socket --no-pager
+```
+
+Override the socket path by running `sudo systemctl edit podman.socket` and editing the contents to:
+
+```
+[Socket]
+ListenStream=
+ListenStream=/run/podman.sock
+SocketMode=0666
+```
+
+Reboot the machine.
+
+Quick test (should display full Podman information and not throw any errors):
+
+```
+CONTAINER_HOST="unix:///run/podman.sock" podman --remote info
+```
+
+Run the test again to verify that the Podman socket permissions persist after reboot:
+
+Another test:
+
+```
+CONTAINER_HOST="unix:///run/podman.sock" podman --remote run hello-world
+```
+
+Install and configure [Tailscale](https://tailscale.com) on the host machine:
+
+```
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up
+```
+
+Verify that the machine appears on the [Tailscale admin console page](https://login.tailscale.com/admin/machines).
+
+Install Dokku per [the official guide](https://dokku.com/docs/getting-started/installation):
+
+```
+wget -NP . https://dokku.com/install/v0.37.2/bootstrap.sh
+sudo DOKKU_TAG=v0.37.2 bash bootstrap.sh
+```
+
+Add at least one SSH key for manual deployment.
+
+Create the app:
+
+```
+dokku apps:create remotebrowser
+dokku ports:add remotebrowser http:80:8300
+dokku config:set remotebrowser CONTAINER_HOST="unix:///run/podman.sock"
+dokku docker-options:add remotebrowser deploy "--cap-add=NET_ADMIN"
+dokku docker-options:add remotebrowser deploy "--cap-add=NET_RAW"
+dokku docker-options:add remotebrowser deploy "--device=/dev/net/tun:/dev/net/tun"
+dokku docker-options:add remotebrowser deploy,run "-v /run/podman.sock:/run/podman.sock"
+```
+
+Set the domain (optional):
+
+```
+dokku domains:set remotebrowser remotebrowser.example.com
+```
+
+Then deploy Remote Browser manually to this Dokku machine.
+
+## Resource limits
+
+Rootful Podman places all container cgroups under `machine.slice`. Setting limits on this slice caps the combined CPU and memory of every browser container on the host.
+
+### Step 1 — Inspect host resources
+
+```bash
+nproc
+free -h
+mount | grep cgroup2   # confirm cgroup v2 is active
+```
+
+### Step 2 — Confirm which slice owns the containers
+
+```bash
+systemd-cgls | grep -E 'libpod|\.slice'
+```
+
+Expected (rootful Podman on Debian/Ubuntu):
+
+```
+machine.slice
+  |-libpod-<id>.scope
+  `-libpod-conmon-<id>.scope
+```
+
+If containers appear under a different slice, target that slice instead.
+
+### Step 3 — Check existing limits (baseline)
+
+```bash
+systemctl show machine.slice --property=MemoryHigh,MemoryMax,MemorySwapMax,CPUQuotaPerSecUSec
+```
+
+All values will be `infinity` / `max` on a fresh host.
+
+### Step 4 — Determine limit values
+
+Use these formulas based on host specs:
+
+| Setting      | Formula                    | Example (32 cores / 64GB) |
+| ------------ | -------------------------- | ------------------------- |
+| `MemoryHigh` | `total_RAM × 0.78`         | `50G`                     |
+| `MemoryMax`  | `total_RAM × 0.875`        | `56G`                     |
+| `CPUQuota`   | `(total_cores − 2) × 100%` | `3000%`                   |
+
+Scaling reference by concurrent container count:
+
+| Containers | MemoryHigh | MemoryMax | CPUQuota |
+| ---------- | ---------- | --------- | -------- |
+| ~20        | 22G        | 26G       | 1600%    |
+| ~40        | 42G        | 48G       | 2800%    |
+| ~60        | 50G        | 56G       | 3000%    |
+
+### Step 5 — Apply the drop-in
+
+```bash
+sudo systemctl edit machine.slice
+```
+
+Paste (adjust values for your host):
+
+```ini
+[Slice]
+MemoryHigh=50G
+MemoryMax=56G
+MemorySwapMax=0
+CPUQuota=3000%
+```
+
+Reload (no restart needed):
+
+```bash
+sudo systemctl daemon-reload
+```
+
+### Step 6 — Verify limits are active
+
+```bash
+# Via systemd
+systemctl show machine.slice --property=MemoryHigh,MemoryMax,MemorySwapMax,CPUQuotaPerSecUSec
+
+# Directly from the kernel (ground truth)
+cat /sys/fs/cgroup/machine.slice/memory.high   # expect 53687091200 (50GiB)
+cat /sys/fs/cgroup/machine.slice/memory.max    # expect 60129542144 (56GiB)
+cat /sys/fs/cgroup/machine.slice/cpu.max       # expect 30000000 100000 (3000%)
+```
+
+### Step 7 — Verify limits survive reboot
+
+```bash
+sudo reboot
+# after reboot:
+systemctl show machine.slice --property=MemoryHigh,MemoryMax,CPUQuotaPerSecUSec
+```
+
+**What each setting does:**
+
+- `MemoryHigh` — soft ceiling; kernel throttles and reclaims pages before killing anything
+- `MemoryMax` — hard ceiling; OOM-kills heaviest processes if memory climbs past this despite throttling
+- `MemorySwapMax=0` — disables swap for all containers (Chromium degrades badly on swap)
+- `CPUQuota` — caps total CPU time across all containers; leaves 2 cores for OS + app
+
+Once deployed, test it by launching a machine:
+
+```
+curl remotebrowser-ip-address/api/v1/start/xyz123
+```

--- a/getgather/main.py
+++ b/getgather/main.py
@@ -59,7 +59,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="Get Gather",
     description="GetGather mcp, frontend, and api",
-    version="0.1.0",
+    version="0.1.1",
     generate_unique_id_function=custom_generate_unique_id,
     lifespan=lifespan,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "remotebrowser"
-version = "0.1.0"
+version = "0.1.1"
 description = "Free your data"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Rewrite README to position Remote Browser as a browser orchestration system rather than just an MCP server. Add API documentation and deployment sections. Add deploy-dokku.md with step-by-step guide for Podman setup, Dokku installation, and cgroup resource limits configuration. Bump version to 0.1.1.