### PR TITLE
Add an experimental page distillation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,28 @@ _Example_: `curl localhost:8300/api/v1/browsers` returns:
 ["xyz123", "abc234"]
 ```
 
+### List pages of a browser
+
+`GET /api/v1/browsers/{browser_id}/pages` returns a JSON array of page identifiers (CDP target IDs) for all open pages in the specified browser. Returns HTTP 404 if the browser is not found.
+
+_Example_: `curl localhost:23456/api/v1/browsers/test/pages` returns:
+
+```json
+["96FDE4162B8EEEBF98E26756D21CF0C5"]
+```
+
+### Get page HTML
+
+`GET /api/v1/browsers/{browser_id}/pages/{page_id}/html` returns the raw HTML of the specified page. Returns HTTP 404 if the browser or page is not found.
+
+_Example_: `curl localhost:23456/api/v1/browsers/test/pages/96FDE4162B8EEEBF98E26756D21CF0C5/html`
+
+### Get distilled page JSON
+
+`GET /api/v1/browsers/{browser_id}/pages/{page_id}/distilled` returns the distilled JSON representation of the specified page, produced by matching the page against distillation patterns. Returns HTTP 404 if the browser or page is not found.
+
+_Example_: `curl localhost:23456/api/v1/browsers/test/pages/96FDE4162B8EEEBF98E26756D21CF0C5/distilled`
+
 ## Development
 
 To run the development version, clone this repository and run:

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -249,6 +249,11 @@ def _setup_cdp_url(browser_id: str) -> str:
     return f"{cdp_base}/cdp/{browser_id}"
 
 
+async def get_remote_browser_cdp_url(browser_id: str) -> str:
+    await _call_chromefleet_api("GET", browser_id, timeout=2.0, retries=0)
+    return _setup_cdp_url(browser_id)
+
+
 async def get_remote_browser(browser_id: str) -> zd.Browser | None:
     logger.debug(f"Finding the ChromeFleet browser: {browser_id}")
     try:

--- a/getgather/browsers_api_router.py
+++ b/getgather/browsers_api_router.py
@@ -3,6 +3,7 @@ import json
 import os
 import subprocess
 import sys
+import urllib.parse
 from typing import Any
 
 import httpx
@@ -14,8 +15,10 @@ from loguru import logger
 from starlette.requests import HTTPConnection
 from websockets.exceptions import ConnectionClosed
 
+from getgather.cdp_client import PageNotFoundError, open_cdp
 from getgather.config import settings
 from getgather.residential_proxy import MassiveLocation, MassiveProxy
+from getgather.zen_distill import convert, distill, load_distillation_patterns
 
 router = APIRouter()
 
@@ -374,6 +377,16 @@ async def find_browser_id(page_id: str) -> str | None:
     return None
 
 
+def strip_browser_id_from_target_id(target_id: str) -> str:
+    if "@" not in target_id:
+        return target_id
+    return target_id.split("@", 1)[1]
+
+
+def prepend_browser_id_to_target_id(target_id: str, browser_id: str) -> str:
+    return browser_id + "@" + target_id
+
+
 CDP_TARGET_METHODS_STRIP_ID = (
     "Target.attachToTarget",
     "Target.closeTarget",
@@ -396,19 +409,23 @@ def patch_cdp_target(message: str, browser_id: str) -> str:
             if isinstance(params, dict):
                 target_info: Any = params.get("targetInfo")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
                 if isinstance(target_info, dict) and "targetId" in target_info:
-                    target_info["targetId"] = browser_id + "@" + str(target_info["targetId"])  # pyright: ignore[reportUnknownArgumentType]
+                    target_info["targetId"] = prepend_browser_id_to_target_id(
+                        str(target_info["targetId"]),  # pyright: ignore[reportUnknownArgumentType]
+                        browser_id,
+                    )
                     return json.dumps(data)
         elif data.get("method") in CDP_TARGET_METHODS_STRIP_ID:  # pyright: ignore[reportUnknownMemberType]
             params = data.get("params")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
             if isinstance(params, dict) and "targetId" in params:
-                target_id = str(params["targetId"])  # pyright: ignore[reportUnknownArgumentType]
-                if "@" in target_id:
-                    params["targetId"] = target_id.split("@", 1)[1]
-                    return json.dumps(data)
+                params["targetId"] = strip_browser_id_from_target_id(str(params["targetId"]))  # pyright: ignore[reportUnknownArgumentType]
+                return json.dumps(data)
         elif "result" in data:
             result: Any = data.get("result")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
             if isinstance(result, dict) and "targetId" in result:
-                result["targetId"] = browser_id + "@" + str(result["targetId"])  # pyright: ignore[reportUnknownArgumentType]
+                result["targetId"] = prepend_browser_id_to_target_id(
+                    str(result["targetId"]),  # pyright: ignore[reportUnknownArgumentType]
+                    browser_id,
+                )
                 return json.dumps(data)
 
     return message
@@ -539,6 +556,100 @@ async def list_browsers() -> JSONResponse:
         detail = "Unable to list all browsers"
         logger.error(f"{detail} Exception={e}")
         raise HTTPException(status_code=500, detail=detail)
+
+
+@router.get("/api/v1/browsers/{browser_id}/pages")
+async def list_pages(browser_id: str) -> JSONResponse:
+    try:
+        client = await open_cdp(browser_id)
+    except Exception:
+        raise HTTPException(status_code=404, detail=f"Browser {browser_id} not found!")
+
+    try:
+        result = await client.send("Target.getTargets")
+    except Exception as e:
+        logger.error(f"Error listing pages via CDP for {browser_id}: {e}")
+        raise HTTPException(status_code=502, detail=f"Failed to list pages: {e}")
+    finally:
+        await client.aclose()
+
+    target_infos: list[dict[str, Any]] = result.get("targetInfos", [])  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+    page_ids = [str(info["targetId"]) for info in target_infos if info.get("type") == "page"]
+    return JSONResponse(page_ids)
+
+
+@router.get("/api/v1/browsers/{browser_id}/pages/{page_id}/html")
+async def get_page_html(browser_id: str, page_id: str) -> HTMLResponse:
+    page_id = strip_browser_id_from_target_id(page_id)
+    try:
+        client = await open_cdp(browser_id)
+    except Exception:
+        raise HTTPException(status_code=404, detail=f"Browser {browser_id} not found!")
+
+    try:
+        try:
+            page = await client.attach_to_page(page_id)
+        except PageNotFoundError:
+            raise HTTPException(status_code=404, detail=f"Page {page_id} not found in browser")
+        except Exception as e:
+            logger.error(f"Failed to attach to {browser_id}/{page_id}: {e}")
+            raise HTTPException(status_code=502, detail=f"Failed to get page HTML: {e}")
+
+        try:
+            html = await page.evaluate("document.documentElement.outerHTML")
+        except Exception as e:
+            logger.error(f"Error fetching page HTML for {browser_id}/{page_id}: {e}")
+            raise HTTPException(status_code=502, detail=f"Failed to get page HTML: {e}")
+
+        if not isinstance(html, str):
+            html = str(html) if html is not None else ""
+        return HTMLResponse(content=html)
+    finally:
+        await client.aclose()
+
+
+@router.get("/api/v1/browsers/{browser_id}/pages/{page_id}/distilled")
+async def get_page_distilled(browser_id: str, page_id: str) -> JSONResponse:
+    page_id = strip_browser_id_from_target_id(page_id)
+    try:
+        client = await open_cdp(browser_id)
+    except Exception:
+        raise HTTPException(status_code=404, detail=f"Browser {browser_id} not found!")
+
+    try:
+        try:
+            page = await client.attach_to_page(page_id)
+        except PageNotFoundError:
+            raise HTTPException(status_code=404, detail=f"Page {page_id} not found in browser")
+        except Exception as e:
+            logger.error(f"Failed to attach to {browser_id}/{page_id}: {e}")
+            raise HTTPException(status_code=502, detail=f"Failed to distill page: {e}")
+
+        try:
+            current_url = str(await page.evaluate("window.location.href", await_promise=True))
+            hostname = urllib.parse.urlparse(current_url).hostname or ""
+
+            path = os.path.join(os.path.dirname(__file__), "mcp", "patterns", "*.html")
+            patterns = load_distillation_patterns(path)
+            if not patterns:
+                raise HTTPException(status_code=502, detail="No patterns found for '*.html'")
+
+            match = await distill(hostname, page, patterns)  # type: ignore[arg-type]
+            if not match:
+                raise HTTPException(status_code=502, detail="No matching pattern found for page")
+
+            converted = await convert(match.distilled, pattern_path=match.name)
+            if converted:
+                return JSONResponse(converted)
+
+            return JSONResponse({"distilled": match.distilled})
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Error distilling page for {browser_id}/{page_id}: {e}")
+            raise HTTPException(status_code=502, detail=f"Failed to distill page: {e}")
+    finally:
+        await client.aclose()
 
 
 @router.websocket("/cdp/{browser_id}")

--- a/getgather/cdp_client.py
+++ b/getgather/cdp_client.py
@@ -1,0 +1,171 @@
+import asyncio
+import json
+from typing import Any, cast
+
+import websockets
+
+from getgather.browser import get_remote_browser_cdp_url
+from getgather.config import settings
+
+
+class CDPError(Exception):
+    """Base class for CDP client errors that callers (e.g. HTTP routers) may
+    translate into protocol-specific responses."""
+
+
+class PageNotFoundError(CDPError):
+    """Raised when a requested page target does not exist in the browser."""
+
+
+class PageAttachError(CDPError):
+    """Raised when attaching to a page target fails."""
+
+
+async def open_cdp(browser_id: str) -> "CDPClient":
+    """Locate the browser and return a connected CDP client. Raises if the
+    browser is not found or the websocket cannot be opened."""
+    cdp_websocket_url = await get_remote_browser_cdp_url(browser_id)
+    ws = await websockets.connect(
+        cdp_websocket_url,
+        open_timeout=settings.CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS,
+    )
+    return CDPClient(ws)
+
+
+class CDPClient:
+    def __init__(self, ws: websockets.asyncio.client.ClientConnection) -> None:  # type: ignore[name-defined]
+        self._ws: Any = ws
+        self._id = 0
+        self._pending: dict[int, asyncio.Future[dict[str, Any]]] = {}
+        self._reader_task = asyncio.create_task(self._read())
+
+    async def _read(self) -> None:
+        try:
+            while True:
+                raw = await self._ws.recv()
+                if not isinstance(raw, str):
+                    continue
+                try:
+                    loaded: Any = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                if not isinstance(loaded, dict):
+                    continue
+                data: dict[str, Any] = cast(dict[str, Any], loaded)
+                msg_id: Any = data.get("id")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+                if isinstance(msg_id, int) and msg_id in self._pending:
+                    future = self._pending.pop(msg_id)
+                    if future.done():
+                        continue
+                    if "error" in data:
+                        error_info: Any = data["error"]  # pyright: ignore[reportUnknownVariableType]
+                        if isinstance(error_info, dict):
+                            message = str(
+                                error_info.get("message", "CDP error")  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+                            )
+                        else:
+                            message = f"CDP error: {error_info}"
+                        future.set_exception(Exception(message))
+                    else:
+                        result: Any = data.get("result", {})  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+                        if isinstance(result, dict):
+                            future.set_result(
+                                result  # pyright: ignore[reportUnknownArgumentType]
+                            )
+                        else:
+                            future.set_result({})
+        except Exception:
+            pass
+        for future in list(self._pending.values()):
+            if not future.done():
+                future.set_exception(Exception("CDP connection closed"))
+        self._pending.clear()
+
+    async def send(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        session_id: str | None = None,
+    ) -> dict[str, Any]:
+        self._id += 1
+        msg_id = self._id
+        future: asyncio.Future[dict[str, Any]] = asyncio.get_event_loop().create_future()
+        self._pending[msg_id] = future
+        msg: dict[str, Any] = {"id": msg_id, "method": method}
+        if params:
+            msg["params"] = params
+        if session_id:
+            msg["sessionId"] = session_id
+        await self._ws.send(json.dumps(msg))
+        return await future
+
+    async def aclose(self) -> None:
+        if not self._reader_task.done():
+            self._reader_task.cancel()
+        try:
+            await self._reader_task
+        except (asyncio.CancelledError, Exception):
+            pass
+        for future in list(self._pending.values()):
+            if not future.done():
+                future.set_exception(Exception("CDP client closed"))
+        self._pending.clear()
+        try:
+            await self._ws.close()
+        except Exception:
+            pass
+
+    async def find_page_target(self, page_id: str) -> dict[str, Any]:
+        """Return the TargetInfo dict for the given page_id, or raise PageNotFoundError."""
+        result = await self.send("Target.getTargets")
+        target_infos: list[dict[str, Any]] = result.get("targetInfos", [])  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+        for info in target_infos:
+            if info.get("targetId") == page_id and info.get("type") == "page":
+                return info
+        raise PageNotFoundError(f"Page {page_id} not found in browser")
+
+    async def attach_to_page(self, page_id: str) -> "CDPPage":
+        target_info = await self.find_page_target(page_id)
+        attach = await self.send(
+            "Target.attachToTarget", {"targetId": target_info["targetId"], "flatten": True}
+        )
+        session_id = attach.get("sessionId")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+        if not isinstance(session_id, str):
+            raise PageAttachError("Failed to attach to page target")
+        return CDPPage(self, session_id)
+
+
+class CDPPage:
+    def __init__(self, client: CDPClient, session_id: str) -> None:
+        self._client = client
+        self._session_id = session_id
+
+    async def evaluate(self, expression: str, await_promise: bool = False) -> Any:
+        result = await self._client.send(
+            "Runtime.evaluate",
+            {
+                "expression": expression,
+                "returnByValue": True,
+                "awaitPromise": await_promise,
+            },
+            session_id=self._session_id,
+        )
+        if "exceptionDetails" in result:
+            exc: Any = result.get("exceptionDetails") or {}  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+            if isinstance(exc, dict):
+                text = str(exc.get("text", ""))  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+                exception: Any = exc.get("exception", {})  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+                if isinstance(exception, dict):
+                    description = str(
+                        exception.get("description", "")  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+                    )
+                else:
+                    description = ""
+            else:
+                text = ""
+                description = ""
+            raise Exception(f"JS error: {text}: {description}")
+        remote_result: Any = result.get("result", {}) or {}  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+        if isinstance(remote_result, dict):
+            return remote_result.get("value")  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType, reportUnknownVariableType]
+        return None

--- a/tests/test_browser_api_e2e.py
+++ b/tests/test_browser_api_e2e.py
@@ -117,3 +117,66 @@ class TestAutoStart:
 
         response = client.get(f"/api/v1/browsers/{browser_id}")
         assert response.status_code == 200
+
+
+@pytest.mark.api
+class TestListPages:
+    def __init__(self) -> None:
+        self.browser_ids: list[str] = []
+
+    @pytest.fixture(autouse=True)
+    def cleanup(self, client: httpx.Client) -> Generator[None, None, None]:
+        self.browser_ids = []
+        yield
+        for browser_id in self.browser_ids:
+            try:
+                client.delete(f"/api/v1/browsers/{browser_id}")
+            except Exception:
+                pass
+
+    def test_list_pages_is_stable(self, client: httpx.Client) -> None:
+        browser_id = "test-list-pages"
+        self.browser_ids.append(browser_id)
+
+        # Ensure clean state
+        client.delete(f"/api/v1/browsers/{browser_id}")
+        assert client.post(f"/api/v1/browsers/{browser_id}").status_code == 200
+
+        first: list[object] = client.get(f"/api/v1/browsers/{browser_id}/pages").json()
+        second: list[object] = client.get(f"/api/v1/browsers/{browser_id}/pages").json()
+
+        assert isinstance(first, list)
+        assert len(first) >= 1
+        assert first == second
+
+
+@pytest.mark.api
+class TestPageContent:
+    def __init__(self) -> None:
+        self.browser_ids: list[str] = []
+
+    @pytest.fixture(autouse=True)
+    def cleanup(self, client: httpx.Client) -> Generator[None, None, None]:
+        self.browser_ids = []
+        yield
+        for browser_id in self.browser_ids:
+            try:
+                client.delete(f"/api/v1/browsers/{browser_id}")
+            except Exception:
+                pass
+
+    def test_page_html_and_distilled(self, client: httpx.Client) -> None:
+        browser_id = "test-page-content"
+        self.browser_ids.append(browser_id)
+
+        # Ensure clean state
+        client.delete(f"/api/v1/browsers/{browser_id}")
+        assert client.post(f"/api/v1/browsers/{browser_id}").status_code == 200
+
+        page_ids: list[object] = client.get(f"/api/v1/browsers/{browser_id}/pages").json()
+        assert len(page_ids) >= 1
+        page_id = str(page_ids[0])
+
+        html = client.get(f"/api/v1/browsers/{browser_id}/pages/{page_id}/html")
+        assert html.status_code == 200
+        assert "<html" in html.text.lower()


### PR DESCRIPTION
With this, it's possible to retrieve the distilled JSON of a specific page. This will be used mainly in the Headline Hub.

To verify, run locally as usual. Then, create a new remote browser with:

```bash
curl -X POST http://localhost:23456/api/v1/browsers/test
```

After that, open the web UI, find that `test` browser, and go to NPR website, `text.npr.org`. Once that's done, check the list of pages:

```bash
curl http://localhost:23456/api/v1/browsers/test/pages
```

which should give something like:
```json
["96FDE4162B8EEEBF98E26756D21CF0C5"]
```

That is the page identifier. Use that to retrieve the distilled JSON:
```bash
curl http://localhost:23456/api/v1/browsers/test/pages/96FDE4162B8EEEBF98E26756D21CF0C5/distilled
```

And for troubleshooting, retrieve also its raw HTML:
```
curl http://localhost:23456/api/v1/browsers/test/pages/96FDE4162B8EEEBF98E26756D21CF0C5/html
```