### PR TITLE
feat: init walmart tool

### DIFF
--- a/getgather/mcp/mcp-tools.yaml
+++ b/getgather/mcp/mcp-tools.yaml
@@ -580,6 +580,14 @@
     - function_name: get_wishlists
       description: Get wishlists of wayfair.
 
+- id: walmart
+  name: Walmart MCP
+  custom: true
+  module: walmart
+  tools:
+    - function_name: get_order_history
+      description: Get order history from a user's Walmart account.
+
 - id: youtube
   name: YouTube MCP
   custom: true

--- a/getgather/mcp/patterns/walmart-orders.html
+++ b/getgather/mcp/patterns/walmart-orders.html
@@ -1,0 +1,10 @@
+<html gg-domain="walmart">
+  <head>
+    <title>Walmart Orders - Purchase History</title>
+  </head>
+  <body>
+    <h1 gg-stop gg-match="//h1[contains(normalize-space(.), 'Purchase history')]"></h1>
+    <div gg-optional gg-match="[data-testid='order-0']"></div>
+    <div gg-optional gg-match="[data-testid='orderGroup-0']"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walmart-pre-signin.html
+++ b/getgather/mcp/patterns/walmart-pre-signin.html
@@ -1,0 +1,10 @@
+<html gg-domain="walmart">
+  <head>
+    <title>Walmart Pre Sign In</title>
+  </head>
+  <body>
+    <h1 gg-match="//h1[contains(normalize-space(.), 'Track your order')]"></h1>
+    <h1 gg-match="//h1[contains(normalize-space(.), 'Sign in to do more with your account')]"></h1>
+    <div gg-autoclick gg-match="button[data-automation-id='account-sign-in-button']"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walmart-signin-email.html
+++ b/getgather/mcp/patterns/walmart-signin-email.html
@@ -1,0 +1,15 @@
+<html gg-domain="walmart">
+  <head>
+    <title>Walmart Sign In - Email or Phone</title>
+  </head>
+  <body>
+    <input
+      autofocus
+      name="loginId"
+      type="text"
+      placeholder="Phone number or email (required)"
+      gg-match="input[aria-label='Phone number or email (required)']"
+    />
+    <button type="submit" gg-match="button#login-continue-button">Continue</button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walmart-signin-method-select.html
+++ b/getgather/mcp/patterns/walmart-signin-method-select.html
@@ -1,0 +1,9 @@
+<html gg-domain="walmart" gg-priority="1">
+  <head>
+    <title>Walmart Sign In - Choose Sign In Method</title>
+  </head>
+  <body>
+    <h1 gg-match="h1.f3">Welcome back!</h1>
+    <div gg-autoclick gg-match="input[name='password'][type='radio']"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walmart-signin-otp.html
+++ b/getgather/mcp/patterns/walmart-signin-otp.html
@@ -1,0 +1,18 @@
+<html gg-domain="walmart">
+  <head>
+    <title>Walmart Sign In - Enter Verification Code</title>
+  </head>
+  <body>
+    <h1 gg-match="h1.f3">Enter verification code</h1>
+    <input
+      autofocus
+      name="otp"
+      type="text"
+      placeholder="6-digit verification code"
+      gg-match="input#input-verificationCode"
+    />
+    <button type="submit" gg-match="button[type='submit'][form='verifyitsyou-otp-form']">
+      Sign in
+    </button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walmart-signin-password.html
+++ b/getgather/mcp/patterns/walmart-signin-password.html
@@ -1,0 +1,16 @@
+<html gg-domain="walmart">
+  <head>
+    <title>Walmart Sign In - Password</title>
+  </head>
+  <body>
+    <h1 gg-match="h1.f3">Welcome back!</h1>
+    <input
+      autofocus
+      name="password"
+      type="password"
+      placeholder="Password"
+      gg-match="input[name='password'][type='password']"
+    />
+    <button type="submit" gg-match="button#withpassword-sign-in-button">Sign in</button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walmart-signin-verify-method-select.html
+++ b/getgather/mcp/patterns/walmart-signin-verify-method-select.html
@@ -1,0 +1,21 @@
+<html gg-domain="walmart" gg-priority="1">
+  <head>
+    <title>Walmart Sign In - Verify It's You</title>
+  </head>
+  <body>
+    <h1 gg-match="h1.f3">Verify it's you</h1>
+    <p>Please choose a verification method</p>
+    <button name="otp" value="otp" gg-optional gg-match="input[name='otp'][type='radio']">
+      Send me a verification code
+    </button>
+    <button
+      name="otpEmail"
+      value="otpEmail"
+      gg-optional
+      gg-match="input[name='otpEmail'][type='radio']"
+    >
+      Email me a verification code
+    </button>
+    <button type="submit" gg-match="//button[contains(text(), 'Send code')]">Send code</button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walmart-signin-verify-phone-only.html
+++ b/getgather/mcp/patterns/walmart-signin-verify-phone-only.html
@@ -1,0 +1,13 @@
+<html gg-domain="walmart">
+  <head>
+    <title>Walmart Sign In - Verify Phone Only</title>
+  </head>
+  <body>
+    <h1 gg-match="h1.f3">Verify it's you</h1>
+    <p
+      gg-match="//div[@data-testid='identity-generic-choice-options']//div[contains(normalize-space(.), 'We')]"
+    ></p>
+    <p><span gg-match="span[data-qm-mask='true']"></span></p>
+    <div gg-autoclick gg-match="//button[contains(text(), 'Send code')]"></div>
+  </body>
+</html>

