### PR TITLE
fix: remove browser profile dirs on terminate and sweep orphaned profiles

### DIFF
--- a/getgather/main.py
+++ b/getgather/main.py
@@ -51,6 +51,11 @@ async def lifespan(app: FastAPI):
             except Exception as e:
                 logger.error(f"Error in cleanup_incognito_browsers: {e}", exc_info=True)
             try:
+                # Run in a thread: rmtree of large profile dirs can block for seconds
+                await asyncio.to_thread(browser_manager.cleanup_orphaned_profiles)
+            except Exception as e:
+                logger.error(f"Error in cleanup_orphaned_profiles: {e}", exc_info=True)
+            try:
                 await asyncio.wait_for(stop_event.wait(), timeout=5 * 60)
             except asyncio.TimeoutError:
                 pass  # Timeout = 5 minutes passed, continue loop

--- a/getgather/mcp/browser.py
+++ b/getgather/mcp/browser.py
@@ -1,12 +1,23 @@
+import shutil
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import TypedDict, cast
 
 import zendriver as zd
 from loguru import logger
 from websockets.exceptions import ConnectionClosed
-from zendriver.core.browser import shutil
 
 from getgather.config import settings
+
+
+def remove_profile_dir(user_data_dir: Path) -> None:
+    """Remove a browser profile directory from disk."""
+    if not user_data_dir.exists():
+        return
+    try:
+        shutil.rmtree(user_data_dir)
+    except Exception as e:
+        logger.warning(f"Failed to remove profile dir {user_data_dir}: {e}")
 
 
 async def terminate_zendriver_browser(browser: zd.Browser):
@@ -20,28 +31,13 @@ async def terminate_zendriver_browser(browser: zd.Browser):
         )
     user_data_dir = settings.profiles_dir / browser_id
     logger.info(
-        f"Terminating Zendriver browser with user_data_dir: {user_data_dir}",
+        f"Terminating Zendriver browser and removing user_data_dir: {user_data_dir}",
         extra={"profile_id": browser_id},
     )
-    for directory in [
-        "Default/DawnGraphiteCache",
-        "Default/DawnWebGPUCache",
-        "Default/GPUCache",
-        "Default/Code Cache",
-        "Default/Cache",
-        "GraphiteDawnCache",
-        "GrShaderCache",
-        "ShaderCache",
-        "Subresource Filter",
-        "segmentation_platform",
-    ]:
-        path = user_data_dir / directory
-
-        if path.exists():
-            try:
-                shutil.rmtree(path)
-            except Exception as e:
-                logger.warning(f"Failed to remove {directory}: {e}")
+    # Profiles are never reopened after their browser is terminated
+    # (init_zendriver_browser only looks up in-memory browsers), so remove
+    # the whole profile dir instead of letting it accumulate on disk.
+    remove_profile_dir(user_data_dir)
 
 
 class BrowserInformation(TypedDict):
@@ -125,6 +121,47 @@ class BrowserManager:
                     logger.error(f"Failed to stop browser with signin ID {signin_id}: {e}")
                 finally:
                     self.remove_incognito_browser(signin_id)
+
+    def cleanup_orphaned_profiles(self):
+        """Remove on-disk profile dirs that no longer belong to an active browser.
+
+        Browser tracking is in-memory only, so profile dirs left behind by
+        crashes, restarts or failed browser starts are never seen by
+        cleanup_incognito_browsers and accumulate until the disk is full.
+        Sweep the profiles dir and remove anything that is not an active
+        browser and has not been modified within BROWSER_SESSION_AGE.
+        """
+        current_time = datetime.now()
+        max_session_age = timedelta(minutes=settings.BROWSER_SESSION_AGE)
+
+        active_ids = set(self._incognito_browsers.keys())
+        if self._zen_global_browser is not None:
+            global_browser_id = getattr(self._zen_global_browser, "id", None)
+            if global_browser_id is not None:
+                active_ids.add(cast(str, global_browser_id))
+
+        removed_count = 0
+        for profile_dir in settings.profiles_dir.iterdir():
+            if not profile_dir.is_dir() or profile_dir.name in active_ids:
+                continue
+            try:
+                last_modified = datetime.fromtimestamp(profile_dir.stat().st_mtime)
+            except OSError as e:
+                logger.warning(f"Failed to stat profile dir {profile_dir}: {e}")
+                continue
+            # Keep recently-modified dirs: they may belong to a browser that
+            # is still starting up and not yet registered in the manager.
+            if current_time - last_modified <= max_session_age:
+                continue
+            logger.info(
+                f"Removing orphaned profile dir {profile_dir}",
+                extra={"profile_id": profile_dir.name},
+            )
+            remove_profile_dir(profile_dir)
+            removed_count += 1
+
+        if removed_count:
+            logger.info(f"Removed {removed_count} orphaned browser profile dirs")
 
 
 browser_manager = BrowserManager()

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -31,7 +31,11 @@ from getgather.browser.resource_blocker import (
 )
 from getgather.config import FRIENDLY_CHARS, settings
 from getgather.container_utils import check_x_server_available
