### PR TITLE
fix: add delays between input focus, fill, and submit actions

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -27,7 +27,6 @@ from getgather.client_ip import client_ip_var
 from getgather.config import settings
 
 HTTP_METHOD = Literal["GET", "POST", "DELETE"]
-_INPUT_FOCUS_DELAY_MS = 250
 _ws_extra_headers_var: ContextVar[dict[str, str] | None] = ContextVar(
     "_ws_extra_headers_var", default=None
 )
@@ -624,8 +623,9 @@ class Element:
         logger.error("TODO: Element#check")
         await asyncio.sleep(0.25)
 
-    async def type_text(self, text: str) -> None:
-        await asyncio.sleep(_INPUT_FOCUS_DELAY_MS / 1000)
+    async def type_text(self, text: str, focus_delay_ms: int = 0) -> None:
+        if focus_delay_ms > 0:
+            await asyncio.sleep(focus_delay_ms / 1000)
         await self.element.clear_input_by_deleting()
         await asyncio.sleep(self.config.typing_clear_delay)
         await self.element.clear_input()
@@ -975,8 +975,9 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
         }}
 
         for (const [index, action] of actions.entries()) {{
-            if (index > 0) {{
-                await sleep(300);
+            const actionDelayMs = Number(action?.action_delay_ms) || 0;
+            if (index > 0 && actionDelayMs > 0) {{
+                await sleep(actionDelayMs);
             }}
             const key = action?.key;
             const kind = action?.kind;
@@ -1042,7 +1043,9 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
                     }};
 
                     element.focus();
-                    await sleep({_INPUT_FOCUS_DELAY_MS});
+                    if (actionDelayMs > 0) {{
+                        await sleep(actionDelayMs);
+                    }}
                     element.dispatchEvent(new KeyboardEvent("keydown", {{ key: "Tab", bubbles: true }}));
 
                     setNativeValue(element, "");

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -973,7 +973,10 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
             return null;
         }}
 
-        for (const action of actions) {{
+        for (const [index, action] of actions.entries()) {{
+            if (index > 0) {{
+                await sleep(300);
+            }}
             const key = action?.key;
             const kind = action?.kind;
             const selector = action?.selector;

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -507,6 +507,7 @@ class ElementConfig:
     typing_clear_delay: float = 0.1
     typing_char_delay_min: float = 0.01
     typing_char_delay_max: float = 0.05
+    action_delay_ms: float = 0
 
 
 class Element:
@@ -568,6 +569,8 @@ class Element:
             return False
 
     async def click(self) -> None:
+        if self.config.action_delay_ms > 0:
+            await asyncio.sleep(self.config.action_delay_ms / 1000)
         if self.css_selector:
             await self.css_click()
         else:
@@ -624,6 +627,8 @@ class Element:
         await asyncio.sleep(0.25)
 
     async def type_text(self, text: str) -> None:
+        if self.config.action_delay_ms > 0:
+            await asyncio.sleep(self.config.action_delay_ms / 1000)
         await self.element.clear_input_by_deleting()
         await asyncio.sleep(self.config.typing_clear_delay)
         await self.element.clear_input()

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -27,6 +27,7 @@ from getgather.client_ip import client_ip_var
 from getgather.config import settings
 
 HTTP_METHOD = Literal["GET", "POST", "DELETE"]
+_INPUT_FOCUS_DELAY_MS = 250
 _ws_extra_headers_var: ContextVar[dict[str, str] | None] = ContextVar(
     "_ws_extra_headers_var", default=None
 )
@@ -624,7 +625,7 @@ class Element:
         await asyncio.sleep(0.25)
 
     async def type_text(self, text: str) -> None:
-        await asyncio.sleep(0.25)
+        await asyncio.sleep(_INPUT_FOCUS_DELAY_MS / 1000)
         await self.element.clear_input_by_deleting()
         await asyncio.sleep(self.config.typing_clear_delay)
         await self.element.clear_input()
@@ -1041,7 +1042,7 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
                     }};
 
                     element.focus();
-                    await sleep(250);
+                    await sleep({_INPUT_FOCUS_DELAY_MS});
                     element.dispatchEvent(new KeyboardEvent("keydown", {{ key: "Tab", bubbles: true }}));
 
                     setNativeValue(element, "");

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -623,9 +623,7 @@ class Element:
         logger.error("TODO: Element#check")
         await asyncio.sleep(0.25)
 
-    async def type_text(self, text: str, focus_delay_ms: int = 0) -> None:
-        if focus_delay_ms > 0:
-            await asyncio.sleep(focus_delay_ms / 1000)
+    async def type_text(self, text: str) -> None:
         await self.element.clear_input_by_deleting()
         await asyncio.sleep(self.config.typing_clear_delay)
         await self.element.clear_input()

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -624,6 +624,7 @@ class Element:
         await asyncio.sleep(0.25)
 
     async def type_text(self, text: str) -> None:
+        await asyncio.sleep(0.25)
         await self.element.clear_input_by_deleting()
         await asyncio.sleep(self.config.typing_clear_delay)
         await self.element.clear_input()
@@ -1037,6 +1038,7 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
                     }};
 
                     element.focus();
