### PR TITLE
Install podman client in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && apt-get install -y \
     sudo \
     ca-certificates \
     iptables \
+    podman \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Allows spawning containers at runtime when `CHROMEFLEET_URL` is empty, necessary when being deployed in an environment without an external Chrome Fleet service.