-from getgather.mcp.browser import browser_manager
+from getgather.mcp.browser import (
+    browser_manager,
+    remove_profile_dir,
+    terminate_zendriver_browser,
+)
 from getgather.request_info import request_info
 
 
@@ -443,6 +447,8 @@ async def _create_zendriver_browser(id: str | None = None) -> zd.Browser:
         MAX_START_ATTEMPTS,
         extra={"profile_id": id},
     )
+    # Don't leave a partially-initialized profile dir behind
+    remove_profile_dir(user_data_dir)
     raise last_error or RuntimeError("Failed to start browser")
 
 
@@ -473,11 +479,12 @@ async def init_zendriver_browser(id: str | None = None) -> zd.Browser:
             return browser
         except Exception as e:
             logger.warning(f"Browser validation failed on attempt {attempt}: {e}")
-            if attempt < MAX_ATTEMPTS:
-                try:
-                    await browser.stop()
-                except Exception:
-                    pass
+            # Terminate (instead of just stop) so the profile dir is removed:
+            # each retry creates a fresh profile, this one is never reused.
+            try:
+                await terminate_zendriver_browser(browser)
+            except Exception:
+                pass
 
     logger.error(f"Failed to get a working browser after {MAX_ATTEMPTS} attempts!")
     raise RuntimeError(f"Failed to get a working Zendriver browser after {MAX_ATTEMPTS} attempts!")

--- a/tests/mcp/test_browser_cleanup.py
+++ b/tests/mcp/test_browser_cleanup.py
@@ -1,0 +1,133 @@
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import cast
+
+import pytest
+import zendriver as zd
+from pytest import MonkeyPatch
+from websockets.exceptions import ConnectionClosed
+
+from getgather.config import settings
+from getgather.mcp.browser import (
+    BrowserManager,
+    remove_profile_dir,
+    terminate_zendriver_browser,
+)
+
+
+class StubBrowser:
+    """Minimal stand-in for zd.Browser: terminate only uses .id and .stop()."""
+
+    def __init__(self, id: str, stop_error: Exception | None = None):
+        self.id = id
+        self.stopped = False
+        self._stop_error = stop_error
+
+    async def stop(self):
+        self.stopped = True
+        if self._stop_error is not None:
+            raise self._stop_error
+
+
+@pytest.fixture
+def profiles_dir(tmp_path: Path, monkeypatch: MonkeyPatch) -> Path:
+    monkeypatch.setattr(settings, "DATA_DIR", str(tmp_path))
+    return settings.profiles_dir
+
+
+def make_profile(profiles_dir: Path, profile_id: str, age: timedelta | None = None) -> Path:
+    profile = profiles_dir / profile_id
+    (profile / "Default").mkdir(parents=True)
+    (profile / "Default" / "Cookies").write_text("cookies")
+    if age is not None:
+        mtime = (datetime.now() - age).timestamp()
+        os.utime(profile, (mtime, mtime))
+    return profile
+
+
+class TestRemoveProfileDir:
+    def test_removes_directory(self, profiles_dir: Path):
+        profile = make_profile(profiles_dir, "abc123")
+        remove_profile_dir(profile)
+        assert not profile.exists()
+
+    def test_missing_directory_is_noop(self, profiles_dir: Path):
+        remove_profile_dir(profiles_dir / "missing")
+
+
+class TestTerminateZendriverBrowser:
+    @pytest.mark.asyncio
+    async def test_stops_browser_and_removes_profile_dir(self, profiles_dir: Path):
+        profile = make_profile(profiles_dir, "abc123")
+        browser = StubBrowser("abc123")
+
+        await terminate_zendriver_browser(cast(zd.Browser, browser))
+
+        assert browser.stopped
+        assert not profile.exists()
+
+    @pytest.mark.asyncio
+    async def test_removes_profile_dir_when_websocket_already_closed(self, profiles_dir: Path):
+        profile = make_profile(profiles_dir, "abc123")
+        browser = StubBrowser("abc123", stop_error=ConnectionClosed(None, None))
+
+        await terminate_zendriver_browser(cast(zd.Browser, browser))
+
+        assert not profile.exists()
+
+
+class TestCleanupOrphanedProfiles:
+    def test_removes_stale_orphaned_profiles(self, profiles_dir: Path):
+        stale = make_profile(profiles_dir, "stale1", age=timedelta(hours=2))
+
+        BrowserManager().cleanup_orphaned_profiles()
+
+        assert not stale.exists()
+
+    def test_keeps_recently_modified_profiles(self, profiles_dir: Path):
+        recent = make_profile(profiles_dir, "recent", age=timedelta(minutes=1))
+
+        BrowserManager().cleanup_orphaned_profiles()
+
+        assert recent.exists()
+
+    def test_keeps_profiles_of_active_browsers(self, profiles_dir: Path):
+        active = make_profile(profiles_dir, "active", age=timedelta(hours=2))
+        manager = BrowserManager()
+        manager.set_incognito_browser("active", cast(zd.Browser, StubBrowser("active")))
+
+        manager.cleanup_orphaned_profiles()
+
+        assert active.exists()
+
+    def test_keeps_profile_of_global_browser(self, profiles_dir: Path):
+        global_profile = make_profile(profiles_dir, "global", age=timedelta(hours=2))
+        manager = BrowserManager()
+        manager.set_global_browser(cast(zd.Browser, StubBrowser("global")))
+
+        manager.cleanup_orphaned_profiles()
+
+        assert global_profile.exists()
+
+    def test_ignores_stray_files(self, profiles_dir: Path):
+        stray = profiles_dir / "stray.txt"
+        stray.write_text("not a profile")
+        mtime = (datetime.now() - timedelta(hours=2)).timestamp()
+        os.utime(stray, (mtime, mtime))
+
+        BrowserManager().cleanup_orphaned_profiles()
+
+        assert stray.exists()
+
+    def test_respects_browser_session_age_setting(
+        self, profiles_dir: Path, monkeypatch: MonkeyPatch
+    ):
+        monkeypatch.setattr(settings, "BROWSER_SESSION_AGE", 5)
+        stale = make_profile(profiles_dir, "stale1", age=timedelta(minutes=10))
+        fresh = make_profile(profiles_dir, "fresh1", age=timedelta(minutes=2))
+
+        BrowserManager().cleanup_orphaned_profiles()
+
+        assert not stale.exists()
+        assert fresh.exists()


