### PR TITLE
Run distillation tests against built wheel, not Chrome Fleet

### DIFF
--- a/.github/workflows/distill-tests.yml
+++ b/.github/workflows/distill-tests.yml
@@ -11,20 +11,28 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
+      - name: Prepare the browser container image
+        run: podman pull ghcr.io/remotebrowser/chromium-live
+
       - name: Checkout code
         uses: actions/checkout@v6
-
-      - name: Run Chrome Fleet
-        uses: ./.github/actions/run-chromefleet
-        timeout-minutes: 5
 
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
 
+      - run: uvx hatch build
+
+      - name: Launch Remote Browser
+        run: uvx ./dist/*.whl &
+
+      - name: Run the health check validation
+        run: while ! curl -s 'http://localhost:23456/health' | grep 'OK'; do sleep 1; done
+        timeout-minutes: 3
+
       - name: Run the distillation tests
         run: uv run pytest -m "distill" -s -p no:xdist
         env:
-          CHROMEFLEET_URL: http://localhost:8300
+          CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS: 120
           ACME_EMAIL: joe@example.com
           ACME_PASSWORD: trustno1
           ACME_OTP: 123456


### PR DESCRIPTION
Build the wheel and self-host Remote Browser directly in CI, removing the dependency on the separate Chrome Fleet app. This ensures distillation tests run against the same binary that gets published to PyPI (continues #1235).

<img width="1117" height="697" alt="image" src="https://github.com/user-attachments/assets/789233a7-4192-4c72-86b4-e568a4a280dd" />
