### PR TITLE
fix: increase Xvnc maxclients to 2048

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ export USER=getgather
 rm -f /tmp/.X99-lock /tmp/.X11-unix/X99 || true
 
 echo "Starting TigerVNC server on DISPLAY=$DISPLAY..."
-Xvnc -alwaysshared ${DISPLAY} -geometry 1920x1080 -depth 24 -rfbport 5900 -SecurityTypes None &
+Xvnc -alwaysshared ${DISPLAY} -geometry 1920x1080 -depth 24 -rfbport 5900 -SecurityTypes None -maxclients 2048 &
 
 echo "Waiting for X server at $DISPLAY..."
 for i in $(seq 1 20); do


### PR DESCRIPTION
## Problem

The server was hitting the following error in Sentry:

[https://heyario.sentry.io/issues/7332149473/?project=4509832551858176&query=is%3Aunresolved&referrer=issue-stream](https://heyario.sentry.io/issues/7332149473/?project=4509832551858176&query=is%3Aunresolved&referrer=issue-stream)

```txt
xdpyinfo error: Maximum number of clients reached
xdpyinfo: unable to open display ":99".
```

Running this command showed that display `:99` had reached 255 active X11 client connections:

```bash
ss -xp | grep X99 | wc -l
```

By default, Xorg allows up to 256 clients. The supported maximum is 2048, as defined by `MAXCLIENTS` in Xorg:

[https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/include/misc.h](https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/include/misc.h)

<img width="641" height="55" alt="image" src="https://github.com/user-attachments/assets/67b91b3d-c29f-486a-8500-fd5796d63951" />

## Fix

Added `-maxclients 2048` to the Xvnc startup command in `entrypoint.sh`.

Before applying the change, I verified that the flag is supported by the live container by starting a test Xvnc instance on display `:100`.
