### PR TITLE
feat(walmart): support "Text me" button variant in choose-method pattern

### DIFF
--- a/getgather/mcp/patterns/walmart-signin-choose-method.html
+++ b/getgather/mcp/patterns/walmart-signin-choose-method.html
@@ -61,7 +61,7 @@
       id="wm-submit"
       type="submit"
       disabled
-      gg-match="//button[(contains(text(), 'Sign in') or contains(text(), 'Request code') or contains(text(), 'Send code') or contains(text(), 'Continue')) and not(@disabled)]"
+      gg-match="//button[(contains(text(), 'Sign in') or contains(text(), 'Request code') or contains(text(), 'Send code') or contains(text(), 'Continue') or contains(text(), 'Text me')) and not(@disabled)]"
     >
       Choose a method above
     </button>


### PR DESCRIPTION
Adds "Text me" to the submit button XPath in the choose-method pattern to cover a Walmart sign-in variant that uses that label instead of "Sign in" / "Request code" / "Continue".

<img width="2692" height="2040" alt="Firefox Developer Edition 2026-06-05 16 07 56" src="https://github.com/user-attachments/assets/304675c1-38a8-4692-95c1-3737b78db72a" />
