### PR TITLE
feat(walmart): add signup page error pattern

### DIFF
--- a/getgather/mcp/patterns/walmart-signup.html
+++ b/getgather/mcp/patterns/walmart-signup.html
@@ -5,7 +5,8 @@
       gg-error="email_not_found"
       gg-match="//h1[contains(normalize-space(.), 'Create your Walmart account')]"
     >
-      This email isn't registered with Walmart. Please create an account at walmart.com first, then try again.
+      This email isn't registered with Walmart. Please create an account at walmart.com first, then
+      try again.
     </h1>
   </body>
 </html>

--- a/getgather/mcp/patterns/walmart-signup.html
+++ b/getgather/mcp/patterns/walmart-signup.html
@@ -1,0 +1,11 @@
+<html gg-domain="walmart">
+  <body>
+    <h1
+      gg-stop
+      gg-error="email_not_found"
+      gg-match="//h1[contains(normalize-space(.), 'Create your Walmart account')]"
+    >
+      This email isn't registered with Walmart. Please create an account at walmart.com first, then try again.
+    </h1>
+  </body>
+</html>


### PR DESCRIPTION
When a user's email isn't registered on Walmart, the sign-in flow redirects to an account creation page. This adds a distillation pattern that detects that page and stops the flow with an `email_not_found` error, so the tool caller gets a clear error instead of a timeout.

<img width="2692" height="2040" alt="image" src="https://github.com/user-attachments/assets/4e072d7d-b1d2-456e-b312-6f7ecf99dc93" />
