### PR TITLE
feat(walmart): include canonicalUrl in order history items

### DIFF
--- a/getgather/mcp/walmart.py
+++ b/getgather/mcp/walmart.py
@@ -122,7 +122,8 @@ function collectItems(priceByItemId, items) {
         priceByItemId[id] = {
             linePrice: pi.linePrice ?? null,
             itemPrice: pi.itemPrice ?? null,
-            unitPrice: pi.unitPrice ?? null
+            unitPrice: pi.unitPrice ?? null,
+            canonicalUrl: item?.productInfo?.canonicalUrl ?? null
         };
     }
 }
@@ -288,7 +289,17 @@ def _merge_price_info(
         for group in order.get("groups", []):
             for item in group.get("items", []):
                 item_id = item.get("id")
-                item["priceInfo"] = item_prices.get(item_id) if (item_prices and item_id) else None
+                detail = item_prices.get(item_id) if (item_prices and item_id) else None
+                if detail:
+                    item["priceInfo"] = {
+                        "linePrice": detail.get("linePrice"),
+                        "itemPrice": detail.get("itemPrice"),
+                        "unitPrice": detail.get("unitPrice"),
+                    }
+                    item["canonicalUrl"] = detail.get("canonicalUrl")
+                else:
+                    item["priceInfo"] = None
+                    item["canonicalUrl"] = None
 
 
 @walmart_mcp.tool


### PR DESCRIPTION
Order history items didn't include a product URL, requiring a separate lookup to link to the item page. `canonicalUrl` is already fetched as part of the detail enrichment pass, so this change extracts it from `productInfo` and attaches it to each item alongside `priceInfo` at no extra cost.

Example of `canonicalUrl` value:
- /ip/Fresh-Red-Cherries-2-25-lb-Bag/46491694
- /ip/Lay-s-Wavy-Potato-Chips-Original-Flavor-7-75-oz-Bag/476979874