### PR TITLE
fix(walmart): match "valid number or email" signin error

### DIFF
--- a/getgather/mcp/patterns/walmart-signin-email.html
+++ b/getgather/mcp/patterns/walmart-signin-email.html
@@ -8,6 +8,11 @@
       gg-optional
       gg-match="div[data-testid='dropdown'] section div span"
     ></span>
+    <span
+      class="error-box"
+      gg-optional
+      gg-match="xpath=//span[contains(text(),'Please enter a valid number or email')]"
+    ></span>
     <input
       autofocus
       name="email"


### PR DESCRIPTION
Match Walmart's "Please enter a valid number or email" validation error so the distillation flow surfaces it during email signin.