### PR TITLE
fix(dpage): strip hyphens from phone inputs on form submit

### DIFF
--- a/getgather/mcp/html_renderer.py
+++ b/getgather/mcp/html_renderer.py
@@ -302,9 +302,25 @@ def render_form(
     <script>
       document.addEventListener("DOMContentLoaded", function () {{
         const form = document.querySelector("div.card");
+        const phoneTextPattern = /^\\+?\\d+(-\\d+)+$/;
 
         if (form) {{
           form.addEventListener("submit", function (e) {{
+            const formElement = form.querySelector("form");
+            if (formElement) {{
+              formElement.querySelectorAll("input").forEach(function (input) {{
+                const value = input.value;
+                if (!value || !value.includes("-")) {{
+                  return;
+                }}
+                const type = input.type.toLowerCase();
+                if (type === "tel" || type === "number") {{
+                  input.value = value.replace(/-/g, "");
+                }} else if (type === "text" && phoneTextPattern.test(value)) {{
+                  input.value = value.replace(/-/g, "");
+                }}
+              }});
+            }}
 
             const overlay = document.createElement("div");
             overlay.className = "form-overlay";


### PR DESCRIPTION
Normalize tel/number fields and hyphenated phone-like text inputs before POST so sign-in flows receive digits-only values.


https://github.com/user-attachments/assets/938ffeb7-4d8d-4fb7-9f5e-3f9fd1764575


https://github.com/user-attachments/assets/5bb64f0d-6698-4e57-ad88-92b208adb435


