### PR TITLE
fix(walmart): improve OTP fill reliability with per-digit inputs

### DIFF
--- a/getgather/mcp/patterns/walmart-signin-otp.html
+++ b/getgather/mcp/patterns/walmart-signin-otp.html
@@ -8,13 +8,159 @@
     <p gg-optional gg-match="[data-testid='verifyotpform-description'] span[data-qm-mask='true']">
       Please enter the 6-digit verification code
     </p>
-    <input
-      autofocus
-      name="otp"
-      type="text"
-      placeholder="6-digit verification code"
-      gg-match="input#input-verificationCode"
-    />
+    <div
+      id="otp-box"
+      style="
+        display: grid;
+        grid-template-columns: repeat(6, minmax(0, 1fr));
+        gap: 10px;
+        width: 100%;
+      "
+    >
+      <input
+        autofocus
+        name="otp-0"
+        type="text"
+        inputmode="numeric"
+        pattern="[0-9]*"
+        maxlength="1"
+        style="
+          width: 100%;
+          box-sizing: border-box;
+          text-align: center;
+          height: 52px;
+          font-size: 1.5rem;
+          font-weight: bold;
+        "
+        gg-match="input#input-verificationCode"
+      />
+      <input
+        name="otp-1"
+        type="text"
+        inputmode="numeric"
+        pattern="[0-9]*"
+        maxlength="1"
+        style="
+          width: 100%;
+          box-sizing: border-box;
+          text-align: center;
+          height: 52px;
+          font-size: 1.5rem;
+          font-weight: bold;
+        "
+        gg-match="input#input-verificationCode-1"
+      />
+      <input
+        name="otp-2"
+        type="text"
+        inputmode="numeric"
+        pattern="[0-9]*"
+        maxlength="1"
+        style="
+          width: 100%;
+          box-sizing: border-box;
+          text-align: center;
+          height: 52px;
+          font-size: 1.5rem;
+          font-weight: bold;
+        "
+        gg-match="input#input-verificationCode-2"
+      />
+      <input
+        name="otp-3"
+        type="text"
+        inputmode="numeric"
+        pattern="[0-9]*"
+        maxlength="1"
+        style="
+          width: 100%;
+          box-sizing: border-box;
+          text-align: center;
+          height: 52px;
+          font-size: 1.5rem;
+          font-weight: bold;
+        "
+        gg-match="input#input-verificationCode-3"
+      />
+      <input
+        name="otp-4"
+        type="text"
+        inputmode="numeric"
+        pattern="[0-9]*"
+        maxlength="1"
+        style="
+          width: 100%;
+          box-sizing: border-box;
+          text-align: center;
+          height: 52px;
+          font-size: 1.5rem;
+          font-weight: bold;
+        "
+        gg-match="input#input-verificationCode-4"
+      />
+      <input
+        name="otp-5"
+        type="text"
+        inputmode="numeric"
+        pattern="[0-9]*"
+        maxlength="1"
+        style="
+          width: 100%;
+          box-sizing: border-box;
+          text-align: center;
+          height: 52px;
+          font-size: 1.5rem;
+          font-weight: bold;
+        "
+        gg-match="input#input-verificationCode-5"
+      />
+    </div>
+    <script>
+      const box = document.getElementById("otp-box");
+      const inputs = [...box.querySelectorAll("input")];
+
+      box.addEventListener("focusin", (e) => {
+        if (e.target.tagName !== "INPUT") return;
+        setTimeout(() => e.target.select(), 0);
+      });
+
+      box.addEventListener("paste", (e) => {
+        e.preventDefault();
+        const digits = (e.clipboardData.getData("text") || "").replace(/\D/g, "").slice(0, 6);
+        digits.split("").forEach((d, i) => {
+          if (inputs[i]) inputs[i].value = d;
+        });
+        const next = inputs[Math.min(digits.length, inputs.length - 1)];
+        if (next) next.focus();
+      });
+
+      box.addEventListener("keydown", (e) => {
+        const i = inputs.indexOf(e.target);
+        if (i < 0) return;
+        if (e.key === "ArrowLeft" && inputs[i - 1]) {
+          e.preventDefault();
+          inputs[i - 1].focus();
+        } else if (e.key === "ArrowRight" && inputs[i + 1]) {
+          e.preventDefault();
+          inputs[i + 1].focus();
+        } else if (e.key === "Backspace") {
+          if (e.target.value) {
+            e.target.value = "";
+          } else if (inputs[i - 1]) {
+            inputs[i - 1].value = "";
+            inputs[i - 1].focus();
+          }
+          e.preventDefault();
+        }
+      });
+
+      box.addEventListener("input", (e) => {
+        const i = inputs.indexOf(e.target);
+        if (i < 0) return;
+        e.target.value = e.target.value.replace(/\D/g, "").slice(-1);
+        if (e.target.value && inputs[i + 1]) inputs[i + 1].focus();
+      });
+    </script>
     <button type="submit" gg-match="button[type='submit'][form$='-otp-form']">Sign in</button>
   </body>
 </html>


### PR DESCRIPTION
Instead of typing a full 6-digit code into the first input and relying on Walmart's auto-distribute JS, each digit is now filled explicitly into its own `input#input-verificationCode-N` selector. This removes the timing dependency on Walmart's client-side focus-advance logic.

The dpage UI mirrors the real Walmart OTP experience with focus-advance, backspace-to-previous, arrow key navigation, and paste support.