### PR TITLE
feat(walmart): enrich order history items with price info

### DIFF
--- a/getgather/mcp/walmart.py
+++ b/getgather/mcp/walmart.py
@@ -1,13 +1,23 @@
+import asyncio
 import json
+import random
 from typing import Any, cast
 
 import zendriver as zd
+from loguru import logger
 
-from getgather.browser import retry_with_navigation, zen_navigate_with_retry
+from getgather.browser import (
+    get_new_page,
+    retry_with_navigation,
+    safe_close_page,
+    zen_navigate_with_retry,
+)
 from getgather.mcp.dpage import remote_zen_dpage_with_action
 from getgather.mcp.registry import MCPTool
 
 walmart_mcp = MCPTool.registry["walmart"]
+
+_BATCH_SIZE = 3
 
 
 async def _get_order_history(tab: zd.Tab, page_cursor: str) -> dict[str, Any]:
@@ -101,12 +111,199 @@ async def _get_order_history(tab: zd.Tab, page_cursor: str) -> dict[str, Any]:
     )
 
 
+_COLLECT_ITEMS_JS = """
+function collectItems(priceByItemId, items) {
+    if (!Array.isArray(items)) return;
+    for (const item of items) {
+        const id = item?.id;
+        const pi = item?.priceInfo;
+        if (!id || !pi) continue;
+        priceByItemId[id] = {
+            linePrice: pi.linePrice ?? null,
+            itemPrice: pi.itemPrice ?? null,
+            unitPrice: pi.unitPrice ?? null
+        };
+    }
+}
+"""
+
+
+async def _fetch_single_order_detail(
+    browser: zd.Browser, order_id: str, group_id: str
+) -> dict[str, Any] | None:
+    """Open a new tab on the order detail page and extract price data from __NEXT_DATA__.
+
+    Returns a map of itemId -> priceInfo, or None on failure.
+    """
+    detail_url = f"https://www.walmart.com/orders/{order_id}?groupId={group_id}"
+    logger.info("Opening order detail tab for order {}: {}", order_id, detail_url)
+    try:
+        page = await get_new_page(browser)
+    except Exception as e:
+        logger.warning("Failed to open tab for order {}: {}", order_id, e)
+        return None
+
+    try:
+        await zen_navigate_with_retry(page, detail_url)
+
+        raw = await page.evaluate(
+            f"""
+            (async () => {{
+                {_COLLECT_ITEMS_JS}
+
+                const el = document.getElementById('__NEXT_DATA__');
+                if (!el) return {{ _error: 'no __NEXT_DATA__ element found' }};
+                if (!el.textContent) return {{ _error: '__NEXT_DATA__ element is empty' }};
+
+                let parsed;
+                try {{ parsed = JSON.parse(el.textContent); }} catch (e) {{
+                    return {{ _error: `JSON parse failed: ${{e.message}}` }};
+                }}
+
+                const order = parsed?.props?.pageProps?.initialData?.data?.order;
+                if (!order) {{
+                    const keys = JSON.stringify(Object.keys(parsed?.props?.pageProps?.initialData?.data ?? {{}}));
+                    return {{ _error: `no order in __NEXT_DATA__, keys: ${{keys}}` }};
+                }}
+
+                const priceByItemId = {{}};
+                const tg = order.tippableGroup;
+                if (tg) collectItems(priceByItemId, tg.items);
+                const groups = order.groups_2101;
+                if (Array.isArray(groups)) {{
+                    for (const g of groups) {{
+                        if (Array.isArray(g.categories)) {{
+                            for (const cat of g.categories) collectItems(priceByItemId, cat.items);
+                        }}
+                        if (Array.isArray(g.subGroups)) {{
+                            for (const sg of g.subGroups) {{
+                                if (Array.isArray(sg.categories)) {{
+                                    for (const cat of sg.categories) collectItems(priceByItemId, cat.items);
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+                return priceByItemId;
+            }})()
+            """,
+            await_promise=True,
+        )
+
+        if not isinstance(raw, dict):
+            logger.warning("Order detail for {} returned unexpected type {}", order_id, type(raw))
+            return None
+
+        if "_error" in raw:
+            logger.warning("Order detail fetch failed for {}: {}", order_id, raw["_error"])
+            return None
+
+        logger.info("Order detail fetched successfully for order {}", order_id)
+        return cast(dict[str, Any], raw)
+
+    except Exception as e:
+        logger.warning("Order detail tab failed for order {}: {}", order_id, e)
+        return None
+    finally:
+        await safe_close_page(page)
+
+
+async def _fetch_order_details(
+    browser: zd.Browser, orders: list[dict[str, Any]]
+) -> dict[str, dict[str, Any]]:
+    """Fetch order details for all orders in batches, each batch running concurrently.
+
+    Never raises — returns an empty dict on any failure so order history still succeeds.
+    """
+    order_inputs: list[dict[str, str]] = []
+    for order in orders:
+        order_id = order.get("id", "")
+        if not order_id:
+            continue
+        groups: list[dict[str, Any]] = order.get("groups", [])
+        first_group: dict[str, Any] = groups[0] if groups else {}
+        group_id: str = first_group.get("groupId") or first_group.get("id") or ""
+        order_inputs.append({"orderId": order_id, "groupId": group_id})
+
+    if not order_inputs:
+        return {}
+
+    total_batches = (len(order_inputs) + _BATCH_SIZE - 1) // _BATCH_SIZE
+    logger.info(
+        "Fetching order details for {} orders ({} batches of {})",
+        len(order_inputs),
+        total_batches,
+        _BATCH_SIZE,
+    )
+
+    price_map: dict[str, dict[str, Any]] = {}
+    for i in range(0, len(order_inputs), _BATCH_SIZE):
+        chunk = order_inputs[i : i + _BATCH_SIZE]
+        batch_num = i // _BATCH_SIZE + 1
+        chunk_ids = [o["orderId"] for o in chunk]
+        logger.info("Order detail batch {}/{}: {}", batch_num, total_batches, chunk_ids)
+
+        results = await asyncio.gather(
+            *[_fetch_single_order_detail(browser, o["orderId"], o["groupId"]) for o in chunk],
+            return_exceptions=True,
+        )
+
+        succeeded: list[str] = []
+        failed: list[str] = []
+        for o, result in zip(chunk, results):
+            oid = o["orderId"]
+            if isinstance(result, BaseException):
+                logger.warning("Unexpected error fetching order detail for {}: {}", oid, result)
+                failed.append(oid)
+            elif result is not None:
+                price_map[oid] = result
+                succeeded.append(oid)
+            else:
+                failed.append(oid)
+        logger.info(
+            "Batch {}/{} complete — succeeded: {}, failed: {}",
+            batch_num,
+            total_batches,
+            succeeded,
+            failed,
+        )
+
+        if i + _BATCH_SIZE < len(order_inputs):
+            await asyncio.sleep(random.uniform(0.2, 0.5))
+
+    return price_map
+
+
+def _merge_price_info(
+    purchase_history: dict[str, Any], price_map: dict[str, dict[str, Any]]
+) -> None:
+    """Mutate purchase_history in-place, attaching priceInfo to each item.
+
+    Items for orders with no detail result get priceInfo=None explicitly.
+    """
+    for order in purchase_history.get("orders", []):
+        order_id = order.get("id", "")
+        item_prices = price_map.get(order_id)
+        for group in order.get("groups", []):
+            for item in group.get("items", []):
+                item_id = item.get("id")
+                item["priceInfo"] = item_prices.get(item_id) if (item_prices and item_id) else None
+
+
 @walmart_mcp.tool
 async def get_order_history(page_cursor: str = "") -> dict[str, Any]:
     """Get order history from a user's Walmart account. Pass next_cursor from a previous response to fetch the next page."""
 
     async def action(tab: zd.Tab, browser: zd.Browser) -> dict[str, Any]:
-        return await _get_order_history(tab, page_cursor)
+        result = await _get_order_history(tab, page_cursor)
+        purchase_history = result["order_history"]
+        orders = purchase_history.get("orders", [])
+
+        price_map = await _fetch_order_details(browser, orders)
+        logger.info("Order price enrichment complete for {} orders", len(orders))
+
+        _merge_price_info(purchase_history, price_map)
+        return result
 
     return await remote_zen_dpage_with_action(
         "https://www.walmart.com/account",


### PR DESCRIPTION
The `get_order_history` tool previously returned items with no price data. This PR adds per-item `priceInfo` (line price, item price, unit price) by fetching each order's detail page and reading from the Next.js SSR payload.

**Approach**

A few constraints shaped the implementation:

- **No href on the order detail link.** Navigation from the history list is client-side (onClick), so there's no URL to read from the DOM. We construct it directly as `https://www.walmart.com/orders/{orderId}?groupId={groupId}` from data already in the history response.
- **Can't intercept the GraphQL request.** The order detail page is SSR, so the `getOrder` GraphQL call happens on the server, not in the browser tab.
- **Injected `fetch()` returns HTTP 418.** Calling the GraphQL endpoint directly from page context likely fails due to missing Walmart-specific request headers.
- **One tab per order, not sequential navigation.** Opening each order in a new tab lets multiple orders be fetched concurrently without the main tab losing its state or paying the back-and-forth navigation cost for every order.

Given all of the above, the simplest path is to open each order detail URL in a new tab and read `__NEXT_DATA__` from the DOM. The SSR payload contains the full order at `props.pageProps.initialData.data.order` (same schema as the GraphQL response) with no extra HTTP request needed.


https://github.com/user-attachments/assets/6528937a-db88-4dc8-a85f-2a5627dcacf0