--- a/getgather/mcp/walmart.py
+++ b/getgather/mcp/walmart.py
@@ -1,0 +1,34 @@
+from typing import Any, cast
+
+import zendriver as zd
+
+from getgather.mcp.dpage import remote_zen_dpage_with_action
+from getgather.mcp.registry import MCPTool
+
+walmart_mcp = MCPTool.registry["walmart"]
+
+
+async def _get_order_history_action(tab: zd.Tab, _: zd.Browser) -> dict[str, Any]:
+    result = await tab.evaluate(
+        """
+        (() => {
+            const el = document.getElementById('__NEXT_DATA__');
+            if (!el) throw new Error('__NEXT_DATA__ not found');
+            const data = JSON.parse(el.textContent);
+            const purchaseHistory = data?.props?.pageProps?.phRedesignInitialData?.data?.purchaseHistory;
+            if (!purchaseHistory) throw new Error('purchaseHistory not found in __NEXT_DATA__');
+            return purchaseHistory;
+        })()
+        """,
+        await_promise=False,
+    )
+    return {"walmart_order_history": cast(dict[str, Any], result)}
+
+
+@walmart_mcp.tool
+async def get_order_history() -> dict[str, Any]:
+    """Get order history from a user's Walmart account."""
+    return await remote_zen_dpage_with_action(
+        "https://www.walmart.com/orders",
+        _get_order_history_action,
+    )

--- a/getgather/mcp/walmart.py
+++ b/getgather/mcp/walmart.py
@@ -22,7 +22,7 @@ async def _get_order_history_action(tab: zd.Tab, _: zd.Browser) -> dict[str, Any
         """,
         await_promise=False,
     )
-    return {"walmart_order_history": cast(dict[str, Any], result)}
+    return {"order_history": cast(dict[str, Any], result)}
 
 
 @walmart_mcp.tool


### PR DESCRIPTION
- Adds `walmart_get_order_history` MCP tool that extracts purchase history from the Walmart `/orders` page
- Implements full sign-in distillation flow: email/phone input, password, OTP, and two post-password verification paths (verify method selection and phone-only auto-send)
- Order history is read from the SSR'd `__NEXT_DATA__` script tag (`props.pageProps.phRedesignInitialData.data.purchaseHistory`) rather than intercepting GraphQL, because Walmart SSRs the page on direct URL navigation and the `PurchaseHistoryV3` GraphQL call only fires during client-side SPA navigation

<img width="484" height="690" alt="Firefox Developer Edition 2026-05-20 12 29 06" src="https://github.com/user-attachments/assets/97f901cc-ec83-4945-aaff-bcdc3fbc33c8" />
