### PR TITLE
fix: surface page_batch_extract failures to Sentry

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 import asyncio_atexit
 import httpx
 import logfire
+import sentry_sdk
 import websockets
 import zendriver as zd
 from fastmcp.server.dependencies import get_http_headers
@@ -880,8 +881,11 @@ async def page_batch_extract(
         result = await page.evaluate(js_code)
         if isinstance(result, dict):
             return cast(dict[str, dict[str, object]], result)
+        logger.warning(f"Batch extract returned unexpected type: {type(result)}")
+        sentry_sdk.capture_message(f"Batch extract returned unexpected type: {type(result)}")
     except Exception as error:
-        logger.debug(f"Batch extract failed: {error}")
+        logger.warning(f"Batch extract failed: {error}")
+        sentry_sdk.capture_exception(error)
     return None
 
 


### PR DESCRIPTION
## Summary

- `page_batch_extract` silently returned `None` on failure (logged at `DEBUG`, invisible in production)
- This caused distillation to time out with no trace in Sentry
- Promote to `WARNING` + `capture_exception` so failures are visible