### PR TITLE
feat(walmart): add homepage logged-in/out distillation patterns

### DIFF
--- a/getgather/mcp/patterns/walmart-logged-in.html
+++ b/getgather/mcp/patterns/walmart-logged-in.html
@@ -1,0 +1,11 @@
+<html gg-domain="walmart">
+  <head>
+    <title>Walmart Logged In Mobile</title>
+  </head>
+  <body>
+    <div
+      gg-stop
+      gg-match="[data-testid='logged-in-account-button-name'], [data-test-id='walmart-cash-in-nav']"
+    ></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walmart-logged-out-menu.html
+++ b/getgather/mcp/patterns/walmart-logged-out-menu.html
@@ -1,0 +1,9 @@
+<html gg-domain="walmart">
+  <head>
+    <title>Walmart Logged Out Menu</title>
+  </head>
+  <body>
+    <div gg-match="#logged-out-links-container"></div>
+    <div gg-autoclick gg-match="a[data-testid='sign-in']"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walmart-logged-out-mobile-menu.html
+++ b/getgather/mcp/patterns/walmart-logged-out-mobile-menu.html
@@ -1,0 +1,9 @@
+<html gg-domain="walmart">
+  <head>
+    <title>Walmart Logged Out Mobile Menu</title>
+  </head>
+  <body>
+    <span gg-match="[data-testid='mobile-menu-Departments']"></span>
+    <div gg-autoclick gg-match="a[data-testid='sign-in']"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walmart-logged-out-mobile.html
+++ b/getgather/mcp/patterns/walmart-logged-out-mobile.html
@@ -1,0 +1,9 @@
+<html gg-domain="walmart" gg-priority="1">
+  <head>
+    <title>Walmart Logged Out Mobile</title>
+  </head>
+  <body>
+    <button gg-match="button[data-testid='Menu']"></button>
+    <div gg-autoclick gg-match="button[data-testid='Menu']"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walmart-logged-out.html
+++ b/getgather/mcp/patterns/walmart-logged-out.html
@@ -1,0 +1,9 @@
+<html gg-domain="walmart" gg-priority="1">
+  <head>
+    <title>Walmart Logged Out</title>
+  </head>
+  <body>
+    <div gg-match="[data-automation-id='headerSignIn']"></div>
+    <div gg-autoclick gg-match="[data-automation-id='headerSignIn']"></div>
+  </body>
+</html>


### PR DESCRIPTION
Fixes a Walmart sign-in reliability issue on Flyfleet where submitting the email form sometimes redirects to the homepage (`walmart.com/?userName=...`) instead of advancing to the next step. Without homepage patterns, the distillation engine had no way to recover from this redirect.

**What's added:**
- Desktop and mobile logged-out patterns that detect the logged-out homepage and click through to the sign-in page (two steps on mobile: open hamburger menu first, then click sign-in)
- A logged-in stop pattern that immediately terminates the loop when the user is already authenticated, preventing the engine from re-triggering sign-in on retry

## Homepage pattern detection demo

https://github.com/user-attachments/assets/fc4e7b29-7e74-41df-afff-0e2a0db36a82

