### PR TITLE
feat(walmart): signin error pattern

### DIFF
--- a/getgather/mcp/html_renderer.py
+++ b/getgather/mcp/html_renderer.py
@@ -95,18 +95,18 @@ def render_form(
         font-weight: 500;
         color: var(--gray-800);
       }}
-      
+
       .radio-wrapper {{
         display: flex;
         align-items: center;
         gap: 10px;
       }}
-      
+
       .vertical-radios {{
-        gap: 1rem; 
-        display: flex; 
-        flex-direction: column; 
-        margin-bottom: 1rem; 
+        gap: 1rem;
+        display: flex;
+        flex-direction: column;
+        margin-bottom: 1rem;
         margin-top: 1rem;
       }}
 
@@ -230,7 +230,7 @@ def render_form(
         flex-direction: column;
         gap: 1rem;
       }}
-      
+
     .content-wrapper
       :is(a, div, p, span, h1, h2, h3, h4, h5, h6):empty {{
       display: none;
@@ -246,7 +246,7 @@ def render_form(
           max-width: 100%;
         }}
       }}
-      
+
       /* Loading spinner styles */
       .spinner {{
         display: inline-block;
@@ -283,6 +283,20 @@ def render_form(
 
       form {{
         position: relative;
+      }}
+
+      .error-box {{
+        display: flex;
+        align-items: flex-start;
+        gap: 0.625rem;
+        padding: 0.875rem 1rem;
+        background: #fff5f5;
+        border: 1.5px solid #c0392b;
+        border-left-width: 4px;
+        border-radius: 8px;
+        color: #c0392b;
+        font-size: 0.9375rem;
+        line-height: 1.5;
       }}
     </style>
     <script>

--- a/getgather/mcp/patterns/walmart-signin-choose-method.html
+++ b/getgather/mcp/patterns/walmart-signin-choose-method.html
@@ -3,7 +3,7 @@
     <title gg-match="h1.f3">Walmart - Choose verification method</title>
   </head>
   <body>
-    <span gg-optional gg-match="div[data-testid='alert'] div"></span>
+    <span class="error-box" gg-optional gg-match="div[data-testid='alert'] div"></span>
     <div gg-match="[data-testid='auth-choice-title']"></div>
     <div class="vertical-radios">
       <div class="radio-wrapper">

--- a/getgather/mcp/patterns/walmart-signin-choose-method.html
+++ b/getgather/mcp/patterns/walmart-signin-choose-method.html
@@ -3,6 +3,7 @@
     <title gg-match="h1.f3">Walmart - Choose verification method</title>
   </head>
   <body>
+    <span gg-optional gg-match="div[data-testid='alert'] div"></span>
     <div gg-match="[data-testid='auth-choice-title']"></div>
     <div class="vertical-radios">
       <div class="radio-wrapper">

--- a/getgather/mcp/patterns/walmart-signin-email.html
+++ b/getgather/mcp/patterns/walmart-signin-email.html
@@ -3,6 +3,7 @@
     <title>Walmart Sign In - Email or Phone</title>
   </head>
   <body>
+    <span class="error-box" gg-optional gg-match="div[data-testid='dropdown'] section div span"></span>
     <input
       autofocus
       name="email"
@@ -10,7 +11,6 @@
       placeholder="Phone number or email (required)"
       gg-match="input[aria-label='Phone number or email (required)']"
     />
-    <span gg-optional gg-match="div[data-testid='dropdown'] section div span"></span>
     <button type="submit" gg-match="button#login-continue-button">Continue</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/walmart-signin-email.html
+++ b/getgather/mcp/patterns/walmart-signin-email.html
@@ -10,6 +10,7 @@
       placeholder="Phone number or email (required)"
       gg-match="input[aria-label='Phone number or email (required)']"
     />
+    <span gg-optional gg-match="div[data-testid='dropdown'] section div span"></span>
     <button type="submit" gg-match="button#login-continue-button">Continue</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/walmart-signin-email.html
+++ b/getgather/mcp/patterns/walmart-signin-email.html
@@ -3,7 +3,11 @@
     <title>Walmart Sign In - Email or Phone</title>
   </head>
   <body>
-    <span class="error-box" gg-optional gg-match="div[data-testid='dropdown'] section div span"></span>
+    <span
+      class="error-box"
+      gg-optional
+      gg-match="div[data-testid='dropdown'] section div span"
+    ></span>
     <input
       autofocus
       name="email"

--- a/getgather/mcp/patterns/walmart-signin-otp.html
+++ b/getgather/mcp/patterns/walmart-signin-otp.html
@@ -4,7 +4,7 @@
   </head>
   <body>
     <h1 gg-match="h1.f3">Enter verification code</h1>
-    <span gg-optional gg-match="div#alert div.ld_u div"></span>
+    <span class="error-box" gg-optional gg-match="div#alert div.ld_u div"></span>
     <p gg-optional gg-match="[data-testid='verifyotpform-description'] span[data-qm-mask='true']">
       Please enter the 6-digit verification code
     </p>

--- a/getgather/mcp/patterns/walmart-signin-otp.html
+++ b/getgather/mcp/patterns/walmart-signin-otp.html
@@ -4,6 +4,7 @@
   </head>
   <body>
     <h1 gg-match="h1.f3">Enter verification code</h1>
+    <span gg-optional gg-match="div#alert div.ld_u div"></span>
     <p gg-optional gg-match="[data-testid='verifyotpform-description'] span[data-qm-mask='true']">
       Please enter the 6-digit verification code
     </p>


### PR DESCRIPTION
Adds error message display to Walmart sign-in distillation patterns and styles them with a red box matching Walmart's native error style.

<table>
<tr>
<td>
<img width="2692" height="2040" alt="Firefox Developer Edition 2026-06-02 10 45 10" src="https://github.com/user-attachments/assets/83f145c1-b1d4-40a5-8886-d80858456682" />
</td>
<td>
<img width="2692" height="2040" alt="Firefox Developer Edition 2026-06-02 10 41 33" src="https://github.com/user-attachments/assets/70ddc2cb-c16a-44c7-ab84-b530ec115fdd" />
</td>
</tr>
<tr>
<td>
<img width="2692" height="2040" alt="Firefox Developer Edition 2026-06-02 10 46 14" src="https://github.com/user-attachments/assets/a51e7178-59fe-4038-98f9-c16c6254a534" />
</td>
<td>
<img width="2692" height="2040" alt="Firefox Developer Edition 2026-06-02 10 46 21" src="https://github.com/user-attachments/assets/01018745-0439-4c68-b40d-72bb31f05914" />
</td>
</tr>
<tr>
<td>
<img width="2692" height="2040" alt="Firefox Developer Edition 2026-06-02 10 47 23" src="https://github.com/user-attachments/assets/0404bfb9-ea47-4168-b414-e8901c376c1c" />
</td>
<td>
<img width="2692" height="2040" alt="Firefox Developer Edition 2026-06-02 10 47 13" src="https://github.com/user-attachments/assets/eb262bd8-709e-4459-b4b2-a0f2436fd8ef" />
</td>
</tr>
</table>
