### PR TITLE
feat: handle pattern new account amazon

### DIFF
--- a/getgather/mcp/patterns/amazon-new-to-amazon.html
+++ b/getgather/mcp/patterns/amazon-new-to-amazon.html
@@ -1,10 +1,6 @@
 <html gg-domain="amazon" gg-priority="5">
   <body>
-    <h1
-      gg-stop
-      gg-error="email_not_found"
-      gg-match="a.signin-with-another-account"
-    >
+    <h1 gg-stop gg-error="email_not_found" gg-match="a.signin-with-another-account">
       Looks like you're new to Amazon
     </h1>
   </body>

--- a/getgather/mcp/patterns/amazon-new-to-amazon.html
+++ b/getgather/mcp/patterns/amazon-new-to-amazon.html
@@ -1,0 +1,11 @@
+<html gg-domain="amazon" gg-priority="5">
+  <body>
+    <h1
+      gg-stop
+      gg-error="email_not_found"
+      gg-match="a.signin-with-another-account"
+    >
+      Looks like you're new to Amazon
+    </h1>
+  </body>
+</html>


### PR DESCRIPTION
https://github.com/gather-engineering/demos/issues/739

## Summary

Existing amazon-email-not-found.html requires input[name='email'] to match, but on this page that input is type="hidden"  so the  distillation engine missed it.

The new pattern matches on a.signin-with-another-account (a class unique to this page variant).

Priority 5, so it beat amazon-email-not-found.html (priority 6).

## Test

<img width="784" height="618" alt="image" src="https://github.com/user-attachments/assets/a242e7d7-e8ed-4dae-9b69-69b0998b3326" />



