### PR TITLE
remove keypress from batch actions

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -1068,7 +1068,6 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
                     let currentValue = "";
                     for (const char of value) {{
                         element.dispatchEvent(new KeyboardEvent("keydown", {{ key: char, bubbles: true }}));
-                        element.dispatchEvent(new KeyboardEvent("keypress", {{ key: char, bubbles: true }}));
                         currentValue += char;
                         setNativeValue(element, currentValue);
                         element.dispatchEvent(


### PR DESCRIPTION
The "keypress" event causes weird behavior. It's as if the submit button is being clicked when that event fires.


Before:

https://github.com/user-attachments/assets/c7e016f0-55cd-4312-8f2e-0186fa76aa9f



After:


https://github.com/user-attachments/assets/efb1d985-d58c-499d-91b6-13df133271ea


# Test Plan

- [x] Test Amazon
- [x] Test Walmart
- [x] Test Doordash