### PR TITLE
Support both stand-alone and external Chrome Fleet operations

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -190,19 +190,22 @@ async def _create_browser_from_cdp_websocket(
     return instance
 
 
-async def _call_chromefleet_api(
+async def call_chromefleet_api(
     method: HTTP_METHOD,
-    browser_id: str,
+    browser_id: str | None = None,
     *,
     target_domain: str | None = None,
     timeout: float = 120.0,
     retries: int = 3,
     raise_for_status: bool = True,
-):
+    headers: dict[str, str] | None = None,
+) -> httpx.Response | None:
     base_url = settings.effective_chromefleet_url.rstrip("/")
-    url = f"{base_url}/api/v1/browsers/{browser_id}"
+    path = f"/api/v1/browsers/{browser_id}" if browser_id else "/api/v1/browsers"
+    url = f"{base_url}{path}"
 
-    headers = _build_chromefleet_headers(target_domain=target_domain)
+    if headers is None:
+        headers = _build_chromefleet_headers(target_domain=target_domain)
 
     async with httpx.AsyncClient(
         transport=RetryTransport(
@@ -250,14 +253,14 @@ def _setup_cdp_url(browser_id: str) -> str:
 
 
 async def get_remote_browser_cdp_url(browser_id: str) -> str:
-    await _call_chromefleet_api("GET", browser_id, timeout=2.0, retries=0)
+    await call_chromefleet_api("GET", browser_id, timeout=2.0, retries=0)
     return _setup_cdp_url(browser_id)
 
 
 async def get_remote_browser(browser_id: str) -> zd.Browser | None:
     logger.debug(f"Finding the ChromeFleet browser: {browser_id}")
     try:
-        await _call_chromefleet_api("GET", browser_id)
+        await call_chromefleet_api("GET", browser_id)
     except Exception:
         return None
 
@@ -291,9 +294,7 @@ async def terminate_remote_browser(browser: zd.Browser) -> None:
     browser_id = cast(str, browser.id)  # type: ignore[attr-defined]
     logger.info(f"Terminating ChromeFleet browser: {browser_id}")
     # no need to raise for error (which would fail the whole process)
-    await _call_chromefleet_api(
-        "DELETE", browser_id, timeout=1.0, retries=0, raise_for_status=False
-    )
+    await call_chromefleet_api("DELETE", browser_id, timeout=1.0, retries=0, raise_for_status=False)
 
 
 _CREDENTIALS_BLOCK_SCRIPT = r"""

--- a/getgather/browsers_api_router.py
+++ b/getgather/browsers_api_router.py
@@ -33,6 +33,26 @@ from getgather.zen_distill import convert, distill, load_distillation_patterns
 router = APIRouter()
 
 
+async def _chromefleet_request(
+    method: str,
+    path: str,
+    *,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    url = f"{settings.CHROMEFLEET_URL}{path}"
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        return await client.request(method, url, headers=headers)
+
+
+def _forward_headers(request: HTTPConnection, *names: str) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for name in names:
+        value = request.headers.get(name)
+        if value:
+            headers[name] = value
+    return headers
+
+
 async def get_cdp_websocket_url(browser_id: str) -> str:
     cdp_url = await get_cdp_url(browser_id)
 
@@ -206,8 +226,19 @@ async def websocket_proxy(client_ws: WebSocket, remote_url: str, browser_id: str
             await client_ws.close(code=4500, reason="Internal proxy error")
 
 
-@router.post("/api/v1/browsers/{browser_id}")
-async def create_browser(browser_id: str, request: HTTPConnection) -> dict[str, str | None]:
+@router.post("/api/v1/browsers/{browser_id}", response_model=None)
+async def create_browser(
+    browser_id: str, request: HTTPConnection
+) -> dict[str, str | None] | JSONResponse:
+    if settings.CHROMEFLEET_URL:
+        logger.info(f"Proxying create_browser({browser_id}) to external Chrome Fleet")
+        response = await _chromefleet_request(
+            "POST",
+            f"/api/v1/browsers/{browser_id}",
+            headers=_forward_headers(request, "x-origin-ip"),
+        )
+        return JSONResponse(content=response.json(), status_code=response.status_code)  # pyright: ignore[reportUnknownArgumentType]
+
     logger.info(f"Starting browser {browser_id}...")
     container_name = f"chromium-{browser_id}"
     try:
@@ -222,8 +253,13 @@ async def create_browser(browser_id: str, request: HTTPConnection) -> dict[str, 
         raise HTTPException(status_code=500, detail=detail)
 
 
-@router.delete("/api/v1/browsers/{browser_id}")
-async def delete_browser(browser_id: str) -> dict[str, str]:
+@router.delete("/api/v1/browsers/{browser_id}", response_model=None)
+async def delete_browser(browser_id: str) -> dict[str, str] | JSONResponse:
+    if settings.CHROMEFLEET_URL:
+        logger.info(f"Proxying delete_browser({browser_id}) to external Chrome Fleet")
+        response = await _chromefleet_request("DELETE", f"/api/v1/browsers/{browser_id}")
+        return JSONResponse(content=response.json(), status_code=response.status_code)  # pyright: ignore[reportUnknownArgumentType]
+
     logger.info(f"Stopping browser {browser_id}...")
     container_name = f"chromium-{browser_id}"
     if not await container_exists(container_name):
@@ -240,8 +276,19 @@ async def delete_browser(browser_id: str) -> dict[str, str]:
         raise HTTPException(status_code=500, detail=detail)
 
 
-@router.get("/api/v1/browsers/{browser_id}")
-async def get_browser(browser_id: str, request: Request) -> dict[str, float | str | None]:
+@router.get("/api/v1/browsers/{browser_id}", response_model=None)
+async def get_browser(
+    browser_id: str, request: Request
+) -> dict[str, float | str | None] | JSONResponse:
+    if settings.CHROMEFLEET_URL:
+        logger.info(f"Proxying get_browser({browser_id}) to external Chrome Fleet")
+        response = await _chromefleet_request(
+            "GET",
+            f"/api/v1/browsers/{browser_id}",
+            headers=_forward_headers(request, "x-origin-ip"),
+        )
+        return JSONResponse(content=response.json(), status_code=response.status_code)  # pyright: ignore[reportUnknownArgumentType]
+
     logger.info(f"Querying browser {browser_id}...")
     container_name = f"chromium-{browser_id}"
     if not await container_is_running(container_name):
@@ -260,6 +307,11 @@ async def get_browser(browser_id: str, request: Request) -> dict[str, float | st
 
 @router.get("/api/v1/browsers")
 async def list_browsers() -> JSONResponse:
+    if settings.CHROMEFLEET_URL:
+        logger.info("Proxying list_browsers() to external Chrome Fleet")
+        response = await _chromefleet_request("GET", "/api/v1/browsers")
+        return JSONResponse(content=response.json(), status_code=response.status_code)  # pyright: ignore[reportUnknownArgumentType]
+
     logger.info("Enumerating all browsers...")
     try:
         containers = await list_containers()

--- a/getgather/browsers_api_router.py
+++ b/getgather/browsers_api_router.py
@@ -13,6 +13,7 @@ from loguru import logger
 from starlette.requests import HTTPConnection
 from websockets.exceptions import ConnectionClosed
 
+from getgather.browser import call_chromefleet_api
 from getgather.cdp_client import PageNotFoundError, open_cdp
 from getgather.config import settings
 from getgather.podman_browsers import (
@@ -31,17 +32,6 @@ from getgather.podman_browsers import (
 from getgather.zen_distill import convert, distill, load_distillation_patterns
 
 router = APIRouter()
-
-
-async def _chromefleet_request(
-    method: str,
-    path: str,
-    *,
-    headers: dict[str, str] | None = None,
-) -> httpx.Response:
-    url = f"{settings.CHROMEFLEET_URL}{path}"
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        return await client.request(method, url, headers=headers)
 
 
 def _forward_headers(request: HTTPConnection, *names: str) -> dict[str, str]:
@@ -232,11 +222,13 @@ async def create_browser(
 ) -> dict[str, str | None] | JSONResponse:
     if settings.CHROMEFLEET_URL:
         logger.info(f"Proxying create_browser({browser_id}) to external Chrome Fleet")
-        response = await _chromefleet_request(
+        response = await call_chromefleet_api(
             "POST",
-            f"/api/v1/browsers/{browser_id}",
+            browser_id,
             headers=_forward_headers(request, "x-origin-ip"),
         )
+        if response is None:
+            raise HTTPException(status_code=502, detail="Chrome Fleet request failed")
         return JSONResponse(content=response.json(), status_code=response.status_code)  # pyright: ignore[reportUnknownArgumentType]
 
     logger.info(f"Starting browser {browser_id}...")
@@ -257,7 +249,9 @@ async def create_browser(
 async def delete_browser(browser_id: str) -> dict[str, str] | JSONResponse:
     if settings.CHROMEFLEET_URL:
         logger.info(f"Proxying delete_browser({browser_id}) to external Chrome Fleet")
-        response = await _chromefleet_request("DELETE", f"/api/v1/browsers/{browser_id}")
+        response = await call_chromefleet_api("DELETE", browser_id)
+        if response is None:
+            raise HTTPException(status_code=502, detail="Chrome Fleet request failed")
         return JSONResponse(content=response.json(), status_code=response.status_code)  # pyright: ignore[reportUnknownArgumentType]
 
     logger.info(f"Stopping browser {browser_id}...")
@@ -282,11 +276,13 @@ async def get_browser(
 ) -> dict[str, float | str | None] | JSONResponse:
     if settings.CHROMEFLEET_URL:
         logger.info(f"Proxying get_browser({browser_id}) to external Chrome Fleet")
-        response = await _chromefleet_request(
+        response = await call_chromefleet_api(
             "GET",
-            f"/api/v1/browsers/{browser_id}",
+            browser_id,
             headers=_forward_headers(request, "x-origin-ip"),
         )
+        if response is None:
+            raise HTTPException(status_code=502, detail="Chrome Fleet request failed")
         return JSONResponse(content=response.json(), status_code=response.status_code)  # pyright: ignore[reportUnknownArgumentType]
 
     logger.info(f"Querying browser {browser_id}...")
@@ -309,7 +305,9 @@ async def get_browser(
 async def list_browsers() -> JSONResponse:
     if settings.CHROMEFLEET_URL:
         logger.info("Proxying list_browsers() to external Chrome Fleet")
-        response = await _chromefleet_request("GET", "/api/v1/browsers")
+        response = await call_chromefleet_api("GET")
+        if response is None:
+            raise HTTPException(status_code=502, detail="Chrome Fleet request failed")
         return JSONResponse(content=response.json(), status_code=response.status_code)  # pyright: ignore[reportUnknownArgumentType]
 
     logger.info("Enumerating all browsers...")


### PR DESCRIPTION
Remote Browser can operate in two modes: stand-alone or with an external Chrome Fleet.

In stand-alone mode, Podman manages browser containers locally. All browser CRUD endpoints (create, delete, get, list) use the Podman-based container handling.

With an external Chrome Fleet, those same CRUD endpoints are proxied to the upstream Chrome Fleet service.

To verify, first run Chrome Fleet (or any compatible implementation) on port 8300. Then launch Remote Browser as usual, specifying the URL of that Chrome Fleet, e.g.

```bash
export CHROMEFLEET_URL=http://localhost:8300
LOG_LEVEL=DEBUG npm run dev
```

Then invoke the Remote Browser REST API, e.g.

```bash
curl localhost:23456/api/v1/browsers
```

The log of Chrome Fleet should show something like:
```
13:43:52 INFO     Enumerating all browsers...
         INFO     127.0.0.1:41704 - "GET /api/v1/browsers HTTP/1.1" 200
```

while the log of Remote Browser would indicate the proxying of that request to Chrome Fleet:
```
13:43:52 INFO     Proxying list_browsers() to external Chrome Fleet
         INFO     127.0.0.1:33326 - "GET /api/v1/browsers HTTP/1.1" 200
```