### PR TITLE
feat(walmart): improve homepage detection reliability on desktop layout

### DIFF
--- a/getgather/mcp/patterns/walmart-logged-out-menu.html
+++ b/getgather/mcp/patterns/walmart-logged-out-menu.html
@@ -3,6 +3,7 @@
     <title>Walmart Logged Out Menu</title>
   </head>
   <body>
+    <div gg-match="main#maincontentredesign"></div>
     <div gg-match="#logged-out-links-container"></div>
     <div gg-autoclick gg-match="a[data-testid='sign-in']"></div>
   </body>

--- a/getgather/mcp/patterns/walmart-logged-out.html
+++ b/getgather/mcp/patterns/walmart-logged-out.html
@@ -3,6 +3,7 @@
     <title>Walmart Logged Out</title>
   </head>
   <body>
+    <div gg-match="main#maincontentredesign"></div>
     <div gg-match="[data-automation-id='headerSignIn']"></div>
     <div gg-autoclick gg-match="[data-automation-id='headerSignIn']"></div>
   </body>


### PR DESCRIPTION
On flyfleet, the logged-out patterns were matching before the pre-signin pattern because both pages share a similar header. Adds `gg-match="main#maincontentredesign"` so the logged-out patterns only match the actual homepage, making detection reliable.