### PR TITLE
feat(walmart): add passkey skip pattern

### DIFF
--- a/getgather/mcp/patterns/walmart-passkey-skip.html
+++ b/getgather/mcp/patterns/walmart-passkey-skip.html
@@ -1,0 +1,8 @@
+<html gg-domain="walmart">
+  <head>
+    <title gg-match="h1">Passkeys</title>
+  </head>
+  <body>
+    <a gg-autoclick gg-match="a[link-identifier='Generic Name'][href*='verifyToken']">Skip for now</a>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walmart-passkey-skip.html
+++ b/getgather/mcp/patterns/walmart-passkey-skip.html
@@ -3,6 +3,8 @@
     <title gg-match="h1">Passkeys</title>
   </head>
   <body>
-    <a gg-autoclick gg-match="a[link-identifier='Generic Name'][href*='verifyToken']">Skip for now</a>
+    <a gg-autoclick gg-match="a[link-identifier='Generic Name'][href*='verifyToken']"
+      >Skip for now</a
+    >
   </body>
 </html>


### PR DESCRIPTION
Walmart shows a passkey promotion page mid sign-in with no matching pattern, leaving the distillation loop stuck. Auto-clicks "Skip for now" to unblock the flow.

<img width="2692" height="2040" alt="Firefox Developer Edition 2026-06-05 16 34 39" src="https://github.com/user-attachments/assets/a6992018-03ea-4ed1-88b7-30b9bbbae498" />
