### PR TITLE
Fix the broken workflow of testing published container image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,17 +95,20 @@ jobs:
           CONTAINER_HOST: unix:///run/podman/podman.sock
         run: podman --remote run --rm quay.io/podman/hello
 
-      - name: Pull Chromium container image
+      - name: Prepare Chromium container image
         env:
           CONTAINER_HOST: unix:///run/podman/podman.sock
         run: podman --remote pull ghcr.io/remotebrowser/chromium-live
 
       - name: Pull published container image
-        run: podman pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+        run: |
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest published-remotebrowser
 
       - uses: remotebrowser/shared-github-actions/container-health-check@v1
         with:
-          image-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          image-name: published-remotebrowser
+          container-name: test-published-container
           health-checks: |
             {"url": "http://localhost:23456/health"}
             {"url": "http://localhost:23456/extended-health"}


### PR DESCRIPTION
Tag pulled image as a local image named `published-remotebrowser`. Then the rest of the verification steps can work as expected.

<img width="1507" height="833" alt="image" src="https://github.com/user-attachments/assets/1711c35a-3439-4004-b90d-36d6f153ff35" />