### PR TITLE
fix(walmart): apply action delay before first set_value to stop email clearing

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -984,7 +984,7 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
 
         for (const [index, action] of actions.entries()) {{
             const actionDelayMs = Number(action?.action_delay_ms) || 0;
-            if (index > 0 && actionDelayMs > 0) {{
+            if (actionDelayMs > 0) {{
                 await new Promise(resolve => setTimeout(resolve, actionDelayMs));
             }}
             const key = action?.key;

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -565,7 +565,7 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
             results = action_results if isinstance(action_results, dict) else {}
 
             # Fallback for failed/unexecuted actions to preserve behavior.
-            for i, action in enumerate(pending_actions):
+            for action in pending_actions:
                 key = action.get("key")
                 kind = action.get("kind")
                 selector = action.get("selector")
@@ -578,7 +578,7 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                 if results.get(key, False):
                     continue
 
-                config = element_config if i > 0 else None
+                config = element_config
                 element = await page_query_selector(page, selector, config=config)
                 if not element:
                     continue

--- a/getgather/mcp/patterns/walmart-signin-email.html
+++ b/getgather/mcp/patterns/walmart-signin-email.html
@@ -1,4 +1,4 @@
-<html gg-domain="walmart" gg-action-delay="200">
+<html gg-domain="walmart" gg-action-delay="1000">
   <head>
     <title>Walmart Sign In - Email or Phone</title>
   </head>


### PR DESCRIPTION
## Problem
On `identity.walmart.com` the email sign-in field intermittently clears before submit. `set_value` types the email char-by-char, the value is confirmed in the DOM, a few chars flash, then the field resets to empty. Submit fires empty and Walmart returns "Please enter a valid phone number or email". Intermittent on remote FlyFleet.

## Root cause
The input is a React controlled component still mid-render when typing begins, so the re-render wipes the typed value.

## Fix
Apply `action_delay_ms` before the first action (the `set_value`), not just subsequent ones, so React finishes rendering before typing.

- `browser.py` — drop the `index > 0` guard on the batch-loop delay
- `dpage.py` — fallback always uses `element_config`; simplify the now-unused `enumerate`
- `walmart-signin-email.html` — bump `gg-action-delay` 200ms → 1000ms
