### PR TITLE
feat: walmart order history with pagination

### DIFF
--- a/getgather/mcp/patterns/walmart-account.html
+++ b/getgather/mcp/patterns/walmart-account.html
@@ -1,0 +1,9 @@
+<html gg-domain="walmart">
+  <head>
+    <title>Walmart Account</title>
+  </head>
+  <body>
+    <h3 gg-stop gg-match="//h3[contains(normalize-space(.), 'Purchase History')]"></h3>
+    <button gg-match="button[name='viewPurchaseHistory']">View all orders</button>
+  </body>
+</html>

--- a/getgather/mcp/walmart.py
+++ b/getgather/mcp/walmart.py
@@ -87,6 +87,7 @@ async def _get_order_history_action(tab: zd.Tab, _: zd.Browser, page_cursor: str
 @walmart_mcp.tool
 async def get_order_history(page_cursor: str = "") -> dict[str, Any]:
     """Get order history from a user's Walmart account. Pass next_cursor from a previous response to fetch the next page."""
+
     async def action(tab: zd.Tab, browser: zd.Browser) -> dict[str, Any]:
         return await _get_order_history_action(tab, browser, page_cursor)
 

--- a/getgather/mcp/walmart.py
+++ b/getgather/mcp/walmart.py
@@ -8,80 +8,71 @@ from getgather.mcp.registry import MCPTool
 walmart_mcp = MCPTool.registry["walmart"]
 
 
-async def _get_order_history_action(tab: zd.Tab, _: zd.Browser) -> dict[str, Any]:
+async def _get_order_history_action(tab: zd.Tab, _: zd.Browser, page_cursor: str) -> dict[str, Any]:
     result = await tab.evaluate(
-        """
-        (async () => {
-            const httpRequest = await new Promise((resolve, reject) => {
+        f"""
+        (async () => {{
+            const httpRequest = await new Promise((resolve, reject) => {{
                 const timer = setTimeout(() => reject(new Error('Timed out waiting for PurchaseHistoryV3')), 10000);
                 const originalFetch = window.fetch;
-                window.fetch = async function (...args) {
-                    if (typeof args[0] === 'string' && args[0].includes('/PurchaseHistoryV3')) {
+                window.fetch = async function (...args) {{
+                    if (typeof args[0] === 'string' && args[0].includes('/PurchaseHistoryV3')) {{
                         window.fetch = originalFetch;
                         clearTimeout(timer);
-                        resolve({ url: args[0], headers: (args[1] || {}).headers || {} });
-                    }
+                        resolve({{ url: args[0], headers: (args[1] || {{}}).headers || {{}} }});
+                    }}
                     return originalFetch.apply(this, args);
-                };
+                }};
                 document.querySelector('button[name="viewPurchaseHistory"]')?.click();
-            });
+            }});
 
             const baseUrl = httpRequest.url.split('?')[0];
             const headers = httpRequest.headers;
 
-            const fetchPage = async (cursor) => {
-                const variables = encodeURIComponent(JSON.stringify({
-                    input: {
-                        cursor,
-                        search: '',
-                        filterIds: [],
-                        limit: 20,
-                        type: null,
-                        minTimestamp: null,
-                        maxTimestamp: null,
-                        filters: { minTimestamp: null, maxTimestamp: null, filterIds: [] },
-                        enabledFeatures: [],
-                        eligibleFeatures: { isEbtEligible: false, enablePhFiltersEnhancement: true }
-                    },
-                    platform: 'WEB',
-                    enableIsWcpOrder: false
-                }));
-                const res = await fetch(`${baseUrl}?variables=${variables}`, {
-                    method: 'GET',
-                    credentials: 'include',
-                    headers
-                });
-                if (!res.ok) {
-                    const text = await res.text();
-                    throw new Error(`HTTP error! status: ${res.status} - ${text}`);
-                }
-                return await res.json();
-            };
+            const variables = encodeURIComponent(JSON.stringify({{
+                input: {{
+                    cursor: {repr(page_cursor)},
+                    search: '',
+                    filterIds: [],
+                    limit: 20,
+                    type: null,
+                    minTimestamp: null,
+                    maxTimestamp: null,
+                    filters: {{ minTimestamp: null, maxTimestamp: null, filterIds: [] }},
+                    enabledFeatures: [],
+                    eligibleFeatures: {{ isEbtEligible: false, enablePhFiltersEnhancement: true }}
+                }},
+                platform: 'WEB',
+                enableIsWcpOrder: false
+            }}));
 
-            const allOrders = [];
-            let cursor = '';
-
-            while (true) {
-                const page = await fetchPage(cursor);
-                const purchaseHistory = page?.data?.purchaseHistory;
-                if (!purchaseHistory) throw new Error('purchaseHistory not found in response');
-                allOrders.push(...purchaseHistory.orders);
-                cursor = purchaseHistory.pageInfo?.nextPageCursor;
-                if (cursor === null || cursor === undefined) break;
-            }
-
-            return allOrders;
-        })()
+            const res = await fetch(`${{baseUrl}}?variables=${{variables}}`, {{
+                method: 'GET',
+                credentials: 'include',
+                headers
+            }});
+            if (!res.ok) {{
+                const text = await res.text();
+                throw new Error(`HTTP error! status: ${{res.status}} - ${{text}}`);
+            }}
+            const data = await res.json();
+            const purchaseHistory = data?.data?.purchaseHistory;
+            if (!purchaseHistory) throw new Error('purchaseHistory not found in response');
+            return purchaseHistory;
+        }})()
         """,
         await_promise=True,
     )
-    return {"order_history": cast(list[Any], result)}
+    return {"order_history": cast(dict[str, Any], result)}
 
 
 @walmart_mcp.tool
-async def get_order_history() -> dict[str, Any]:
-    """Get order history from a user's Walmart account."""
+async def get_order_history(page_cursor: str = "") -> dict[str, Any]:
+    """Get order history from a user's Walmart account. Pass next_cursor from a previous response to fetch the next page."""
+    async def action(tab: zd.Tab, browser: zd.Browser) -> dict[str, Any]:
+        return await _get_order_history_action(tab, browser, page_cursor)
+
     return await remote_zen_dpage_with_action(
         "https://www.walmart.com/account",
-        _get_order_history_action,
+        action,
     )

