### PR TITLE
fix(walmart): support "Text me" button in send-code signin step

### DIFF
--- a/getgather/mcp/patterns/walmart-signin-send-code.html
+++ b/getgather/mcp/patterns/walmart-signin-send-code.html
@@ -5,6 +5,6 @@
   <body>
     <h1 gg-match="h1.f3">Verify it's you</h1>
     <p gg-optional gg-match="[data-testid='identity-generic-choice-options'] .dark-gray"></p>
-    <div gg-autoclick gg-match="//button[contains(text(), 'Send code')]"></div>
+    <div gg-autoclick gg-match="//button[contains(text(), 'Send code') or contains(text(), 'Text me')]"></div>
   </body>
 </html>

--- a/getgather/mcp/patterns/walmart-signin-send-code.html
+++ b/getgather/mcp/patterns/walmart-signin-send-code.html
@@ -5,6 +5,9 @@
   <body>
     <h1 gg-match="h1.f3">Verify it's you</h1>
     <p gg-optional gg-match="[data-testid='identity-generic-choice-options'] .dark-gray"></p>
-    <div gg-autoclick gg-match="//button[contains(text(), 'Send code') or contains(text(), 'Text me')]"></div>
+    <div
+      gg-autoclick
+      gg-match="//button[contains(text(), 'Send code') or contains(text(), 'Text me')]"
+    ></div>
   </body>
 </html>


### PR DESCRIPTION
Walmart renders either "Send code" or "Text me" on the SMS OTP verification step depending on the account. Both buttons do the same thing, but the pattern only matched the first variant, so the autoclick would silently miss when "Text me" appeared.

Updated the XPath selector with an `or` condition to match both.