+                    await sleep(250);
                     element.dispatchEvent(new KeyboardEvent("keydown", {{ key: "Tab", bubbles: true }}));
 
                     setNativeValue(element, "");

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -554,7 +554,7 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
             results = action_results if isinstance(action_results, dict) else {}
 
             # Fallback for failed/unexecuted actions to preserve behavior.
-            for action in pending_actions:
+            for i, action in enumerate(pending_actions):
                 key = action.get("key")
                 kind = action.get("kind")
                 selector = action.get("selector")
@@ -567,6 +567,8 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                 if results.get(key, False):
                     continue
 
+                if i > 0:
+                    await asyncio.sleep(0.3)
                 element = await page_query_selector(page, selector)
                 if not element:
                     continue

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -362,8 +362,8 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
         options = {"title": title, "action": action}
         inputs = document.find_all("input")
         pending_actions: list[dict[str, str]] = []
-        body = document.find("body")
-        action_delay_ms = int(str(body.get("gg-action-delay") or 0)) if isinstance(body, Tag) else 0
+        html_element = document.find("html")
+        action_delay_ms = int(str(html_element.get("gg-action-delay") or 0)) if isinstance(html_element, Tag) else 0
         element_config = ElementConfig(action_delay_ms=action_delay_ms) if action_delay_ms > 0 else None
 
         if match.distilled == current.distilled:

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -362,6 +362,8 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
         options = {"title": title, "action": action}
         inputs = document.find_all("input")
         pending_actions: list[dict[str, str]] = []
+        body = document.find("body")
+        action_delay_ms = str(body.get("gg-action-delay", "0")) if isinstance(body, Tag) else "0"
 
         if match.distilled == current.distilled:
             logger.info(f"Still the same: {match.name}")
@@ -516,6 +518,7 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                             "kind": "set_value",
                             "selector": str(selector),
                             "value": str(value),
+                            "action_delay_ms": action_delay_ms,
                         })
                         del fields[name_str]
                     else:
@@ -543,6 +546,7 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                             "key": f"click:submit:{len(pending_actions)}",
                             "kind": "click",
                             "selector": str(submit_selector),
+                            "action_delay_ms": action_delay_ms,
                         })
                 should_submit = True
             else:
@@ -567,8 +571,9 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                 if results.get(key, False):
                     continue
 
-                if i > 0:
-                    await asyncio.sleep(0.3)
+                delay_ms = int(action.get("action_delay_ms") or 0)
+                if i > 0 and delay_ms > 0:
+                    await asyncio.sleep(delay_ms / 1000)
                 element = await page_query_selector(page, selector)
                 if not element:
                     continue
@@ -576,7 +581,9 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                     await element.click()
                 elif kind == "set_value":
                     value = action.get("value")
-                    await element.type_text(value if isinstance(value, str) else "")
+                    await element.type_text(
+                        value if isinstance(value, str) else "", focus_delay_ms=delay_ms
+                    )
 
             await asyncio.sleep(0.25)
 

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -363,7 +363,8 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
         inputs = document.find_all("input")
         pending_actions: list[dict[str, str]] = []
         body = document.find("body")
-        action_delay_ms = str(body.get("gg-action-delay", "0")) if isinstance(body, Tag) else "0"
+        action_delay_ms = int(str(body.get("gg-action-delay") or 0)) if isinstance(body, Tag) else 0
+        element_config = ElementConfig(action_delay_ms=action_delay_ms) if action_delay_ms > 0 else None
 
         if match.distilled == current.distilled:
             logger.info(f"Still the same: {match.name}")
@@ -518,7 +519,7 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                             "kind": "set_value",
                             "selector": str(selector),
                             "value": str(value),
-                            "action_delay_ms": action_delay_ms,
+                            "action_delay_ms": str(action_delay_ms),
                         })
                         del fields[name_str]
                     else:
@@ -546,7 +547,7 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                             "key": f"click:submit:{len(pending_actions)}",
                             "kind": "click",
                             "selector": str(submit_selector),
-                            "action_delay_ms": action_delay_ms,
+                            "action_delay_ms": str(action_delay_ms),
                         })
                 should_submit = True
             else:
@@ -571,10 +572,8 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                 if results.get(key, False):
                     continue
 