--- a/getgather/mcp/walmart.py
+++ b/getgather/mcp/walmart.py
@@ -3,85 +3,102 @@ from typing import Any, cast
 
 import zendriver as zd
 
+from getgather.browser import retry_with_navigation, zen_navigate_with_retry
 from getgather.mcp.dpage import remote_zen_dpage_with_action
 from getgather.mcp.registry import MCPTool
 
 walmart_mcp = MCPTool.registry["walmart"]
 
 
-async def _get_order_history_action(tab: zd.Tab, _: zd.Browser, page_cursor: str) -> dict[str, Any]:
-    result = await tab.evaluate(
-        f"""
-        (async () => {{
-            const httpRequest = await new Promise((resolve, reject) => {{
-                const originalFetch = window.fetch;
-                const restore = () => {{ window.fetch = originalFetch; }};
-                const timer = setTimeout(() => {{
-                    restore();
-                    reject(new Error('Timed out waiting for PurchaseHistoryV3'));
-                }}, 10000);
+async def _get_order_history(tab: zd.Tab, page_cursor: str) -> dict[str, Any]:
+    async def fetch_orders() -> dict[str, Any]:
+        await zen_navigate_with_retry(tab, "https://www.walmart.com/account", wait_for_ready=False)
+        result = await tab.evaluate(
+            f"""
+            (async () => {{
+                const btn = await new Promise((resolve, reject) => {{
+                    const deadline = Date.now() + 10000;
+                    const poll = () => {{
+                        const el = document.querySelector('button[name="viewPurchaseHistory"]');
+                        if (el) return resolve(el);
+                        if (Date.now() >= deadline) return reject(new Error('viewPurchaseHistory button not found'));
+                        setTimeout(poll, 200);
+                    }};
+                    poll();
+                }});
 
-                window.fetch = async function (...args) {{
-                    if (typeof args[0] === 'string' && args[0].includes('/PurchaseHistoryV3')) {{
+                const httpRequest = await new Promise((resolve, reject) => {{
+                    const originalFetch = window.fetch;
+                    const restore = () => {{ window.fetch = originalFetch; }};
+                    const timer = setTimeout(() => {{
                         restore();
-                        clearTimeout(timer);
-                        const rawHeaders = (args[1] || {{}}).headers || {{}};
-                        const headers = rawHeaders instanceof Headers
-                            ? Object.fromEntries(rawHeaders.entries())
-                            : rawHeaders;
-                        resolve({{ url: args[0], headers }});
-                    }}
-                    return originalFetch.apply(this, args);
-                }};
+                        reject(new Error('Timed out waiting for PurchaseHistoryV3'));
+                    }}, 10000);
 
-                const btn = document.querySelector('button[name="viewPurchaseHistory"]');
-                if (!btn) {{
-                    restore();
-                    clearTimeout(timer);
-                    reject(new Error('viewPurchaseHistory button not found'));
-                    return;
+                    window.fetch = async function (...args) {{
+                        if (typeof args[0] === 'string' && args[0].includes('/PurchaseHistoryV3')) {{
+                            restore();
+                            clearTimeout(timer);
+                            const rawHeaders = (args[1] || {{}}).headers || {{}};
+                            const headers = rawHeaders instanceof Headers
+                                ? Object.fromEntries(rawHeaders.entries())
+                                : rawHeaders;
+                            resolve({{ url: args[0], headers }});
+                        }}
+                        return originalFetch.apply(this, args);
+                    }};
+
+                    btn.click();
+                }});
+
+                const baseUrl = httpRequest.url.split('?')[0];
+                const headers = httpRequest.headers;
+
+                const variables = encodeURIComponent(JSON.stringify({{
+                    input: {{
+                        cursor: {json.dumps(page_cursor)},
+                        search: '',
+                        filterIds: [],
+                        limit: 20,
+                        type: null,
+                        minTimestamp: null,
+                        maxTimestamp: null,
+                        filters: {{ minTimestamp: null, maxTimestamp: null, filterIds: [] }},
+                        enabledFeatures: [],
+                        eligibleFeatures: {{ isEbtEligible: false, enablePhFiltersEnhancement: true }}
+                    }},
+                    platform: 'WEB',
+                    enableIsWcpOrder: false
+                }}));
+
+                const res = await fetch(`${{baseUrl}}?variables=${{variables}}`, {{
+                    method: 'GET',
+                    credentials: 'include',
+                    headers
+                }});
+                if (!res.ok) {{
+                    const text = await res.text();
+                    throw new Error(`HTTP error! status: ${{res.status}} - ${{text}}`);
                 }}
-                btn.click();
-            }});
+                const data = await res.json();
+                const purchaseHistory = data?.data?.purchaseHistory;
+                if (!purchaseHistory) throw new Error('purchaseHistory not found in response');
+                return purchaseHistory;
+            }})()
+            """,
+            await_promise=True,
+        )
+        return {"order_history": cast(dict[str, Any], result)}
 
-            const baseUrl = httpRequest.url.split('?')[0];
-            const headers = httpRequest.headers;
-
-            const variables = encodeURIComponent(JSON.stringify({{
-                input: {{
-                    cursor: {json.dumps(page_cursor)},
-                    search: '',
-                    filterIds: [],
-                    limit: 20,
-                    type: null,
-                    minTimestamp: null,
-                    maxTimestamp: null,
-                    filters: {{ minTimestamp: null, maxTimestamp: null, filterIds: [] }},
-                    enabledFeatures: [],
-                    eligibleFeatures: {{ isEbtEligible: false, enablePhFiltersEnhancement: true }}
-                }},
-                platform: 'WEB',
-                enableIsWcpOrder: false
-            }}));
-
-            const res = await fetch(`${{baseUrl}}?variables=${{variables}}`, {{
-                method: 'GET',
-                credentials: 'include',
-                headers
-            }});
-            if (!res.ok) {{
-                const text = await res.text();
-                throw new Error(`HTTP error! status: ${{res.status}} - ${{text}}`);
-            }}
-            const data = await res.json();
-            const purchaseHistory = data?.data?.purchaseHistory;
-            if (!purchaseHistory) throw new Error('purchaseHistory not found in response');
-            return purchaseHistory;
-        }})()
-        """,
-        await_promise=True,
+    return await retry_with_navigation(
+        tab=tab,
+        operation=fetch_orders,
+        navigation_url="https://www.walmart.com/account",
+        max_retries=3,
+        exceptions=(Exception,),
+        re_raise_on_max_retries=True,
+        operation_name="get_order_history",
     )
