### PR TITLE
CI: Remove Chrome Fleet dependency from package workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -36,18 +36,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run Chrome Fleet
-        uses: ./.github/actions/run-chromefleet
-        timeout-minutes: 5
-
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: remotebrowser-mcp-linux-x86_64
 
       - run: chmod +x remotebrowser-mcp && ./remotebrowser-mcp &
-        env:
-          CHROMEFLEET_URL: http://localhost:8300
 
       - name: Run the health check validation
         run: while ! curl -s 'http://localhost:23456/health' | grep 'OK'; do sleep 1; done


### PR DESCRIPTION
The package workflow no longer needs to spin up Chrome Fleet since the health check runs against a standalone binary.

<img width="1828" height="659" alt="image" src="https://github.com/user-attachments/assets/447ead56-a709-48e3-aa80-3eaf561da35f" />
