### PR TITLE
fix(mcp): bound every tool call with an overall timeout

### DIFF
--- a/getgather/config.py
+++ b/getgather/config.py
@@ -35,6 +35,11 @@ class Settings(AuthSettings, BaseSettings):
     # Max session age, in minutes
     BROWSER_SESSION_AGE: int = 60
 
+    # Overall wall-clock deadline for a single MCP tool call, in seconds.
+    # Guards against a stuck tool call (e.g. a hung page navigation) running
+    # indefinitely and pinning its browser.
+    MCP_TOOL_CALL_TIMEOUT: int = 300
+
     @property
     def data_dir(self) -> Path:
         path = Path(self.DATA_DIR).resolve() if self.DATA_DIR else PROJECT_DIR / "data"

--- a/getgather/mcp/main.py
+++ b/getgather/mcp/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from dataclasses import dataclass
 from functools import cache, cached_property
@@ -13,7 +14,9 @@ from loguru import logger
 from pydantic import BaseModel
 
 from getgather.auth.auth import get_auth_user
+from getgather.config import settings
 from getgather.mcp.auto_import import auto_import
+from getgather.mcp.browser import browser_manager, terminate_zendriver_browser
 from getgather.mcp.dpage import (
     dpage_check,
     dpage_finalize,
@@ -95,6 +98,8 @@ class LocationProxyMiddleware(Middleware):
         if browser_session_id:
             log_context["browser_session_id"] = browser_session_id
 
+        signin_id = headers.get("x-signin-id") or None
+
         # Initialize request_info data
         info_data: dict[str, str | None] = {}
 
@@ -121,7 +126,7 @@ class LocationProxyMiddleware(Middleware):
 
         if "general_tool" in tool.tags:  # pyright: ignore[reportOptionalMemberAccess]
             with logger.contextualize(**log_context):
-                return await call_next(context)
+                return await self._call_next_with_timeout(context, call_next, signin_id)
 
         brand_id = context.message.name.split("_")[0]
         await context.fastmcp_context.set_state("brand_id", brand_id)
@@ -131,7 +136,54 @@ class LocationProxyMiddleware(Middleware):
             logger.info(f"[AuthMiddleware Context]: {context.message}")
             if proxy_type:
                 logger.info(f"Received x-proxy-type header: {proxy_type}")
-            return await call_next(context)
+            return await self._call_next_with_timeout(context, call_next, signin_id)
+
+    async def _call_next_with_timeout(
+        self,
+        context: MiddlewareContext[Any],
+        call_next: CallNext[Any, Any],
+        signin_id: str | None,
+    ) -> Any:
+        """Run the tool with an overall deadline.
+
+        A stuck tool call (e.g. a hung page navigation) must not be able to run
+        indefinitely and pin its browser. On timeout we release the session
+        browser and surface the failure to the client instead of hanging.
+        """
+        timeout = settings.MCP_TOOL_CALL_TIMEOUT
+        try:
+            async with asyncio.timeout(timeout):
+                return await call_next(context)
+        except TimeoutError:
+            logger.error(
+                f"Tool call '{context.message.name}' exceeded {timeout}s timeout; "
+                f"aborting and releasing browser"
+            )
+            await self._release_session_browser(signin_id)
+            raise TimeoutError(
+                f"Tool call '{context.message.name}' timed out after {timeout}s"
+            ) from None
+
+    @staticmethod
+    async def _release_session_browser(signin_id: str | None) -> None:
+        """Terminate the browser tied to a signin session after a timeout.
+
+        Only incognito (per-session) browsers are released; the shared global
+        browser is left untouched. Bounded by its own timeout so a stuck
+        teardown cannot hang the request that is already timing out.
+        """
+        if not signin_id or not browser_manager.has_incognito_browser(signin_id):
+            return
+        browser = browser_manager.get_incognito_browser(signin_id)
+        try:
+            if browser is not None:
+                async with asyncio.timeout(30):
+                    await terminate_zendriver_browser(browser)
+                logger.info(f"Released browser for signin_id {signin_id} after tool timeout")
+        except Exception as e:
+            logger.error(f"Failed to release browser for signin_id {signin_id} after timeout: {e}")
+        finally:
+            browser_manager.remove_incognito_browser(signin_id)
 
 
 MCP_BUNDLES: dict[str, list[str]] = {

--- a/tests/mcp/test_tool_call_timeout.py
+++ b/tests/mcp/test_tool_call_timeout.py
@@ -1,0 +1,97 @@
+import asyncio
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from pytest import MonkeyPatch
+
+import getgather.mcp.main as main
+from getgather.config import settings
+from getgather.mcp.browser import BrowserManager
+from getgather.mcp.main import LocationProxyMiddleware
+
+
+class StubBrowser:
+    """Minimal stand-in for zd.Browser: terminate only uses .id and .stop()."""
+
+    def __init__(self, id: str):
+        self.id = id
+        self.stopped = False
+
+    async def stop(self):
+        self.stopped = True
+
+
+class FakeMessage:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class FakeContext:
+    def __init__(self, name: str):
+        self.message = FakeMessage(name)
+
+
+@pytest.fixture
+def manager(monkeypatch: MonkeyPatch, tmp_path: Path) -> BrowserManager:
+    """Isolated browser manager + sandboxed profiles dir for each test."""
+    monkeypatch.setattr(settings, "DATA_DIR", str(tmp_path))
+    fresh = BrowserManager()
+    monkeypatch.setattr(main, "browser_manager", fresh)
+    return fresh
+
+
+def _context(name: str = "amazon_get_purchase_history_with_details") -> Any:
+    return cast(Any, FakeContext(name))
+
+
+# Cast to Any so tests can drive the middleware's internal helpers without
+# tripping reportPrivateUsage / CallNext arg-type checks.
+def _middleware() -> Any:
+    return cast(Any, LocationProxyMiddleware())
+
+
+class TestCallNextWithTimeout:
+    @pytest.mark.asyncio
+    async def test_returns_result_when_within_deadline(
+        self, manager: BrowserManager, monkeypatch: MonkeyPatch
+    ):
+        monkeypatch.setattr(settings, "MCP_TOOL_CALL_TIMEOUT", 5)
+        manager.set_incognito_browser("sess1", cast(Any, StubBrowser("sess1")))
+
+        async def call_next(_ctx: Any) -> str:
+            return "ok"
+
+        result = await _middleware()._call_next_with_timeout(_context(), call_next, "sess1")
+
+        assert result == "ok"
+        # A successful call must not tear down the session browser.
+        assert manager.has_incognito_browser("sess1")
+
+    @pytest.mark.asyncio
+    async def test_times_out_and_releases_browser(
+        self, manager: BrowserManager, monkeypatch: MonkeyPatch
+    ):
+        monkeypatch.setattr(settings, "MCP_TOOL_CALL_TIMEOUT", 0.05)
+        browser = StubBrowser("sess1")
+        manager.set_incognito_browser("sess1", cast(Any, browser))
+
+        async def call_next(_ctx: Any) -> str:
+            await asyncio.sleep(10)
+            return "never"
+
+        with pytest.raises(TimeoutError):
+            await _middleware()._call_next_with_timeout(_context(), call_next, "sess1")
+
+        assert browser.stopped
+        assert not manager.has_incognito_browser("sess1")
+
+
+class TestReleaseSessionBrowser:
+    @pytest.mark.asyncio
+    async def test_noop_without_signin_id(self, manager: BrowserManager):
+        await _middleware()._release_session_browser(None)
+
+    @pytest.mark.asyncio
+    async def test_noop_when_browser_unknown(self, manager: BrowserManager):
+        await _middleware()._release_session_browser("missing")


### PR DESCRIPTION
## Why

On 2026-06-08 a single `amazon_get_purchase_history_with_details` tool call ran for **~4.5 hours** (Logfire trace `019ea52c…`) after its orders-page navigation started failing with a blank error and never returned. It held its ChromeFleet browser open the whole time. With memory already near 100% from accumulated sessions, the box thrashed (CPU pinned, heavy swap I/O) until GCP reset the VM.

The per-attempt navigation retry (`zen_navigate_with_retry`) is already bounded (~105s), but there was **no overall wall-clock deadline** on a tool call, so a hang anywhere in the orchestration/distillation loop could run unbounded.

## What

- Add `MCP_TOOL_CALL_TIMEOUT` setting (default **300s**, env-configurable).
- Enforce it in `LocationProxyMiddleware.on_call_tool` — the single chokepoint every tool call passes through — via `asyncio.timeout`. This bounds **all** scrape tools (amazon, amazonca, doordash, …), not just the one that broke.
- On timeout: log, **force-release the session's incognito ChromeFleet browser** (the shared global browser is left untouched), and surface a clear `TimeoutError` to the client instead of hanging.

## Notes

- 300s is ~3.6× the slowest legitimate call observed in the incident window (`check_signin` at ~83s; normal scrapes ~25s), so it should not trip real flows. Tunable via env without a redeploy.
- Cancellation propagates into the tool coroutine, so its own `finally`/`safe_close_page` cleanup still runs; the browser release is a belt-and-suspenders teardown for the per-session browser.
- This is the highest-leverage fix from the incident. Separate follow-ups still worth doing: a concurrency/memory cap on simultaneous browser sessions, widening `terminate_zendriver_browser` to catch `OSError`/`ConnectionRefusedError`, and making `page_batch_actions` surface failures instead of returning `None`.

## Testing

- New `tests/mcp/test_tool_call_timeout.py`: returns within deadline (browser kept), times out + releases browser, release no-ops without/with-unknown signin id.
- `ruff check`, `ruff format`, `pyright`, and `tests/mcp/test_browser_cleanup.py` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)