-    return {"order_history": cast(dict[str, Any], result)}
 
 
 @walmart_mcp.tool
@@ -89,7 +106,7 @@ async def get_order_history(page_cursor: str = "") -> dict[str, Any]:
     """Get order history from a user's Walmart account. Pass next_cursor from a previous response to fetch the next page."""
 
     async def action(tab: zd.Tab, browser: zd.Browser) -> dict[str, Any]:
-        return await _get_order_history_action(tab, browser, page_cursor)
+        return await _get_order_history(tab, page_cursor)
 
     return await remote_zen_dpage_with_action(
         "https://www.walmart.com/account",

--- a/getgather/mcp/walmart.py
+++ b/getgather/mcp/walmart.py
@@ -11,24 +11,77 @@ walmart_mcp = MCPTool.registry["walmart"]
 async def _get_order_history_action(tab: zd.Tab, _: zd.Browser) -> dict[str, Any]:
     result = await tab.evaluate(
         """
-        (() => {
-            const el = document.getElementById('__NEXT_DATA__');
-            if (!el) throw new Error('__NEXT_DATA__ not found');
-            const data = JSON.parse(el.textContent);
-            const purchaseHistory = data?.props?.pageProps?.phRedesignInitialData?.data?.purchaseHistory;
-            if (!purchaseHistory) throw new Error('purchaseHistory not found in __NEXT_DATA__');
-            return purchaseHistory;
+        (async () => {
+            const httpRequest = await new Promise((resolve, reject) => {
+                const timer = setTimeout(() => reject(new Error('Timed out waiting for PurchaseHistoryV3')), 10000);
+                const originalFetch = window.fetch;
+                window.fetch = async function (...args) {
+                    if (typeof args[0] === 'string' && args[0].includes('/PurchaseHistoryV3')) {
+                        window.fetch = originalFetch;
+                        clearTimeout(timer);
+                        resolve({ url: args[0], headers: (args[1] || {}).headers || {} });
+                    }
+                    return originalFetch.apply(this, args);
+                };
+                document.querySelector('button[name="viewPurchaseHistory"]')?.click();
+            });
+
+            const baseUrl = httpRequest.url.split('?')[0];
+            const headers = httpRequest.headers;
+
+            const fetchPage = async (cursor) => {
+                const variables = encodeURIComponent(JSON.stringify({
+                    input: {
+                        cursor,
+                        search: '',
+                        filterIds: [],
+                        limit: 20,
+                        type: null,
+                        minTimestamp: null,
+                        maxTimestamp: null,
+                        filters: { minTimestamp: null, maxTimestamp: null, filterIds: [] },
+                        enabledFeatures: [],
+                        eligibleFeatures: { isEbtEligible: false, enablePhFiltersEnhancement: true }
+                    },
+                    platform: 'WEB',
+                    enableIsWcpOrder: false
+                }));
+                const res = await fetch(`${baseUrl}?variables=${variables}`, {
+                    method: 'GET',
+                    credentials: 'include',
+                    headers
+                });
+                if (!res.ok) {
+                    const text = await res.text();
+                    throw new Error(`HTTP error! status: ${res.status} - ${text}`);
+                }
+                return await res.json();
+            };
+
+            const allOrders = [];
+            let cursor = '';
+
+            while (true) {
+                const page = await fetchPage(cursor);
+                const purchaseHistory = page?.data?.purchaseHistory;
+                if (!purchaseHistory) throw new Error('purchaseHistory not found in response');
+                allOrders.push(...purchaseHistory.orders);
+                cursor = purchaseHistory.pageInfo?.nextPageCursor;
+                if (cursor === null || cursor === undefined) break;
+            }
+
+            return allOrders;
         })()
         """,
-        await_promise=False,
+        await_promise=True,
     )
-    return {"order_history": cast(dict[str, Any], result)}
+    return {"order_history": cast(list[Any], result)}
 
 
 @walmart_mcp.tool
 async def get_order_history() -> dict[str, Any]:
     """Get order history from a user's Walmart account."""
     return await remote_zen_dpage_with_action(
-        "https://www.walmart.com/orders",
+        "https://www.walmart.com/account",
         _get_order_history_action,
     )

--- a/getgather/mcp/walmart.py
+++ b/getgather/mcp/walmart.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, cast
 
 import zendriver as zd
@@ -13,17 +14,34 @@ async def _get_order_history_action(tab: zd.Tab, _: zd.Browser, page_cursor: str
         f"""
         (async () => {{
             const httpRequest = await new Promise((resolve, reject) => {{
-                const timer = setTimeout(() => reject(new Error('Timed out waiting for PurchaseHistoryV3')), 10000);
                 const originalFetch = window.fetch;
+                const restore = () => {{ window.fetch = originalFetch; }};
+                const timer = setTimeout(() => {{
+                    restore();
+                    reject(new Error('Timed out waiting for PurchaseHistoryV3'));
+                }}, 10000);
+
                 window.fetch = async function (...args) {{
                     if (typeof args[0] === 'string' && args[0].includes('/PurchaseHistoryV3')) {{
-                        window.fetch = originalFetch;
+                        restore();
                         clearTimeout(timer);
-                        resolve({{ url: args[0], headers: (args[1] || {{}}).headers || {{}} }});
+                        const rawHeaders = (args[1] || {{}}).headers || {{}};
+                        const headers = rawHeaders instanceof Headers
+                            ? Object.fromEntries(rawHeaders.entries())
+                            : rawHeaders;
+                        resolve({{ url: args[0], headers }});
                     }}
                     return originalFetch.apply(this, args);
                 }};
-                document.querySelector('button[name="viewPurchaseHistory"]')?.click();
+
+                const btn = document.querySelector('button[name="viewPurchaseHistory"]');
+                if (!btn) {{
+                    restore();
+                    clearTimeout(timer);
+                    reject(new Error('viewPurchaseHistory button not found'));
+                    return;
+                }}
+                btn.click();
             }});
 
             const baseUrl = httpRequest.url.split('?')[0];
@@ -31,7 +49,7 @@ async def _get_order_history_action(tab: zd.Tab, _: zd.Browser, page_cursor: str
 
             const variables = encodeURIComponent(JSON.stringify({{
                 input: {{
-                    cursor: {repr(page_cursor)},
+                    cursor: {json.dumps(page_cursor)},
                     search: '',
                     filterIds: [],
                     limit: 20,


### PR DESCRIPTION
This is follow-up diff from #1262 

Replaces the `__NEXT_DATA__` SSR extraction approach with cursor-based manual pagination. Navigates to `/account`, triggers SPA navigation to intercept the `PurchaseHistoryV3` GraphQL request, then replays it with the provided `page_cursor`. Returns the full `purchaseHistory` object so clients can read `pageInfo.nextPageCursor` to fetch subsequent pages.

<img width="484" height="690" alt="Firefox Developer Edition 2026-05-20 12 29 06" src="https://github.com/user-attachments/assets/97f901cc-ec83-4945-aaff-bcdc3fbc33c8" />