### PR DESCRIPTION
## Problem

Since ~01:00 UTC on Jun 3, tap-amazon production logged **477 \"Failed to start browser after 3 attempts\"** errors (~470 distinct browsers in 3 hours). Root cause: the machine disk filled up with browser profile dirs under `/app/data/profiles`, so Chrome could no longer start.

Profile dirs were never deleted:

- `terminate_zendriver_browser` only pruned cache subdirs (GPUCache, Code Cache, etc.) — the profile itself (Cookies, Local Storage, IndexedDB, …) stayed on disk forever.
- Browser tracking is in-memory only, so profiles orphaned by crashes/restarts/failed starts were never seen by the cleanup loop.
- Failed `zd.start` attempts and failed browser validations also leaked partial profile dirs.

Profiles are never reopened after termination (`init_zendriver_browser` only looks up in-memory browsers), so all of this was dead weight.

## Changes

- **`terminate_zendriver_browser`** now removes the whole profile dir instead of just cache subdirs.
- **`BrowserManager.cleanup_orphaned_profiles()`** (new): sweeps `profiles_dir` and removes dirs that aren't an active browser and haven't been modified within `BROWSER_SESSION_AGE`. Wired into the existing 5-minute timer in `main.py` via `asyncio.to_thread`.
- **`_create_zendriver_browser`**: removes the partially-initialized profile dir when all start attempts fail.
- **`init_zendriver_browser`**: validation failures now use `terminate_zendriver_browser` (instead of bare `browser.stop()`) so throwaway retry profiles are deleted — including on the final attempt, which previously leaked a running browser.

## Tests

- 10 new tests in `tests/mcp/test_browser_cleanup.py` (full-dir removal, `ConnectionClosed` handling, stale orphan removal, active/global browser protection, recent-dir grace period, stray files, `BROWSER_SESSION_AGE` setting).
- pyright + ruff clean.

## Note for ops

This only stops future growth — currently-full machines still need `/app/data/profiles` cleared (fly ssh or machine restart) to recover.