-                delay_ms = int(action.get("action_delay_ms") or 0)
-                if i > 0 and delay_ms > 0:
-                    await asyncio.sleep(delay_ms / 1000)
-                element = await page_query_selector(page, selector)
+                config = element_config if i > 0 else None
+                element = await page_query_selector(page, selector, config=config)
                 if not element:
                     continue
                 if kind == "click":

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -363,8 +363,14 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
         inputs = document.find_all("input")
         pending_actions: list[dict[str, str]] = []
         html_element = document.find("html")
-        action_delay_ms = int(str(html_element.get("gg-action-delay") or 0)) if isinstance(html_element, Tag) else 0
-        element_config = ElementConfig(action_delay_ms=action_delay_ms) if action_delay_ms > 0 else None
+        action_delay_ms = (
+            int(str(html_element.get("gg-action-delay") or 0))
+            if isinstance(html_element, Tag)
+            else 0
+        )
+        element_config = (
+            ElementConfig(action_delay_ms=action_delay_ms) if action_delay_ms > 0 else None
+        )
 
         if match.distilled == current.distilled:
             logger.info(f"Still the same: {match.name}")

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -581,9 +581,7 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                     await element.click()
                 elif kind == "set_value":
                     value = action.get("value")
-                    await element.type_text(
-                        value if isinstance(value, str) else "", focus_delay_ms=delay_ms
-                    )
+                    await element.type_text(value if isinstance(value, str) else "")
 
             await asyncio.sleep(0.25)
 

--- a/getgather/mcp/patterns/walmart-logged-in.html
+++ b/getgather/mcp/patterns/walmart-logged-in.html
@@ -1,4 +1,4 @@
-<html gg-domain="walmart">
+<html gg-domain="walmart" gg-action-delay="200">
   <head>
     <title>Walmart Logged In Mobile</title>
   </head>

--- a/getgather/mcp/patterns/walmart-logged-out-menu.html
+++ b/getgather/mcp/patterns/walmart-logged-out-menu.html
@@ -1,4 +1,4 @@
-<html gg-domain="walmart">
+<html gg-domain="walmart" gg-action-delay="200">
   <head>
     <title>Walmart Logged Out Menu</title>
   </head>

--- a/getgather/mcp/patterns/walmart-logged-out-mobile-menu.html
+++ b/getgather/mcp/patterns/walmart-logged-out-mobile-menu.html
@@ -1,4 +1,4 @@
-<html gg-domain="walmart">
+<html gg-domain="walmart" gg-action-delay="200">
   <head>
     <title>Walmart Logged Out Mobile Menu</title>
   </head>

--- a/getgather/mcp/patterns/walmart-logged-out-mobile.html
+++ b/getgather/mcp/patterns/walmart-logged-out-mobile.html
@@ -1,4 +1,4 @@
-<html gg-domain="walmart" gg-priority="1">
+<html gg-domain="walmart" gg-priority="1" gg-action-delay="200">
   <head>
     <title>Walmart Logged Out Mobile</title>
   </head>

--- a/getgather/mcp/patterns/walmart-logged-out.html
+++ b/getgather/mcp/patterns/walmart-logged-out.html
@@ -1,4 +1,4 @@
-<html gg-domain="walmart" gg-priority="1">
+<html gg-domain="walmart" gg-priority="1" gg-action-delay="200">
   <head>
     <title>Walmart Logged Out</title>
   </head>

--- a/getgather/mcp/patterns/walmart-signin-email.html
+++ b/getgather/mcp/patterns/walmart-signin-email.html
@@ -2,7 +2,7 @@
   <head>
     <title>Walmart Sign In - Email or Phone</title>
   </head>
-  <body>
+  <body gg-action-delay="200">
     <span
       class="error-box"
       gg-optional

--- a/getgather/mcp/patterns/walmart-signin-email.html
+++ b/getgather/mcp/patterns/walmart-signin-email.html
@@ -1,8 +1,8 @@
-<html gg-domain="walmart">
+<html gg-domain="walmart" gg-action-delay="200">
   <head>
     <title>Walmart Sign In - Email or Phone</title>
   </head>
-  <body gg-action-delay="200">
+  <body>
     <span
       class="error-box"
       gg-optional


### PR DESCRIPTION
During Walmart signin, the submit button was firing before the email field was fully filled, a potential race condition that caused the demo app to ask email again in the followup form.

- Add gg-action-delay attribute on pattern <body> to opt into delays per brand
- When set, delays are applied between each batch action (fill, submit click) and after focusing an input before typing starts
- Walmart signin email pattern opts in with gg-action-delay="200"
- All other brands are unaffected (no attribute = no delay)