### PR TITLE
Add Oat CSS for the simple web UI

### DIFF
--- a/getgather/webui/index.html
+++ b/getgather/webui/index.html
@@ -5,6 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RemoteBrowser</title>
     <script src="https://cdn.jsdelivr.net/npm/timeago.js@4/dist/timeago.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/@knadh/oat/oat.min.css" />
+    <style>
+      body {
+        padding: 1rem;
+      }
+    </style>
   </head>
 
   <body>


### PR DESCRIPTION
Usually we use PicoCSS but for a change, let's use Oat instead (https://oat.ink).

Before:

<img width="1032" height="1007" alt="Screenshot_20260519_160424" src="https://github.com/user-attachments/assets/910b5c7b-1649-46e4-ad59-ff0af1457c1f" />


After:

<img width="1032" height="1007" alt="Screenshot_20260519_160256" src="https://github.com/user-attachments/assets/f07f69c1-6c07-4cc5-9561-c55fa4d4f456" />
