### PR TITLE
feat: error pattern logs

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -328,7 +328,7 @@ def make_error_reporter(browser: zd.Browser, location: str | None = None) -> Err
 async def distill(
     hostname: str | None, page: zd.Tab, patterns: list[Pattern], reload_on_error: bool = True
 ) -> Match | None:
-    result: list[Match] = []
+    result: list[tuple[Match, list[str]]] = []
     pattern_runs: list[tuple[str, int, BeautifulSoup, list[dict[str, object]]]] = []
     all_batch_queries: list[dict[str, object]] = []
     next_query_key = 0
@@ -401,6 +401,7 @@ async def distill(
     for name, priority, pattern, target_specs in pattern_runs:
         found = True
         match_count = 0
+        optional_visible_text: list[str] = []
 
         for spec in target_specs:
             target = spec.get("target")
@@ -418,6 +419,23 @@ async def distill(
             source_found = bool(source.get("found"))
 
             if source_found:
+                if optional:
+                    text_content = ""
+                    raw_text = source.get("text")
+                    if isinstance(raw_text, str):
+                        text_content = raw_text.strip()
+                    if not text_content:
+                        raw_value = source.get("value")
+                        if isinstance(raw_value, str):
+                            text_content = raw_value.strip()
+                    if not text_content:
+                        raw_html = source.get("html")
+                        if isinstance(raw_html, str):
+                            text_content = BeautifulSoup(raw_html, "html.parser").get_text(
+                                " ", strip=True
+                            )
+                    if text_content:
+                        optional_visible_text.append(text_content)
                 if html:
                     target.clear()
                     html_content = source.get("html", "")
@@ -446,23 +464,26 @@ async def distill(
         if found and match_count > 0:
             distilled = str(pattern)
             result.append(
-                Match(
-                    name=name,
-                    priority=priority,
-                    distilled=distilled,
+                (
+                    Match(
+                        name=name,
+                        priority=priority,
+                        distilled=distilled,
+                    ),
+                    optional_visible_text,
                 )
             )
 
-    result = sorted(result, key=lambda x: x.priority)
+    result = sorted(result, key=lambda x: x[0].priority)
 
     if len(result) == 0:
         logger.debug("No matches found")
         return None
     else:
         logger.debug(f"Number of matches: {len(result)}")
-        for item in result:
+        for item, _optional_visible_text in result:
             logger.debug(f" - {item.name} with priority {item.priority}")
-        match = result[0]
+        match, optional_visible_text = result[0]
 
         browser_id = getattr(getattr(page, "browser", None), "id", None)
 
@@ -470,6 +491,7 @@ async def distill(
             event="distill_best_match",
             best_match_name=match.name,
             best_match_priority=match.priority,
+            best_match_optional_visible_text=optional_visible_text,
             hostname=hostname,
             browser_id=browser_id,
         ).info("Best match selected")

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -463,16 +463,14 @@ async def distill(
 
         if found and match_count > 0:
             distilled = str(pattern)
-            result.append(
-                (
-                    Match(
-                        name=name,
-                        priority=priority,
-                        distilled=distilled,
-                    ),
-                    optional_visible_text,
-                )
-            )
+            result.append((
+                Match(
+                    name=name,
+                    priority=priority,
+                    distilled=distilled,
+                ),
+                optional_visible_text,
+            ))
 
     result = sorted(result, key=lambda x: x[0].priority)
 


### PR DESCRIPTION
Next phase of #1231: We want to differentiate between the success pattern and the error (gg-optional) pattern. To do this, we also need to add the error message to Logfire.

<img width="936" height="795" alt="Screenshot 2026-05-07 at 14 18 39" src="https://github.com/user-attachments/assets/220d0503-61f2-4847-9419-83a99aa79c9f" />
