### PR TITLE
test(patterns): add data-testid to dpage pattern inputs and buttons

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -60,3 +60,16 @@ jobs:
 
       - name: Check YAML formatting
         run: uv run yamlfix --check $(find . -type f -name '*.yml' -o -name '*.yaml' | grep -v -E '\.venv/|node_modules/|mcp-tools\.yaml')
+
+  pattern-testids:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+
+      - name: Check pattern data-testid convention
+        run: uv run python scripts/check_pattern_testids.py

--- a/getgather/mcp/patterns/adidas-password.html
+++ b/getgather/mcp/patterns/adidas-password.html
@@ -9,10 +9,15 @@
       autofocus
       name="password"
       type="password"
+      data-testid="password"
       gg-match="input#password"
       placeholder="Password"
     />
-    <button type="submit" gg-match="button#login-submit-button:not([disabled]) span">
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="button#login-submit-button:not([disabled]) span"
+    >
       Sign In
     </button>
   </body>

--- a/getgather/mcp/patterns/adidas-signin.html
+++ b/getgather/mcp/patterns/adidas-signin.html
@@ -5,8 +5,19 @@
   <body>
     <p gg-optional gg-match="div#email--error"></p>
     <p gg-optional gg-match="p._error_tbedu_60"></p>
-    <input autofocus name="email" type="email" gg-match="input#email" placeholder="Email Address" />
-    <button type="submit" gg-match="button#two-step-form-button:not([disabled]) span">
+    <input
+      autofocus
+      name="email"
+      type="email"
+      data-testid="email"
+      gg-match="input#email"
+      placeholder="Email Address"
+    />
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="button#two-step-form-button:not([disabled]) span"
+    >
       Continue
     </button>
   </body>

--- a/getgather/mcp/patterns/agoda-otp.html
+++ b/getgather/mcp/patterns/agoda-otp.html
@@ -8,17 +8,49 @@
         name="otp-0"
         type="text"
         inputmode="numeric"
+        data-testid="otp-0"
         gg-match="input[name='otp-0']"
       />
-      <input name="otp-1" type="text" inputmode="numeric" gg-match="input[name='otp-1']" />
-      <input name="otp-2" type="text" inputmode="numeric" gg-match="input[name='otp-2']" />
-      <input name="otp-3" type="text" inputmode="numeric" gg-match="input[name='otp-3']" />
-      <input name="otp-4" type="text" inputmode="numeric" gg-match="input[name='otp-4']" />
-      <input name="otp-5" type="text" inputmode="numeric" gg-match="input[name='otp-5']" />
+      <input
+        name="otp-1"
+        type="text"
+        inputmode="numeric"
+        data-testid="otp-1"
+        gg-match="input[name='otp-1']"
+      />
+      <input
+        name="otp-2"
+        type="text"
+        inputmode="numeric"
+        data-testid="otp-2"
+        gg-match="input[name='otp-2']"
+      />
+      <input
+        name="otp-3"
+        type="text"
+        inputmode="numeric"
+        data-testid="otp-3"
+        gg-match="input[name='otp-3']"
+      />
+      <input
+        name="otp-4"
+        type="text"
+        inputmode="numeric"
+        data-testid="otp-4"
+        gg-match="input[name='otp-4']"
+      />
+      <input
+        name="otp-5"
+        type="text"
+        inputmode="numeric"
+        data-testid="otp-5"
+        gg-match="input[name='otp-5']"
+      />
     </div>
 
     <button
       type="submit"
+      data-testid="submit"
       gg-match="button[data-element-name='universal-login-unified-auth-otp-continue']"
     >
       Continue

--- a/getgather/mcp/patterns/agoda-signin.html
+++ b/getgather/mcp/patterns/agoda-signin.html
@@ -1,9 +1,16 @@
 <html gg-domain="agoda" gg-priority="1">
   <body>
     <h2>Sign in or create an account</h2>
-    <input name="email" type="email" gg-match="input[type=email]" placeholder="Email" />
+    <input
+      name="email"
+      type="email"
+      data-testid="email"
+      gg-match="input[type=email]"
+      placeholder="Email"
+    />
     <button
       type="submit"
+      data-testid="submit"
       gg-match="button[data-element-name='universal-login-unified-auth-email-continue']"
     >
       Continue

--- a/getgather/mcp/patterns/alfagift-login.html
+++ b/getgather/mcp/patterns/alfagift-login.html
@@ -4,10 +4,17 @@
     <title>Alfagift Sign In</title>
   </head>
   <body>
-    <input name="email" type="text" gg-match="input[id='email']" placeholder="Ketik user Anda" />
+    <input
+      name="email"
+      type="text"
+      data-testid="email"
+      gg-match="input[id='email']"
+      placeholder="Ketik user Anda"
+    />
     <input
       name="password"
       type="password"
+      data-testid="password"
       gg-match="input[type='password']"
       placeholder="Password"
     />
@@ -15,6 +22,7 @@
     <div gg-optional gg-match="p.text-center.mb-4"></div>
     <button
       type="submit"
+      data-testid="submit"
       gg-match="//button[contains(normalize-space(.),'Masuk') or contains(normalize-space(.),'Log in')]"
     >
       Masuk

--- a/getgather/mcp/patterns/aliexpress-email-not-found.html
+++ b/getgather/mcp/patterns/aliexpress-email-not-found.html
@@ -6,7 +6,13 @@
     <h2 gg-match="//button/span[contains(text(), 'Register')]"></h2>
     <p>You do not have an account with this email, please try again with a different email.</p>
     <input name="none" style="display: none" />
-    <button type="submit" name="button" value="back" gg-match="//button[contains(text(), 'Back')]">
+    <button
+      type="submit"
+      name="button"
+      value="back"
+      data-testid="submit"
+      gg-match="//button[contains(text(), 'Back')]"
+    >
       Back
     </button>
   </body>

--- a/getgather/mcp/patterns/aliexpress-otp.html
+++ b/getgather/mcp/patterns/aliexpress-otp.html
@@ -5,7 +5,13 @@
   <body>
     <span gg-match="//div[contains(text(), 'Email verification code')]"></span>
     <span gg-match="div.subTitle_field_item"></span>
-    <input name="otp" type="tel" gg-match="input[data-id='0']" placeholder="OTP" />
-    <button type="submit" gg-match="button#j-test">Verify</button>
+    <input
+      name="otp"
+      type="tel"
+      data-testid="otp"
+      gg-match="input[data-id='0']"
+      placeholder="OTP"
+    />
+    <button type="submit" data-testid="submit" gg-match="button#j-test">Verify</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/aliexpress-password.html
+++ b/getgather/mcp/patterns/aliexpress-password.html
@@ -10,10 +10,15 @@
     <input
       name="password"
       type="password"
+      data-testid="password"
       gg-match="input#fm-login-password"
       placeholder="Password"
     />
-    <button type="submit" gg-match="//button[@type='button']//span[contains(text(), 'Sign in')]">
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="//button[@type='button']//span[contains(text(), 'Sign in')]"
+    >
       Sign in
     </button>
   </body>

--- a/getgather/mcp/patterns/aliexpress-signin-2.html
+++ b/getgather/mcp/patterns/aliexpress-signin-2.html
@@ -6,9 +6,12 @@
     <input
       name="email"
       type="email"
+      data-testid="email"
       gg-match="input[label='Email']"
       placeholder="Email or phone number"
     />
-    <button gg-match="button[aria-label='Continue']" type="submit">Continue</button>
+    <button data-testid="submit" gg-match="button[aria-label='Continue']" type="submit">
+      Continue
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/aliexpress-signin.html
+++ b/getgather/mcp/patterns/aliexpress-signin.html
@@ -6,9 +6,10 @@
     <input
       name="email"
       type="email"
+      data-testid="email"
       gg-match="input[label='Email or phone number']"
       placeholder="Email or phone number"
     />
-    <button type="submit">Continue</button>
+    <button type="submit" data-testid="submit">Continue</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/aliexpress-signin.html
+++ b/getgather/mcp/patterns/aliexpress-signin.html
@@ -6,7 +6,7 @@
     <input
       name="email"
       type="email"
-      data-testid="email"
+      data-testid="username"
       gg-match="input[label='Email or phone number']"
       placeholder="Email or phone number"
     />

--- a/getgather/mcp/patterns/alltrails-signin.html
+++ b/getgather/mcp/patterns/alltrails-signin.html
@@ -4,9 +4,25 @@
   </head>
   <body>
     <p gg-optional gg-match="div[class*=serverError]"></p>
-    <input type="email" gg-match="input#userEmail" placeholder="Email Address" name="email" />
-    <input type="password" gg-match="input#userPassword" placeholder="Password" name="password" />
-    <button type="submit" gg-match="button[data-testid='email-password-login-button']">
+    <input
+      type="email"
+      data-testid="email"
+      gg-match="input#userEmail"
+      placeholder="Email Address"
+      name="email"
+    />
+    <input
+      type="password"
+      data-testid="password"
+      gg-match="input#userPassword"
+      placeholder="Password"
+      name="password"
+    />
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="button[data-testid='email-password-login-button']"
+    >
       Sign in
     </button>
   </body>

--- a/getgather/mcp/patterns/amainhobbies-signin.html
+++ b/getgather/mcp/patterns/amainhobbies-signin.html
@@ -8,10 +8,17 @@
       autofocus
       name="email"
       type="text"
+      data-testid="email"
       gg-match="input#EmailAddress"
       placeholder="Email Address"
     />
-    <input name="password" type="password" gg-match="input#Password" placeholder="Password" />
-    <button type="submit" gg-match="div.submit button">Login</button>
+    <input
+      name="password"
+      type="password"
+      data-testid="password"
+      gg-match="input#Password"
+      placeholder="Password"
+    />
+    <button type="submit" data-testid="submit" gg-match="div.submit button">Login</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/amazon-approve-notification.html
+++ b/getgather/mcp/patterns/amazon-approve-notification.html
@@ -10,6 +10,6 @@
     </h2>
     <div gg-match-html="#channelDetailsWithImprovedLayout"></div>
     <input type="text" value="submit" name="submit" style="display: none" />
-    <button type="submit">I've done this</button>
+    <button type="submit" data-testid="submit">I've done this</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/amazon-dcq.html
+++ b/getgather/mcp/patterns/amazon-dcq.html
@@ -10,9 +10,14 @@
       name="dcq_question_subjective_1"
       type="text"
       placeholder="Answer"
+      data-testid="answer"
       gg-match="input[name='dcq_question_subjective_1']"
     />
-    <button type="submit" gg-match="span.cvf-widget-btn-verify-dcq input[type=submit]">
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="span.cvf-widget-btn-verify-dcq input[type=submit]"
+    >
       Continue
     </button>
   </body>

--- a/getgather/mcp/patterns/amazon-email-not-found.html
+++ b/getgather/mcp/patterns/amazon-email-not-found.html
@@ -3,7 +3,7 @@
     <p>You do not have an account with this email, please try again with a different email.</p>
     <p gg-match-html="//h1[contains(., 'new to Amazon')]" style="display: none"></p>
     <input gg-match="input[name='email']" name="none" value="none" style="display: none" />
-    <button type="submit" gg-match="a[href*='/ap/signin?']">
+    <button type="submit" data-testid="submit" gg-match="a[href*='/ap/signin?']">
       Sign in with another email or mobile
     </button>
   </body>

--- a/getgather/mcp/patterns/amazon-otp-app.html
+++ b/getgather/mcp/patterns/amazon-otp-app.html
@@ -14,8 +14,15 @@
       type="tel"
       inputmode="numeric"
       placeholder="Enter security code"
+      data-testid="otp"
       gg-match="input#input-box-otp"
     />
-    <button type="submit" gg-match="span#cvf-submit-otp-button input[type=submit]">Verify</button>
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="span#cvf-submit-otp-button input[type=submit]"
+    >
+      Verify
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/amazon-otp-auth.html
+++ b/getgather/mcp/patterns/amazon-otp-auth.html
@@ -9,6 +9,7 @@
       name="otpCode"
       type="tel"
       placeholder="Enter code"
+      data-testid="otp"
       gg-match="input#auth-mfa-otpcode"
     />
     <input
@@ -19,6 +20,8 @@
       gg-match="input#auth-mfa-remember-device"
       style="display: none"
     />
-    <button type="submit" gg-match="input#auth-signin-button[type=submit]">Sign in</button>
+    <button type="submit" data-testid="submit" gg-match="input#auth-signin-button[type=submit]">
+      Sign in
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/amazon-otp-email.html
+++ b/getgather/mcp/patterns/amazon-otp-email.html
@@ -10,8 +10,19 @@
       gg-optional
       gg-match="//div[@id='channelDetailsForOtp']//span[contains(normalize-space(.), 'your email')]"
     ></span>
-    <input autofocus name="otp" type="tel" placeholder="OTP" gg-match="input#input-box-otp" />
-    <button type="submit" gg-match="span#cvf-submit-otp-button input[type=submit]">
+    <input
+      autofocus
+      name="otp"
+      type="tel"
+      placeholder="OTP"
+      data-testid="otp"
+      gg-match="input#input-box-otp"
+    />
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="span#cvf-submit-otp-button input[type=submit]"
+    >
       Submit code
     </button>
   </body>

--- a/getgather/mcp/patterns/amazon-otp-general.html
+++ b/getgather/mcp/patterns/amazon-otp-general.html
@@ -7,7 +7,20 @@
     <span gg-optional gg-match="div#verifyFailureAlerts"></span>
     <h2>Code Verification</h2>
     <span gg-match="div#channelDetailsForOtp"></span>
-    <input autofocus name="otp" type="tel" placeholder="OTP" gg-match="input#input-box-otp" />
-    <button type="submit" gg-match="span#cvf-submit-otp-button input[type=submit]">Submit</button>
+    <input
+      autofocus
+      name="otp"
+      type="tel"
+      placeholder="OTP"
+      data-testid="otp"
+      gg-match="input#input-box-otp"
+    />
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="span#cvf-submit-otp-button input[type=submit]"
+    >
+      Submit
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/amazon-otp-phone.html
+++ b/getgather/mcp/patterns/amazon-otp-phone.html
@@ -9,8 +9,19 @@
     <span
       gg-match="//div[@id='channelDetailsForOtp']//span[contains(normalize-space(.), 'your phone')]"
     ></span>
-    <input autofocus name="otp" type="tel" placeholder="OTP" gg-match="input#input-box-otp" />
-    <button type="submit" gg-match="span#cvf-submit-otp-button input[type=submit]">
+    <input
+      autofocus
+      name="otp"
+      type="tel"
+      placeholder="OTP"
+      data-testid="otp"
+      gg-match="input#input-box-otp"
+    />
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="span#cvf-submit-otp-button input[type=submit]"
+    >
       Submit code
     </button>
   </body>

--- a/getgather/mcp/patterns/amazon-otp-whatsapp.html
+++ b/getgather/mcp/patterns/amazon-otp-whatsapp.html
@@ -9,7 +9,20 @@
       Verify with WhatsApp
     </h2>
     <span gg-match="div#channelDetailsForOtp"></span>
-    <input autofocus name="otp" type="tel" placeholder="OTP" gg-match="input#input-box-otp" />
-    <button type="submit" gg-match="span#cvf-submit-otp-button input[type=submit]">Verify</button>
+    <input
+      autofocus
+      name="otp"
+      type="tel"
+      placeholder="OTP"
+      data-testid="otp"
+      gg-match="input#input-box-otp"
+    />
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="span#cvf-submit-otp-button input[type=submit]"
+    >
+      Verify
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/amazon-signin-email-only-2.html
+++ b/getgather/mcp/patterns/amazon-signin-email-only-2.html
@@ -10,8 +10,11 @@
       name="email"
       type="email"
       placeholder="Email or mobile phone number"
+      data-testid="email"
       gg-match="input#ap_email_login"
     />
-    <button type="submit" gg-match="span#continue input[type=submit]">Continue</button>
+    <button type="submit" data-testid="submit" gg-match="span#continue input[type=submit]">
+      Continue
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/amazon-signin-email-only.html
+++ b/getgather/mcp/patterns/amazon-signin-email-only.html
@@ -12,8 +12,11 @@
       name="email"
       type="email"
       placeholder="Email or mobile phone number"
+      data-testid="email"
       gg-match="input#ap_email"
     />
-    <button type="submit" gg-match="input#continue[type=submit]">Continue</button>
+    <button type="submit" data-testid="submit" gg-match="input#continue[type=submit]">
+      Continue
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/amazon-signin-password-only.html
+++ b/getgather/mcp/patterns/amazon-signin-password-only.html
@@ -15,8 +15,11 @@
       name="password"
       type="password"
       placeholder="Password"
+      data-testid="password"
       gg-match="input#ap_password"
     />
-    <button type="submit" gg-match="input#signInSubmit[type=submit]">Sign in</button>
+    <button type="submit" data-testid="submit" gg-match="input#signInSubmit[type=submit]">
+      Sign in
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/amazon-signin.html
+++ b/getgather/mcp/patterns/amazon-signin.html
@@ -11,9 +11,18 @@
       name="email"
       type="email"
       placeholder="Email or mobile phone number"
+      data-testid="email"
       gg-match="//input[@id='ap_email' and not(@type='hidden')]"
     />
-    <input name="password" type="password" placeholder="Password" gg-match="input#ap_password" />
-    <button type="submit" gg-match="input#signInSubmit[type=submit]">Sign in</button>
+    <input
+      name="password"
+      type="password"
+      placeholder="Password"
+      data-testid="password"
+      gg-match="input#ap_password"
+    />
+    <button type="submit" data-testid="submit" gg-match="input#signInSubmit[type=submit]">
+      Sign in
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/amazon-verification-01.html
+++ b/getgather/mcp/patterns/amazon-verification-01.html
@@ -15,8 +15,9 @@
       name="otpCode"
       type="tel"
       placeholder="Enter code"
+      data-testid="otp"
       gg-match="input#cvf-input-code"
     />
-    <button type="submit" gg-match="input[type=submit]">Sign in</button>
+    <button type="submit" data-testid="submit" gg-match="input[type=submit]">Sign in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/amazon-verification-02.html
+++ b/getgather/mcp/patterns/amazon-verification-02.html
@@ -15,8 +15,9 @@
       name="otpCode"
       type="tel"
       placeholder="Enter code"
+      data-testid="otp"
       gg-match="input[name='code']"
     />
-    <button type="submit" gg-match="input[type=submit]">Sign in</button>
+    <button type="submit" data-testid="submit" gg-match="input[type=submit]">Sign in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/amazon-zen-otp-app-approval.html
+++ b/getgather/mcp/patterns/amazon-zen-otp-app-approval.html
@@ -5,7 +5,20 @@
   <body>
     <span gg-optional gg-match="div#verifyAlerts"></span>
     <span gg-match="//span[contains(., 'Open your Amazon shopping app')]"></span>
-    <input autofocus name="otpCode" type="tel" placeholder="OTP" gg-match="input#input-box-otp" />
-    <button type="submit" gg-match="span#cvf-submit-otp-button input[type=submit]">Verify</button>
+    <input
+      autofocus
+      name="otpCode"
+      type="tel"
+      placeholder="OTP"
+      data-testid="otp"
+      gg-match="input#input-box-otp"
+    />
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="span#cvf-submit-otp-button input[type=submit]"
+    >
+      Verify
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/amazon-zen-otp-auth.html
+++ b/getgather/mcp/patterns/amazon-zen-otp-auth.html
@@ -9,6 +9,7 @@
       name="otpCode"
       type="tel"
       placeholder="Enter code"
+      data-testid="otp"
       gg-match="input#auth-mfa-otpcode"
     />
     <input
@@ -19,6 +20,8 @@
       gg-match="input#auth-mfa-remember-device"
       style="display: none"
     />
-    <button type="submit" gg-match="input#auth-signin-button[type=submit]">Sign in</button>
+    <button type="submit" data-testid="submit" gg-match="input#auth-signin-button[type=submit]">
+      Sign in
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/amazon-zen-otp-email.html
+++ b/getgather/mcp/patterns/amazon-zen-otp-email.html
@@ -7,8 +7,19 @@
     <span gg-optional gg-match="div#verifyFailureAlerts"></span>
     <h2 gg-match="//h2[contains(., 'Enter verification code')]">Enter verification code</h2>
     <span gg-optional gg-match="//span[contains(., 'your email')]"></span>
-    <input autofocus name="otp" type="tel" placeholder="OTP" gg-match="input#input-box-otp" />
-    <button type="submit" gg-match="span#cvf-submit-otp-button input[type=submit]">
+    <input
+      autofocus
+      name="otp"
+      type="tel"
+      placeholder="OTP"
+      data-testid="otp"
+      gg-match="input#input-box-otp"
+    />
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="span#cvf-submit-otp-button input[type=submit]"
+    >
       Submit code
     </button>
   </body>

--- a/getgather/mcp/patterns/amazon-zen-otp-phone.html
+++ b/getgather/mcp/patterns/amazon-zen-otp-phone.html
@@ -9,8 +9,19 @@
     <span
       gg-match="//div[@id='channelDetailsForOtp']//span[contains(normalize-space(.), 'your phone')]"
     ></span>
-    <input autofocus name="otp" type="tel" placeholder="OTP" gg-match="input#input-box-otp" />
-    <button type="submit" gg-match="span#cvf-submit-otp-button input[type=submit]">
+    <input
+      autofocus
+      name="otp"
+      type="tel"
+      placeholder="OTP"
+      data-testid="otp"
+      gg-match="input#input-box-otp"
+    />
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="span#cvf-submit-otp-button input[type=submit]"
+    >
       Submit code
     </button>
   </body>

--- a/getgather/mcp/patterns/amazon-zip-code-required.html
+++ b/getgather/mcp/patterns/amazon-zip-code-required.html
@@ -7,7 +7,7 @@
     <p gg-match-html="//p[contains(normalize-space(.), 'ZIP code')]"></p>
 
     <label>ZIP code</label>
-    <input gg-match="#ap_zip" type="text" name="zipCode" />
-    <button gg-match="#continue" type="submit">Continue</button>
+    <input data-testid="zip-code" gg-match="#ap_zip" type="text" name="zipCode" />
+    <button data-testid="submit" gg-match="#continue" type="submit">Continue</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/americanairlines-otp.html
+++ b/getgather/mcp/patterns/americanairlines-otp.html
@@ -16,41 +16,49 @@
         name="otp-1"
         type="text"
         inputmode="numeric"
+        data-testid="otp-0"
         gg-match="div[class*='_otpinputgroup_'] adc-text-input:nth-of-type(1)"
       />
       <input
         name="otp-2"
         type="text"
         inputmode="numeric"
+        data-testid="otp-1"
         gg-match="div[class*='_otpinputgroup_'] adc-text-input:nth-of-type(2)"
       />
       <input
         name="otp-3"
         type="text"
         inputmode="numeric"
+        data-testid="otp-2"
         gg-match="div[class*='_otpinputgroup_'] adc-text-input:nth-of-type(3)"
       />
       <input
         name="otp-4"
         type="text"
         inputmode="numeric"
+        data-testid="otp-3"
         gg-match="div[class*='_otpinputgroup_'] adc-text-input:nth-of-type(4)"
       />
       <input
         name="otp-5"
         type="text"
         inputmode="numeric"
+        data-testid="otp-4"
         gg-match="div[class*='_otpinputgroup_'] adc-text-input:nth-of-type(5)"
       />
       <input
         name="otp-6"
         type="text"
         inputmode="numeric"
+        data-testid="otp-5"
         gg-match="div[class*='_otpinputgroup_'] adc-text-input:nth-of-type(6)"
       />
     </div>
 
-    <button type="submit" gg-match="div[class*='_verify_'] adc-button">Verify</button>
+    <button type="submit" data-testid="submit" gg-match="div[class*='_verify_'] adc-button">
+      Verify
+    </button>
     <style>
       .otp-container {
         display: flex;

--- a/getgather/mcp/patterns/americanairlines-signin.html
+++ b/getgather/mcp/patterns/americanairlines-signin.html
@@ -11,16 +11,18 @@
     <p gg-optional gg-match="adc-inline-notification[role='alert'][kind='error']"></p>
     <input
       type="text"
+      data-testid="email"
       gg-match="adc-text-input[name='username']"
       placeholder="AAdvantage® # or username"
       name="username"
     />
     <input
       type="password"
+      data-testid="password"
       gg-match="adc-text-input[name='password']"
       placeholder="Password"
       name="password"
     />
-    <button type="submit" gg-match="div.loginButton adc-button">Log in</button>
+    <button type="submit" data-testid="submit" gg-match="div.loginButton adc-button">Log in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/americanairlines-signin.html
+++ b/getgather/mcp/patterns/americanairlines-signin.html
@@ -11,7 +11,7 @@
     <p gg-optional gg-match="adc-inline-notification[role='alert'][kind='error']"></p>
     <input
       type="text"
-      data-testid="email"
+      data-testid="username"
       gg-match="adc-text-input[name='username']"
       placeholder="AAdvantage® # or username"
       name="username"

--- a/getgather/mcp/patterns/ashley-login.html
+++ b/getgather/mcp/patterns/ashley-login.html
@@ -4,8 +4,22 @@
   </head>
   <body>
     <p gg-optional gg-match="div.notification.error"></p>
-    <input type="email" name="email" placeholder="email" gg-match="input#email" />
-    <input type="password" name="password" placeholder="password" gg-match="input#password" />
-    <button type="submit" gg-match="form#login-form button[type=submit]">Log in</button>
+    <input
+      type="email"
+      name="email"
+      placeholder="email"
+      data-testid="email"
+      gg-match="input#email"
+    />
+    <input
+      type="password"
+      name="password"
+      placeholder="password"
+      data-testid="password"
+      gg-match="input#password"
+    />
+    <button type="submit" data-testid="submit" gg-match="form#login-form button[type=submit]">
+      Log in
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/bbc-signin-email.html
+++ b/getgather/mcp/patterns/bbc-signin-email.html
@@ -5,7 +5,14 @@
   <body>
     <p gg-optional gg-match="p.sb-form-message__content__text"></p>
     <label gg-optional gg-match="label#username-label">Email</label>
-    <input autofocus name="email" type="email" placeholder="Email" gg-match="input#username" />
-    <button type="submit" gg-match="button[type=submit]">Sign in</button>
+    <input
+      autofocus
+      name="email"
+      type="email"
+      placeholder="Email"
+      data-testid="email"
+      gg-match="input#username"
+    />
+    <button type="submit" data-testid="submit" gg-match="button[type=submit]">Sign in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/bbc-signin-email.html
+++ b/getgather/mcp/patterns/bbc-signin-email.html
@@ -10,7 +10,7 @@
       name="email"
       type="email"
       placeholder="Email"
-      data-testid="email"
+      data-testid="username"
       gg-match="input#username"
     />
     <button type="submit" data-testid="submit" gg-match="button[type=submit]">Sign in</button>

--- a/getgather/mcp/patterns/bbc-signin-password.html
+++ b/getgather/mcp/patterns/bbc-signin-password.html
@@ -11,8 +11,11 @@
       name="password"
       type="password"
       placeholder="Password"
+      data-testid="password"
       gg-match="input[type=password]"
     />
-    <button type="submit" gg-match="form[novalidate] [type=submit]">Sign in</button>
+    <button type="submit" data-testid="submit" gg-match="form[novalidate] [type=submit]">
+      Sign in
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/bedbathandbeyond-signin.html
+++ b/getgather/mcp/patterns/bedbathandbeyond-signin.html
@@ -7,8 +7,22 @@
       gg-optional
       gg-match="//div[contains(@class, 'gq') and contains(., 'Email and/or password incorrect')]"
     ></p>
-    <input type="email" gg-match="input#login-email" placeholder="Email" name="email" />
-    <input type="password" gg-match="input#login-password" placeholder="Password" name="password" />
-    <button type="submit" gg-match="form#login-form button[type=submit]">Sign In</button>
+    <input
+      type="email"
+      data-testid="email"
+      gg-match="input#login-email"
+      placeholder="Email"
+      name="email"
+    />
+    <input
+      type="password"
+      data-testid="password"
+      gg-match="input#login-password"
+      placeholder="Password"
+      name="password"
+    />
+    <button type="submit" data-testid="submit" gg-match="form#login-form button[type=submit]">
+      Sign In
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/bestbuy-mfa-choices.html
+++ b/getgather/mcp/patterns/bestbuy-mfa-choices.html
@@ -11,6 +11,7 @@
           type="radio"
           name="signin-option-radio"
           id="password-radio"
+          data-testid="signin-method-password"
           gg-match="input#password-radio"
           value="password-radio"
           checked
@@ -23,6 +24,7 @@
           type="radio"
           name="signin-option-radio"
           id="email-code-radio"
+          data-testid="signin-method-email"
           gg-match="input#email-code-radio"
           value="email-code-radio"
         />
@@ -36,12 +38,13 @@
           type="radio"
           name="signin-option-radio"
           id="sms-radio"
+          data-testid="signin-method-sms"
           gg-match="input#sms-radio"
           value="sms-radio"
         />
         <label gg-optional for="sms-radio" gg-match="label[for=sms-radio]">Use email link</label>
       </div>
     </div>
-    <button type="submit" gg-match="button[type=submit]">Continue</button>
+    <button type="submit" data-testid="submit" gg-match="button[type=submit]">Continue</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/bestbuy-signin-email.html
+++ b/getgather/mcp/patterns/bestbuy-signin-email.html
@@ -3,7 +3,14 @@
     <title>Best Buy Sign In</title>
   </head>
   <body>
-    <input autofocus name="email" type="email" placeholder="Email" gg-match="input[type=email]" />
-    <button type="submit" gg-match="button[type=submit]">Continue</button>
+    <input
+      autofocus
+      name="email"
+      type="email"
+      placeholder="Email"
+      data-testid="email"
+      gg-match="input[type=email]"
+    />
+    <button type="submit" data-testid="submit" gg-match="button[type=submit]">Continue</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/bestbuy-signin-password.html
+++ b/getgather/mcp/patterns/bestbuy-signin-password.html
@@ -10,8 +10,11 @@
       name="password"
       type="password"
       placeholder="Password"
+      data-testid="password"
       gg-match="input[type=password]"
     />
-    <button type="submit" gg-match="form[novalidate] [type=submit]">Sign in</button>
+    <button type="submit" data-testid="submit" gg-match="form[novalidate] [type=submit]">
+      Sign in
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/bestbuy-verification-code.html
+++ b/getgather/mcp/patterns/bestbuy-verification-code.html
@@ -12,8 +12,9 @@
       type="text"
       inputmode="numeric"
       placeholder="Verification Code"
+      data-testid="otp"
       gg-match="input#verificationCode"
     />
-    <button type="submit" gg-match="button[type=submit]">Confirm</button>
+    <button type="submit" data-testid="submit" gg-match="button[type=submit]">Confirm</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/blinds-signin.html
+++ b/getgather/mcp/patterns/blinds-signin.html
@@ -8,6 +8,7 @@
       autofocus
       name="email"
       type="email"
+      data-testid="email"
       gg-match="div#sign-in-sign-up-content-wrapper input#login-email"
       placeholder="Email Address"
     />
@@ -15,11 +16,13 @@
       password
       name="password"
       type="password"
+      data-testid="password"
       gg-match="div#sign-in-sign-up-content-wrapper input#login-password"
       placeholder="Password"
     />
     <button
       type="submit"
+      data-testid="submit"
       gg-match="div#sign-in-sign-up-content-wrapper button[data-test-id='my-account-login-button']:not([disabled])"
     >
       Login to My Account

--- a/getgather/mcp/patterns/blindster-signin.html
+++ b/getgather/mcp/patterns/blindster-signin.html
@@ -9,6 +9,7 @@
       autofocus
       name="email"
       type="email"
+      data-testid="email"
       gg-match="input#username"
       placeholder="Email Address"
     />
@@ -16,10 +17,15 @@
       password
       name="password"
       type="password"
+      data-testid="password"
       gg-match="input#password"
       placeholder="Password"
     />
-    <button type="submit" gg-match="form[class='w-full'] div > button[type='submit']">
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="form[class='w-full'] div > button[type='submit']"
+    >
       Login to My Account
     </button>
   </body>

--- a/getgather/mcp/patterns/blindster-signin.html
+++ b/getgather/mcp/patterns/blindster-signin.html
@@ -9,7 +9,7 @@
       autofocus
       name="email"
       type="email"
-      data-testid="email"
+      data-testid="username"
       gg-match="input#username"
       placeholder="Email Address"
     />

--- a/getgather/mcp/patterns/booking-signin-otp.html
+++ b/getgather/mcp/patterns/booking-signin-otp.html
@@ -12,15 +12,48 @@
         name="otp-1"
         type="text"
         inputmode="numeric"
+        data-testid="otp-0"
         gg-match="input[name='code_0']"
       />
-      <input name="otp-2" type="text" inputmode="numeric" gg-match="input[name='code_1']" />
-      <input name="otp-3" type="text" inputmode="numeric" gg-match="input[name='code_2']" />
-      <input name="otp-4" type="text" inputmode="numeric" gg-match="input[name='code_3']" />
-      <input name="otp-5" type="text" inputmode="numeric" gg-match="input[name='code_4']" />
-      <input name="otp-6" type="text" inputmode="numeric" gg-match="input[name='code_5']" />
+      <input
+        name="otp-2"
+        type="text"
+        inputmode="numeric"
+        data-testid="otp-1"
+        gg-match="input[name='code_1']"
+      />
+      <input
+        name="otp-3"
+        type="text"
+        inputmode="numeric"
+        data-testid="otp-2"
+        gg-match="input[name='code_2']"
+      />
+      <input
+        name="otp-4"
+        type="text"
+        inputmode="numeric"
+        data-testid="otp-3"
+        gg-match="input[name='code_3']"
+      />
+      <input
+        name="otp-5"
+        type="text"
+        inputmode="numeric"
+        data-testid="otp-4"
+        gg-match="input[name='code_4']"
+      />
+      <input
+        name="otp-6"
+        type="text"
+        inputmode="numeric"
+        data-testid="otp-5"
+        gg-match="input[name='code_5']"
+      />
     </div>
-    <button type="submit" gg-match="form button[type='submit']">Verify email</button>
+    <button type="submit" data-testid="submit" gg-match="form button[type='submit']">
+      Verify email
+    </button>
 
     <style>
       .otp-container {

--- a/getgather/mcp/patterns/booking-signin.html
+++ b/getgather/mcp/patterns/booking-signin.html
@@ -9,8 +9,11 @@
       placeholder="Email"
       name="email"
       type="email"
+      data-testid="email"
       gg-match="div:not(.app--loading) form input#username"
     />
-    <button type="submit" gg-match="form button[type='submit'] span">Continue</button>
+    <button type="submit" data-testid="submit" gg-match="form button[type='submit'] span">
+      Continue
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/booking-signin.html
+++ b/getgather/mcp/patterns/booking-signin.html
@@ -9,7 +9,7 @@
       placeholder="Email"
       name="email"
       type="email"
-      data-testid="email"
+      data-testid="username"
       gg-match="div:not(.app--loading) form input#username"
     />
     <button type="submit" data-testid="submit" gg-match="form button[type='submit'] span">

--- a/getgather/mcp/patterns/chewy-email-not-found.html
+++ b/getgather/mcp/patterns/chewy-email-not-found.html
@@ -5,6 +5,6 @@
       "Cancel" to go back to the previous page.
     </p>
     <input gg-match="input#fullName" name="none" value="none" style="display: none" />
-    <button type="submit" gg-match="a#register-cancel-button">Cancel</button>
+    <button type="submit" data-testid="submit" gg-match="a#register-cancel-button">Cancel</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/chewy-password.html
+++ b/getgather/mcp/patterns/chewy-password.html
@@ -8,6 +8,7 @@
       autofocus
       name="password"
       type="password"
+      data-testid="password"
       gg-match="input#password"
       placeholder="Password"
     />

--- a/getgather/mcp/patterns/chewy-signin.html
+++ b/getgather/mcp/patterns/chewy-signin.html
@@ -3,7 +3,14 @@
     <title>Chewy Sign In</title>
   </head>
   <body>
-    <input out name="email" type="email" gg-match="input#username" placeholder="Email" />
-    <button type="submit" gg-match="button#kc-login">Continue</button>
+    <input
+      out
+      name="email"
+      type="email"
+      data-testid="email"
+      gg-match="input#username"
+      placeholder="Email"
+    />
+    <button type="submit" data-testid="submit" gg-match="button#kc-login">Continue</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/chewy-signin.html
+++ b/getgather/mcp/patterns/chewy-signin.html
@@ -7,7 +7,7 @@
       out
       name="email"
       type="email"
-      data-testid="email"
+      data-testid="username"
       gg-match="input#username"
       placeholder="Email"
     />

--- a/getgather/mcp/patterns/cnn-signin.html
+++ b/getgather/mcp/patterns/cnn-signin.html
@@ -8,14 +8,22 @@
       name="loginEmail"
       type="email"
       placeholder="Email"
+      data-testid="email"
       gg-match="input#login-email-input"
     />
     <input
       name="loginPassword"
       type="password"
       placeholder="Password"
+      data-testid="password"
       gg-match="input#login-password-input"
     />
-    <button type="submit" gg-match="button[type=submit]:not([aria-disabled=true])">Sign in</button>
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="button[type=submit]:not([aria-disabled=true])"
+    >
+      Sign in
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/containerstore-login.html
+++ b/getgather/mcp/patterns/containerstore-login.html
@@ -1,9 +1,26 @@
 <html gg-domain="containerstore" priority="2">
   <body>
     <p gg-optional gg-match="div.error"></p>
-    <input autofocus name="email" type="email" gg-match="input#signInName" placeholder="Email" />
-    <input name="password" type="password" gg-match="input#password" placeholder="Password" />
-    <button type="submit" gg-match="//button[@id='next' and contains(text(), 'Sign in')]">
+    <input
+      autofocus
+      name="email"
+      type="email"
+      data-testid="email"
+      gg-match="input#signInName"
+      placeholder="Email"
+    />
+    <input
+      name="password"
+      type="password"
+      data-testid="password"
+      gg-match="input#password"
+      placeholder="Password"
+    />
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="//button[@id='next' and contains(text(), 'Sign in')]"
+    >
       Sign in
     </button>
   </body>

--- a/getgather/mcp/patterns/containerstore-login.html
+++ b/getgather/mcp/patterns/containerstore-login.html
@@ -5,7 +5,7 @@
       autofocus
       name="email"
       type="email"
-      data-testid="email"
+      data-testid="username"
       gg-match="input#signInName"
       placeholder="Email"
     />

--- a/getgather/mcp/patterns/delta-home-signin-dialog.html
+++ b/getgather/mcp/patterns/delta-home-signin-dialog.html
@@ -7,9 +7,18 @@
       placeholder="SkyMiles Number Or Username"
       name="userid"
       type="text"
+      data-testid="email"
       gg-match="input#userId"
     />
-    <input placeholder="Password" name="password" type="password" gg-match="input#password" />
-    <button type="submit" gg-match="button[data-cy='idp-button-Log In']">Log In</button>
+    <input
+      placeholder="Password"
+      name="password"
+      type="password"
+      data-testid="password"
+      gg-match="input#password"
+    />
+    <button type="submit" data-testid="submit" gg-match="button[data-cy='idp-button-Log In']">
+      Log In
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/delta-home-signin-dialog.html
+++ b/getgather/mcp/patterns/delta-home-signin-dialog.html
@@ -7,7 +7,7 @@
       placeholder="SkyMiles Number Or Username"
       name="userid"
       type="text"
-      data-testid="email"
+      data-testid="username"
       gg-match="input#userId"
     />
     <input

--- a/getgather/mcp/patterns/doordash-signin-email-password.html
+++ b/getgather/mcp/patterns/doordash-signin-email-password.html
@@ -8,6 +8,7 @@
       name="email"
       type="email"
       placeholder="Email"
+      data-testid="email"
       gg-match="form#guided-email-password-form input[type=email]"
     />
     <input
@@ -15,9 +16,12 @@
       name="password"
       type="password"
       placeholder="Password"
+      data-testid="password"
       gg-match="form#guided-email-password-form input[type=password]"
     />
-    <button type="submit" gg-match="button#login-submit-button">Continue to sign in</button>
+    <button type="submit" data-testid="submit" gg-match="button#login-submit-button">
+      Continue to sign in
+    </button>
     <p
       id="error"
       style="color: red"

--- a/getgather/mcp/patterns/doordash-signin-email.html
+++ b/getgather/mcp/patterns/doordash-signin-email.html
@@ -8,9 +8,12 @@
       name="email"
       type="email"
       placeholder="Email"
+      data-testid="email"
       gg-match="form#login-form-guided-email input[type=email]"
     />
-    <button type="submit" gg-match="button#guided-submit-button">Continue to sign in</button>
+    <button type="submit" data-testid="submit" gg-match="button#guided-submit-button">
+      Continue to sign in
+    </button>
     <p
       id="error"
       style="color: red"

--- a/getgather/mcp/patterns/doordash-signin-otc.html
+++ b/getgather/mcp/patterns/doordash-signin-otc.html
@@ -30,6 +30,7 @@
         inputmode="numeric"
         pattern="[0-9]"
         maxlength="1"
+        data-testid="otp-0"
         gg-match="form#otc-submit-form input[type=number][aria-label='0']"
         value="0"
       />
@@ -40,6 +41,7 @@
         inputmode="numeric"
         pattern="[0-9]"
         maxlength="1"
+        data-testid="otp-1"
         gg-match="form#otc-submit-form input[type=number][aria-label='1']"
         value="0"
       />
@@ -50,6 +52,7 @@
         inputmode="numeric"
         pattern="[0-9]"
         maxlength="1"
+        data-testid="otp-2"
         gg-match="form#otc-submit-form input[type=number][aria-label='2']"
         value="0"
       />
@@ -60,6 +63,7 @@
         inputmode="numeric"
         pattern="[0-9]"
         maxlength="1"
+        data-testid="otp-3"
         gg-match="form#otc-submit-form input[type=number][aria-label='3']"
         value="0"
       />
@@ -70,6 +74,7 @@
         inputmode="numeric"
         pattern="[0-9]"
         maxlength="1"
+        data-testid="otp-4"
         gg-match="form#otc-submit-form input[type=number][aria-label='4']"
         value="0"
       />
@@ -80,6 +85,7 @@
         inputmode="numeric"
         pattern="[0-9]"
         maxlength="1"
+        data-testid="otp-5"
         gg-match="form#otc-submit-form input[type=number][aria-label='5']"
         value="0"
       />
@@ -115,6 +121,6 @@
       gg-optional
       gg-match="form#otc-submit-form span:nth-child(5)"
     />
-    <button type="submit" gg-match="button#otc-submit-button">Sign in</button>
+    <button type="submit" data-testid="submit" gg-match="button#otc-submit-button">Sign in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/doordash-signin-password.html
+++ b/getgather/mcp/patterns/doordash-signin-password.html
@@ -9,9 +9,12 @@
       name="password"
       type="password"
       placeholder="Password"
+      data-testid="password"
       gg-match="form#login-form input[type=password]"
     />
-    <button type="submit" gg-match="button#login-submit-button">Sign in</button>
+    <button type="submit" data-testid="submit" gg-match="button#login-submit-button">
+      Sign in
+    </button>
     <p
       id="error"
       style="color: red"

--- a/getgather/mcp/patterns/doordash-signin-phonenumber.html
+++ b/getgather/mcp/patterns/doordash-signin-phonenumber.html
@@ -14,6 +14,7 @@
       name="phonenumber"
       type="tel"
       placeholder="Phone Number"
+      data-testid="phone"
       gg-match="form#guided-email-phone-form input[type=tel]"
     />
 
@@ -26,6 +27,7 @@
 
     <button
       type="submit"
+      data-testid="submit"
       gg-match="//form[@id='guided-email-phone-form']//button[normalize-space(.)='Continue']"
     >
       Continue

--- a/getgather/mcp/patterns/ebay-signin-password.html
+++ b/getgather/mcp/patterns/ebay-signin-password.html
@@ -4,7 +4,14 @@
   </head>
   <body>
     <p gg-optional gg-match="p#signin-error-msg"></p>
-    <input autofocus name="pass" type="password" gg-match="input#pass" placeholder="Password" />
-    <button type="submit" gg-match="//button[@id='sgnBt']">Sign in</button>
+    <input
+      autofocus
+      name="pass"
+      type="password"
+      data-testid="password"
+      gg-match="input#pass"
+      placeholder="Password"
+    />
+    <button type="submit" data-testid="submit" gg-match="//button[@id='sgnBt']">Sign in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/ebay-signin.html
+++ b/getgather/mcp/patterns/ebay-signin.html
@@ -9,6 +9,7 @@
       autofocus
       name="userid"
       type="text"
+      data-testid="email"
       gg-match="input#userid"
       placeholder="Email or username"
     />

--- a/getgather/mcp/patterns/ebay-signin.html
+++ b/getgather/mcp/patterns/ebay-signin.html
@@ -9,7 +9,7 @@
       autofocus
       name="userid"
       type="text"
-      data-testid="email"
+      data-testid="username"
       gg-match="input#userid"
       placeholder="Email or username"
     />

--- a/getgather/mcp/patterns/ebird-signi-2.html
+++ b/getgather/mcp/patterns/ebird-signi-2.html
@@ -10,9 +10,16 @@
       placeholder="Email"
       name="username"
       type="text"
+      data-testid="email"
       gg-match="input#input-user-name"
     />
-    <input placeholder="Password" name="password" type="password" gg-match="input#input-password" />
-    <button type="submit" gg-match="input#form-submit">Sign in</button>
+    <input
+      placeholder="Password"
+      name="password"
+      type="password"
+      data-testid="password"
+      gg-match="input#input-password"
+    />
+    <button type="submit" data-testid="submit" gg-match="input#form-submit">Sign in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/ebird-signi-2.html
+++ b/getgather/mcp/patterns/ebird-signi-2.html
@@ -10,7 +10,7 @@
       placeholder="Email"
       name="username"
       type="text"
-      data-testid="email"
+      data-testid="username"
       gg-match="input#input-user-name"
     />
     <input

--- a/getgather/mcp/patterns/ebird-signin.html
+++ b/getgather/mcp/patterns/ebird-signin.html
@@ -10,9 +10,16 @@
       placeholder="Email"
       name="username"
       type="text"
+      data-testid="email"
       gg-match="input#input-user-name"
     />
-    <input placeholder="Password" name="password" type="password" gg-match="input#input-password" />
+    <input
+      placeholder="Password"
+      name="password"
+      type="password"
+      data-testid="password"
+      gg-match="input#input-password"
+    />
     <button gg-autoclick gg-match="input#form-submit">Sign in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/ebird-signin.html
+++ b/getgather/mcp/patterns/ebird-signin.html
@@ -10,7 +10,7 @@
       placeholder="Email"
       name="username"
       type="text"
-      data-testid="email"
+      data-testid="username"
       gg-match="input#input-user-name"
     />
     <input

--- a/getgather/mcp/patterns/expedia-signin-code.html
+++ b/getgather/mcp/patterns/expedia-signin-code.html
@@ -9,9 +9,14 @@
       type="text"
       name="code"
       autofocus
+      data-testid="otp"
       gg-match="input#verify-sms-one-time-passcode-input"
     />
-    <button type="submit" gg-match="button#verifyOtpFormSubmitButton:not([disabled])">
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="button#verifyOtpFormSubmitButton:not([disabled])"
+    >
       Continue
     </button>
   </body>

--- a/getgather/mcp/patterns/expedia-signin.html
+++ b/getgather/mcp/patterns/expedia-signin.html
@@ -9,8 +9,15 @@
       placeholder="Email"
       type="text"
       name="loginFormEmailInput"
+      data-testid="email"
       gg-match="input#loginFormEmailInput"
     />
-    <button type="submit" gg-match="button#loginFormSubmitButton:not([disabled])">Continue</button>
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="button#loginFormSubmitButton:not([disabled])"
+    >
+      Continue
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/garmin-signin.html
+++ b/getgather/mcp/patterns/garmin-signin.html
@@ -9,14 +9,16 @@
       name="email"
       type="email"
       placeholder="Email Address"
+      data-testid="email"
       gg-match="input#email[name='email'][type='email']"
     />
     <input
       name="password"
       type="password"
       placeholder="Password"
+      data-testid="password"
       gg-match="input#password[name='password'][type='password']"
     />
-    <button type="submit" gg-match="button[type='submit']">Sign In</button>
+    <button type="submit" data-testid="submit" gg-match="button[type='submit']">Sign In</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/gofood-login.html
+++ b/getgather/mcp/patterns/gofood-login.html
@@ -10,10 +10,11 @@
       <input
         type="tel"
         name="phone"
+        data-testid="phone"
         gg-match="input[data-testid='phone-number-field']"
         placeholder="Phone number"
       />
     </div>
-    <button type="submit" gg-match="button[type=submit]">Continue</button>
+    <button type="submit" data-testid="submit" gg-match="button[type=submit]">Continue</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/gofood-otp.html
+++ b/getgather/mcp/patterns/gofood-otp.html
@@ -8,8 +8,14 @@
     <p gg-optional gg-match="//p[contains(text(), 'Invalid verification code')]"></p>
     <div class="otp-input">
       <label gg-match="p.gf-label-m">Enter code</label>
-      <input name="otp" type="tel" gg-match="input[name='data.otp']" placeholder="4-digit OTP" />
+      <input
+        name="otp"
+        type="tel"
+        data-testid="otp"
+        gg-match="input[name='data.otp']"
+        placeholder="4-digit OTP"
+      />
     </div>
-    <button type="submit" gg-match="button[type=submit]">Continue</button>
+    <button type="submit" data-testid="submit" gg-match="button[type=submit]">Continue</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/gofood-select-signin.html
+++ b/getgather/mcp/patterns/gofood-select-signin.html
@@ -5,7 +5,9 @@
   <body>
     <div class="signin-options">
       <div gg-autoclick gg-match="button.bg-gf-interactive-fill-brand-default">Log in</div>
-      <button gg-match="button.bg-gf-interactive-fill-alternate">I'm new, sign me up!</button>
+      <button data-testid="submit" gg-match="button.bg-gf-interactive-fill-alternate">
+        I'm new, sign me up!
+      </button>
     </div>
   </body>
 </html>

--- a/getgather/mcp/patterns/goodreads-signin.html
+++ b/getgather/mcp/patterns/goodreads-signin.html
@@ -4,8 +4,21 @@
   </head>
   <body>
     <p gg-optional gg-match="div[aria-live] .a-alert-content"></p>
-    <input autofocus name="email" type="email" placeholder="Email" gg-match="input[type=email]" />
-    <input name="password" type="password" placeholder="Password" gg-match="input[type=password]" />
+    <input
+      autofocus
+      name="email"
+      type="email"
+      placeholder="Email"
+      data-testid="email"
+      gg-match="input[type=email]"
+    />
+    <input
+      name="password"
+      type="password"
+      placeholder="Password"
+      data-testid="password"
+      gg-match="input[type=password]"
+    />
     <input
       name="remember"
       type="checkbox"
@@ -13,6 +26,6 @@
       gg-match="input[name=rememberMe]"
       style="display: none"
     />
-    <button type="submit" gg-match="input[type=submit]">Sign in</button>
+    <button type="submit" data-testid="submit" gg-match="input[type=submit]">Sign in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/google-signin-2fa-authenticator-wrong-code.html
+++ b/getgather/mcp/patterns/google-signin-2fa-authenticator-wrong-code.html
@@ -8,10 +8,13 @@
       autofocus
       name="totpPin"
       type="tel"
+      data-testid="otp"
       gg-match="input[name='totpPin']"
       placeholder="Enter code"
       aria-label="Enter code"
     />
-    <button type="submit" gg-match="#totpNext button:not([disabled])">Next</button>
+    <button type="submit" data-testid="submit" gg-match="#totpNext button:not([disabled])">
+      Next
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/google-signin-2fa-authenticator.html
+++ b/getgather/mcp/patterns/google-signin-2fa-authenticator.html
@@ -10,10 +10,13 @@
       autofocus
       name="totpPin"
       type="tel"
+      data-testid="otp"
       gg-match="input[name='totpPin']"
       placeholder="Enter code"
       aria-label="Enter code"
     />
-    <button type="submit" gg-match="#totpNext button:not([disabled])">Next</button>
+    <button type="submit" data-testid="submit" gg-match="#totpNext button:not([disabled])">
+      Next
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/google-signin-2fa-sms.html
+++ b/getgather/mcp/patterns/google-signin-2fa-sms.html
@@ -10,6 +10,7 @@
       autofocus
       name="Pin"
       type="tel"
+      data-testid="otp"
       gg-match="input#idvPin"
       placeholder="Enter the code"
       aria-label="Enter the code"

--- a/getgather/mcp/patterns/google-signin-2fa-wait.html
+++ b/getgather/mcp/patterns/google-signin-2fa-wait.html
@@ -8,6 +8,6 @@
     ></div>
 
     <input type="text" value="submit" name="submit" style="display: none" />
-    <button type="submit">I've done this</button>
+    <button type="submit" data-testid="submit">I've done this</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/google-signin-check-device.html
+++ b/getgather/mcp/patterns/google-signin-check-device.html
@@ -6,6 +6,8 @@
   <body>
     <header gg-match="header.vYeFie"></header>
     <input type="text" value="submit" name="submit" style="display: none" />
-    <button type="submit" gg-match="button[jsname='ponBce']">Try another way</button>
+    <button type="submit" data-testid="submit" gg-match="button[jsname='ponBce']">
+      Try another way
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/google-signin-email-notfound.html
+++ b/getgather/mcp/patterns/google-signin-email-notfound.html
@@ -1,10 +1,17 @@
 <html gg-domain="google" gg-priority="-2">
   <body>
-    <input autofocus placeholder="Email" gg-match="input#identifierId" type="email" name="email" />
+    <input
+      autofocus
+      placeholder="Email"
+      data-testid="email"
+      gg-match="input#identifierId"
+      type="email"
+      name="email"
+    />
     <div
       gg-match="//div[@jsname='B34EJ'][contains(., 'find your Google Account')]"
       style="color: red; font-size: 12px"
     ></div>
-    <button type="submit" gg-match="div#identifierNext">Next</button>
+    <button type="submit" data-testid="submit" gg-match="div#identifierNext">Next</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/google-signin-email-notfound.html
+++ b/getgather/mcp/patterns/google-signin-email-notfound.html
@@ -3,7 +3,7 @@
     <input
       autofocus
       placeholder="Email"
-      data-testid="email"
+      data-testid="username"
       gg-match="input#identifierId"
       type="email"
       name="email"

--- a/getgather/mcp/patterns/google-signin-email.html
+++ b/getgather/mcp/patterns/google-signin-email.html
@@ -3,7 +3,14 @@
     <title>Google Activity</title>
   </head>
   <body>
-    <input autofocus placeholder="Email" gg-match="input#identifierId" type="email" name="email" />
+    <input
+      autofocus
+      placeholder="Email"
+      data-testid="email"
+      gg-match="input#identifierId"
+      type="email"
+      name="email"
+    />
     <button
       type="submit"
       gg-autoclick

--- a/getgather/mcp/patterns/google-signin-email.html
+++ b/getgather/mcp/patterns/google-signin-email.html
@@ -6,7 +6,7 @@
     <input
       autofocus
       placeholder="Email"
-      data-testid="email"
+      data-testid="username"
       gg-match="input#identifierId"
       type="email"
       name="email"

--- a/getgather/mcp/patterns/google-signin-password-wrong.html
+++ b/getgather/mcp/patterns/google-signin-password-wrong.html
@@ -12,10 +12,13 @@
     <input
       autofocus
       placeholder="Password"
+      data-testid="password"
       gg-match="input[name='Passwd']"
       type="password"
       name="password"
     />
-    <button type="submit" gg-match="//div[@id='passwordNext']//button">Next</button>
+    <button type="submit" data-testid="submit" gg-match="//div[@id='passwordNext']//button">
+      Next
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/google-signin-password.html
+++ b/getgather/mcp/patterns/google-signin-password.html
@@ -7,12 +7,14 @@
     <input
       autofocus
       placeholder="Password"
+      data-testid="password"
       gg-match="input[name='Passwd']"
       type="password"
       name="password"
     />
     <button
       type="submit"
+      data-testid="submit"
       gg-match="//div[@id='passwordNext']//button[not(contains(@style, '--mdc-ripple-fg-size'))]"
     >
       Next

--- a/getgather/mcp/patterns/google-signin-phone-qr.html
+++ b/getgather/mcp/patterns/google-signin-phone-qr.html
@@ -14,6 +14,6 @@
     <p gg-match="//div[contains(@class, 'dMNVAe')]"></p>
 
     <input type="text" value="submit" name="submit" style="display: none" />
-    <button type="submit">I've done this</button>
+    <button type="submit" data-testid="submit">I've done this</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/google-signin-tap-yes.html
+++ b/getgather/mcp/patterns/google-signin-tap-yes.html
@@ -7,6 +7,6 @@
       Yes
     </div>
     <input type="text" value="submit" name="submit" style="display: none" />
-    <button type="submit">I've done this</button>
+    <button type="submit" data-testid="submit">I've done this</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/google-signin-verify-phone.html
+++ b/getgather/mcp/patterns/google-signin-verify-phone.html
@@ -9,8 +9,15 @@
       type="tel"
       name="phone"
       placeholder="+1234567890"
+      data-testid="phone"
       gg-match="//input[@id='phoneNumberId']"
     />
-    <button type="submit" gg-match="//div[@id='idvanyphonecollectNext']//button">Next</button>
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="//div[@id='idvanyphonecollectNext']//button"
+    >
+      Next
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/google-signin-verify-pin.html
+++ b/getgather/mcp/patterns/google-signin-verify-pin.html
@@ -8,8 +8,15 @@
       type="tel"
       name="pin"
       placeholder="Enter code"
+      data-testid="otp"
       gg-match="//input[@id='idvAnyPhonePin']"
     />
-    <button type="submit" gg-match="//div[@id='idvanyphoneverifyNext']//button">Next</button>
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="//div[@id='idvanyphoneverifyNext']//button"
+    >
+      Next
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/google-wrong-password.html
+++ b/getgather/mcp/patterns/google-wrong-password.html
@@ -4,12 +4,14 @@
     <input
       autofocus
       placeholder="Password"
+      data-testid="password"
       gg-match="input[name='Passwd']"
       type="password"
       name="password"
     />
     <button
       type="submit"
+      data-testid="submit"
       gg-match="//div[@id='passwordNext']//button[not(contains(@style, '--mdc-ripple-fg-size'))]"
     >
       Next

--- a/getgather/mcp/patterns/hardcover-signin.html
+++ b/getgather/mcp/patterns/hardcover-signin.html
@@ -10,15 +10,21 @@
         placeholder="Email"
         name="email"
         type="email"
+        data-testid="email"
         gg-match="form input[type='email']"
       />
       <input
         placeholder="Password"
         name="password"
         type="password"
+        data-testid="password"
         gg-match="form input[type='password']"
       />
-      <button type="submit" gg-match="//form//button[@type='submit' and not(.//svg)]">
+      <button
+        type="submit"
+        data-testid="submit"
+        gg-match="//form//button[@type='submit' and not(.//svg)]"
+      >
         Sign in
       </button>
     </div>

--- a/getgather/mcp/patterns/harrys-login-dialog.html
+++ b/getgather/mcp/patterns/harrys-login-dialog.html
@@ -6,12 +6,14 @@
       name="email"
       type="email"
       placeholder="Email"
+      data-testid="email"
       gg-match="dialog[open] form input[type=email]"
     />
     <input
       name="password"
       type="password"
       placeholder="Password"
+      data-testid="password"
       gg-match="dialog[open] form input[type=password]"
     />
     <button

--- a/getgather/mcp/patterns/hilton-signin.html
+++ b/getgather/mcp/patterns/hilton-signin.html
@@ -9,15 +9,21 @@
       autofocus
       type="text"
       name="username"
+      data-testid="email"
       gg-match="input[name='username']"
     />
     <input
       placeholder="Password"
       type="password"
       name="password"
+      data-testid="password"
       gg-match="input[name='password']"
     />
-    <button type="submit" gg-match="button[data-e2e='signInButton']:not([disabled])">
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="button[data-e2e='signInButton']:not([disabled])"
+    >
       Sign in
     </button>
   </body>

--- a/getgather/mcp/patterns/hilton-signin.html
+++ b/getgather/mcp/patterns/hilton-signin.html
@@ -9,7 +9,7 @@
       autofocus
       type="text"
       name="username"
-      data-testid="email"
+      data-testid="username"
       gg-match="input[name='username']"
     />
     <input

--- a/getgather/mcp/patterns/horizon-hobby-signin.html
+++ b/getgather/mcp/patterns/horizon-hobby-signin.html
@@ -4,8 +4,21 @@
   </head>
   <body>
     <p gg-optional gg-match="form[data-test='login-form'] div.alert__root"></p>
-    <input autofocus name="email" type="email" placeholder="Email" gg-match="input#email" />
-    <input name="password" type="password" placeholder="Password" gg-match="input#password" />
+    <input
+      autofocus
+      name="email"
+      type="email"
+      placeholder="Email"
+      data-testid="email"
+      gg-match="input#email"
+    />
+    <input
+      name="password"
+      type="password"
+      placeholder="Password"
+      data-testid="password"
+      gg-match="input#password"
+    />
     <button
       type="submit"
       gg-autoclick

--- a/getgather/mcp/patterns/ikea-signin-otp.html
+++ b/getgather/mcp/patterns/ikea-signin-otp.html
@@ -10,6 +10,7 @@
       type="text"
       inputmode="numeric"
       placeholder="OTP"
+      data-testid="otp"
       gg-match="input#passwordless-otp-verification-form-otp"
     />
     <input
@@ -21,6 +22,7 @@
     />
     <button
       type="submit"
+      data-testid="submit"
       gg-match="//button[@type='submit' and contains(., 'Continue') and not(.//span[contains(@class, 'btn__loader')])]"
     >
       Continue

--- a/getgather/mcp/patterns/ikea-signin.html
+++ b/getgather/mcp/patterns/ikea-signin.html
@@ -9,10 +9,12 @@
       name="email"
       type="email"
       placeholder="Email"
+      data-testid="email"
       gg-match="//input[@id='email' or @id='passwordless-primary-login-form-username']"
     />
     <button
       type="submit"
+      data-testid="submit"
       gg-match="//button[@type='submit' and contains(., 'Continue') and not(.//span[contains(@class, 'btn__loader')])]"
     >
       Continue

--- a/getgather/mcp/patterns/ikea-signin.html
+++ b/getgather/mcp/patterns/ikea-signin.html
@@ -9,7 +9,7 @@
       name="email"
       type="email"
       placeholder="Email"
-      data-testid="email"
+      data-testid="username"
       gg-match="//input[@id='email' or @id='passwordless-primary-login-form-username']"
     />
     <button

--- a/getgather/mcp/patterns/jetblue-signin.html
+++ b/getgather/mcp/patterns/jetblue-signin.html
@@ -6,12 +6,14 @@
       type="text"
       name="identifier"
       placeholder="Email"
+      data-testid="email"
       gg-match="input[name='identifier']"
     />
     <input
       type="password"
       name="password"
       placeholder="Password"
+      data-testid="password"
       gg-match="input[name='credentials.passcode']"
     />
     <button

--- a/getgather/mcp/patterns/jetblue-signin.html
+++ b/getgather/mcp/patterns/jetblue-signin.html
@@ -6,7 +6,7 @@
       type="text"
       name="identifier"
       placeholder="Email"
-      data-testid="email"
+      data-testid="username"
       gg-match="input[name='identifier']"
     />
     <input

--- a/getgather/mcp/patterns/jetblue-verification-form.html
+++ b/getgather/mcp/patterns/jetblue-verification-form.html
@@ -8,6 +8,7 @@
       type="text"
       name="otp"
       placeholder="Verification code"
+      data-testid="otp"
       gg-match="input[name='credentials.passcode']"
     />
     <button

--- a/getgather/mcp/patterns/kroger-signin.html
+++ b/getgather/mcp/patterns/kroger-signin.html
@@ -11,15 +11,21 @@
       name="email"
       type="email"
       placeholder="Email"
+      data-testid="email"
       gg-match="form#attributeVerification input#signInName"
     />
     <input
       name="password"
       type="password"
       placeholder="Password"
+      data-testid="password"
       gg-match="form#attributeVerification input#password"
     />
-    <button type="submit" gg-match="form#attributeVerification button#continue:not([disabled])">
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="form#attributeVerification button#continue:not([disabled])"
+    >
       Sign in
     </button>
   </body>

--- a/getgather/mcp/patterns/kroger-signin.html
+++ b/getgather/mcp/patterns/kroger-signin.html
@@ -11,7 +11,7 @@
       name="email"
       type="email"
       placeholder="Email"
-      data-testid="email"
+      data-testid="username"
       gg-match="form#attributeVerification input#signInName"
     />
     <input

--- a/getgather/mcp/patterns/lazada-signin.html
+++ b/getgather/mcp/patterns/lazada-signin.html
@@ -8,15 +8,19 @@
     <input
       name="email"
       type="text"
+      data-testid="email"
       gg-match="div#login-container div.iweb-input-container input[type='text']"
       placeholder="Please enter your Phone or Email"
     />
     <input
       name="password"
       type="password"
+      data-testid="password"
       gg-match="div#login-container div.iweb-input-container input[type='password']"
       placeholder="Password"
     />
-    <button type="submit" gg-match="div#login-container button[type='button']">Login</button>
+    <button type="submit" data-testid="submit" gg-match="div#login-container button[type='button']">
+      Login
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/lazada-signin.html
+++ b/getgather/mcp/patterns/lazada-signin.html
@@ -8,7 +8,7 @@
     <input
       name="email"
       type="text"
-      data-testid="email"
+      data-testid="username"
       gg-match="div#login-container div.iweb-input-container input[type='text']"
       placeholder="Please enter your Phone or Email"
     />

--- a/getgather/mcp/patterns/lazada-wait-mfa.html
+++ b/getgather/mcp/patterns/lazada-wait-mfa.html
@@ -22,6 +22,6 @@
     </p>
 
     <input type="text" value="submit" name="submit" style="display: none" />
-    <button type="submit">Sudah Verifikasi</button>
+    <button type="submit" data-testid="submit">Sudah Verifikasi</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/lenspure-signin.html
+++ b/getgather/mcp/patterns/lenspure-signin.html
@@ -1,8 +1,21 @@
 <html gg-domain="lenspure" gg-priority="1">
   <body>
     <span gg-optional gg-match="ul.woocommerce-error li"></span>
-    <input autofocus placeholder="Email" gg-match="input#username" type="text" name="userId" />
-    <input placeholder="Password" gg-match="input#password" type="password" name="password" />
-    <button type="submit" gg-match="input[type=submit]">Login</button>
+    <input
+      autofocus
+      placeholder="Email"
+      data-testid="email"
+      gg-match="input#username"
+      type="text"
+      name="userId"
+    />
+    <input
+      placeholder="Password"
+      data-testid="password"
+      gg-match="input#password"
+      type="password"
+      name="password"
+    />
+    <button type="submit" data-testid="submit" gg-match="input[type=submit]">Login</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/lenspure-signin.html
+++ b/getgather/mcp/patterns/lenspure-signin.html
@@ -4,7 +4,7 @@
     <input
       autofocus
       placeholder="Email"
-      data-testid="email"
+      data-testid="username"
       gg-match="input#username"
       type="text"
       name="userId"

--- a/getgather/mcp/patterns/linkedin-signin.html
+++ b/getgather/mcp/patterns/linkedin-signin.html
@@ -4,8 +4,27 @@
   </head>
   <body>
     <span gg-optional gg-match="div#error-for-password"></span>
-    <input autofocus name="email" type="email" placeholder="Email" gg-match="input#username" />
-    <input name="password" type="password" placeholder="Password" gg-match="input#password" />
-    <button type="submit" gg-match="button[data-litms-control-urn=login-submit]">Sign in</button>
+    <input
+      autofocus
+      name="email"
+      type="email"
+      placeholder="Email"
+      data-testid="email"
+      gg-match="input#username"
+    />
+    <input
+      name="password"
+      type="password"
+      placeholder="Password"
+      data-testid="password"
+      gg-match="input#password"
+    />
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="button[data-litms-control-urn=login-submit]"
+    >
+      Sign in
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/linkedin-signin.html
+++ b/getgather/mcp/patterns/linkedin-signin.html
@@ -9,7 +9,7 @@
       name="email"
       type="email"
       placeholder="Email"
-      data-testid="email"
+      data-testid="username"
       gg-match="input#username"
     />
     <input

--- a/getgather/mcp/patterns/lululemon-email-not-found.html
+++ b/getgather/mcp/patterns/lululemon-email-not-found.html
@@ -15,7 +15,9 @@
         value="none"
         style="display: none"
       />
-      <button type="submit" gg-match="a#identifier-not-you-link">Not you?</button>
+      <button type="submit" data-testid="submit" gg-match="a#identifier-not-you-link">
+        Not you?
+      </button>
     </div>
   </body>
 </html>

--- a/getgather/mcp/patterns/lululemon-password.html
+++ b/getgather/mcp/patterns/lululemon-password.html
@@ -11,9 +11,14 @@
         placeholder="Password"
         type="password"
         name="password"
+        data-testid="password"
         gg-match="input[data-testid='login-password-input']"
       />
-      <button type="submit" gg-match="input[data-testid='login-signin-button']:not([disabled])">
+      <button
+        type="submit"
+        data-testid="submit"
+        gg-match="input[data-testid='login-signin-button']:not([disabled])"
+      >
         Continue
       </button>
     </div>

--- a/getgather/mcp/patterns/lululemon-signin.html
+++ b/getgather/mcp/patterns/lululemon-signin.html
@@ -9,9 +9,14 @@
         placeholder="Email"
         type="email"
         name="identifier"
+        data-testid="email"
         gg-match="input[name='identifier']"
       />
-      <button type="submit" gg-match="input[data-testid='login-signin-button']:not([disabled])">
+      <button
+        type="submit"
+        data-testid="submit"
+        gg-match="input[data-testid='login-signin-button']:not([disabled])"
+      >
         Continue
       </button>
     </div>

--- a/getgather/mcp/patterns/lululemon-signin.html
+++ b/getgather/mcp/patterns/lululemon-signin.html
@@ -9,7 +9,7 @@
         placeholder="Email"
         type="email"
         name="identifier"
-        data-testid="email"
+        data-testid="username"
         gg-match="input[name='identifier']"
       />
       <button

--- a/getgather/mcp/patterns/marriott-code.html
+++ b/getgather/mcp/patterns/marriott-code.html
@@ -5,6 +5,7 @@
       autofocus
       type="number"
       name="code"
+      data-testid="otp"
       gg-match="input[name='input-text-Verification Code']"
     />
     <button

--- a/getgather/mcp/patterns/marriott-login.html
+++ b/getgather/mcp/patterns/marriott-login.html
@@ -6,12 +6,14 @@
       placeholder="Email or Member Number"
       type="text"
       name="email"
+      data-testid="email"
       gg-match="input[aria-label='email or member number']"
     />
     <input
       type="password"
       name="password"
       placeholder="Password"
+      data-testid="password"
       gg-match="input[aria-label='sign in password']"
     />
     <button

--- a/getgather/mcp/patterns/marriott-login.html
+++ b/getgather/mcp/patterns/marriott-login.html
@@ -6,7 +6,7 @@
       placeholder="Email or Member Number"
       type="text"
       name="email"
-      data-testid="email"
+      data-testid="username"
       gg-match="input[aria-label='email or member number']"
     />
     <input

--- a/getgather/mcp/patterns/netflix-signin.html
+++ b/getgather/mcp/patterns/netflix-signin.html
@@ -9,14 +9,16 @@
       name="email"
       type="email"
       placeholder="Email"
+      data-testid="email"
       gg-match="input[name='userLoginId']"
     />
     <input
       name="password"
       type="password"
       placeholder="Password"
+      data-testid="password"
       gg-match="input[name='password']"
     />
-    <button type="submit" gg-match="button[type='submit']">Sign in</button>
+    <button type="submit" data-testid="submit" gg-match="button[type='submit']">Sign in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/netflix-signin.html
+++ b/getgather/mcp/patterns/netflix-signin.html
@@ -9,7 +9,7 @@
       name="email"
       type="email"
       placeholder="Email"
-      data-testid="email"
+      data-testid="username"
       gg-match="input[name='userLoginId']"
     />
     <input

--- a/getgather/mcp/patterns/nike-email-not-found.html
+++ b/getgather/mcp/patterns/nike-email-not-found.html
@@ -8,6 +8,8 @@
       "Edit" to go back to the previous page.
     </p>
     <input gg-match="input[name='firstName']" name="none" value="none" style="display: none" />
-    <button type="submit" gg-match="//button[contains(text(), 'Edit')]">Edit</button>
+    <button type="submit" data-testid="submit" gg-match="//button[contains(text(), 'Edit')]">
+      Edit
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/nike-otp.html
+++ b/getgather/mcp/patterns/nike-otp.html
@@ -10,10 +10,12 @@
         placeholder="8-digit code"
         type="text"
         name="otp"
+        data-testid="otp"
         gg-match="input#send-code"
       />
       <button
         type="submit"
+        data-testid="submit"
         gg-match="//form//button[@type='submit' and contains(text(), 'Sign In')]"
       >
         Continue

--- a/getgather/mcp/patterns/nike-password.html
+++ b/getgather/mcp/patterns/nike-password.html
@@ -10,10 +10,12 @@
         placeholder="Password"
         type="password"
         name="password"
+        data-testid="password"
         gg-match="input#password"
       />
       <button
         type="submit"
+        data-testid="submit"
         gg-match="//form//button[@type='submit' and contains(text(), 'Sign In')]"
       >
         Continue

--- a/getgather/mcp/patterns/nike-signin.html
+++ b/getgather/mcp/patterns/nike-signin.html
@@ -4,9 +4,17 @@
   </head>
   <body>
     <div>
-      <input autofocus placeholder="Email" type="text" name="email" gg-match="input#username" />
+      <input
+        autofocus
+        placeholder="Email"
+        type="text"
+        name="email"
+        data-testid="email"
+        gg-match="input#username"
+      />
       <button
         type="submit"
+        data-testid="submit"
         gg-match="//form//button[@type='submit' and contains(text(), 'Continue')]"
       >
         Continue

--- a/getgather/mcp/patterns/nike-signin.html
+++ b/getgather/mcp/patterns/nike-signin.html
@@ -9,7 +9,7 @@
         placeholder="Email"
         type="text"
         name="email"
-        data-testid="email"
+        data-testid="username"
         gg-match="input#username"
       />
       <button

--- a/getgather/mcp/patterns/nordstrom-email-not-found.html
+++ b/getgather/mcp/patterns/nordstrom-email-not-found.html
@@ -8,7 +8,13 @@
       "Edit" to go back to the previous page.
     </p>
     <input gg-match="input[name='firstName']" name="none" value="none" style="display: none" />
-    <button type="submit" name="button" value="edit" gg-match="button[alt='edit email link']">
+    <button
+      type="submit"
+      name="button"
+      value="edit"
+      data-testid="submit"
+      gg-match="button[alt='edit email link']"
+    >
       Edit
     </button>
   </body>

--- a/getgather/mcp/patterns/nordstrom-mfa-choice.html
+++ b/getgather/mcp/patterns/nordstrom-mfa-choice.html
@@ -14,6 +14,7 @@
               type="radio"
               name="delivery-method"
               id="EMAIL"
+              data-testid="signin-method-email"
               gg-match="fieldset > label:nth-of-type(1)"
               value="EMAIL"
               checked
@@ -35,6 +36,7 @@
               type="radio"
               name="delivery-method"
               id="sms"
+              data-testid="signin-method-sms"
               gg-match="fieldset > label:nth-of-type(2)"
               value="sms"
             />
@@ -55,7 +57,9 @@
           </div>
         </div>
       </div>
-      <button type="submit" gg-match="//button[contains(text(), 'Send Code')]">Send Code</button>
+      <button type="submit" data-testid="submit" gg-match="//button[contains(text(), 'Send Code')]">
+        Send Code
+      </button>
     </div>
   </body>
 </html>

--- a/getgather/mcp/patterns/nordstrom-mfa.html
+++ b/getgather/mcp/patterns/nordstrom-mfa.html
@@ -18,10 +18,15 @@
       autofocus
       name="code"
       type="text"
+      data-testid="otp"
       gg-match="input[name='code']"
       placeholder="Code"
     />
-    <button type="submit" gg-match="//button[@type='button' and contains(., 'Verify and Sign in')]">
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="//button[@type='button' and contains(., 'Verify and Sign in')]"
+    >
       Verify and Sign in
     </button>
   </body>

--- a/getgather/mcp/patterns/nordstrom-signin-passowrd-wrong.html
+++ b/getgather/mcp/patterns/nordstrom-signin-passowrd-wrong.html
@@ -8,10 +8,15 @@
       autofocus
       name="password"
       type="password"
+      data-testid="password"
       gg-match="form#sign-in input[name='password']"
       placeholder="Password"
     />
-    <button type="submit" gg-match="//button[@alt='sign in button' and contains(., 'Sign In')]">
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="//button[@alt='sign in button' and contains(., 'Sign In')]"
+    >
       Sign In
     </button>
   </body>

--- a/getgather/mcp/patterns/nordstrom-signin-passowrd.html
+++ b/getgather/mcp/patterns/nordstrom-signin-passowrd.html
@@ -7,10 +7,15 @@
       autofocus
       name="password"
       type="password"
+      data-testid="password"
       gg-match="form#sign-in input[name='password']"
       placeholder="Password"
     />
-    <button type="submit" gg-match="//button[@alt='sign in button' and contains(., 'Sign In')]">
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="//button[@alt='sign in button' and contains(., 'Sign In')]"
+    >
       Sign In
     </button>
   </body>

--- a/getgather/mcp/patterns/nordstrom-signin.html
+++ b/getgather/mcp/patterns/nordstrom-signin.html
@@ -3,9 +3,17 @@
     <title>Sign In to Nordstrom</title>
   </head>
   <body>
-    <input autofocus name="email" type="text" gg-match="input[name='email']" placeholder="Email" />
+    <input
+      autofocus
+      name="email"
+      type="text"
+      data-testid="email"
+      gg-match="input[name='email']"
+      placeholder="Email"
+    />
     <button
       type="submit"
+      data-testid="submit"
       gg-match="//button[@id='account-check-next-button' and contains(., 'Next')]"
     >
       Next

--- a/getgather/mcp/patterns/officedepot-login.html
+++ b/getgather/mcp/patterns/officedepot-login.html
@@ -3,8 +3,22 @@
     <title>Office Depot Sign In</title>
   </head>
   <body>
-    <input type="email" gg-match="input[name=loginName]" placeholder="Email Address" name="email" />
-    <input type="password" gg-match="input[name=password]" placeholder="Password" name="password" />
-    <button type="submit" gg-match="input#order_history_login_btn">Log in</button>
+    <input
+      type="email"
+      data-testid="email"
+      gg-match="input[name=loginName]"
+      placeholder="Email Address"
+      name="email"
+    />
+    <input
+      type="password"
+      data-testid="password"
+      gg-match="input[name=password]"
+      placeholder="Password"
+      name="password"
+    />
+    <button type="submit" data-testid="submit" gg-match="input#order_history_login_btn">
+      Log in
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/officedepot-login.html
+++ b/getgather/mcp/patterns/officedepot-login.html
@@ -5,7 +5,7 @@
   <body>
     <input
       type="email"
-      data-testid="email"
+      data-testid="username"
       gg-match="input[name=loginName]"
       placeholder="Email Address"
       name="email"

--- a/getgather/mcp/patterns/petsmart-signin.html
+++ b/getgather/mcp/patterns/petsmart-signin.html
@@ -5,8 +5,20 @@
   <body>
     <h2 gg-optional gg-match=".sparky-c-alert--error h2"></h2>
     <div gg-optional gg-match=".sparky-c-alert--error div.sparky-c-text-passage"></div>
-    <input type="email" name="email" gg-match="input#email" placeholder="Email" />
-    <input type="password" name="password" gg-match="input#password" placeholder="Password" />
+    <input
+      type="email"
+      name="email"
+      data-testid="email"
+      gg-match="input#email"
+      placeholder="Email"
+    />
+    <input
+      type="password"
+      name="password"
+      data-testid="password"
+      gg-match="input#password"
+      placeholder="Password"
+    />
     <button
       type="submit"
       gg-autoclick

--- a/getgather/mcp/patterns/quince-password.html
+++ b/getgather/mcp/patterns/quince-password.html
@@ -6,10 +6,15 @@
     <input
       type="password"
       name="password"
+      data-testid="password"
       gg-match="input[type=password][name=password]"
       placeholder="Password"
     />
-    <button type="submit" gg-match="form#login-form-A-secondary button[type='submit']">
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="form#login-form-A-secondary button[type='submit']"
+    >
       Continue
     </button>
   </body>

--- a/getgather/mcp/patterns/quince-signin.html
+++ b/getgather/mcp/patterns/quince-signin.html
@@ -6,9 +6,12 @@
     <input
       type="email"
       name="username"
+      data-testid="email"
       gg-match="input[type=email][name=username]"
       placeholder="Email"
     />
-    <button type="submit" gg-match="button[form='login-form-A-Initial']">Continue</button>
+    <button type="submit" data-testid="submit" gg-match="button[form='login-form-A-Initial']">
+      Continue
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/revolve-signin.html
+++ b/getgather/mcp/patterns/revolve-signin.html
@@ -4,13 +4,23 @@
   </head>
   <body>
     <div gg-optional gg-match="div#login_error_message"></div>
-    <input autofocus placeholder="Email" type="email" name="email" gg-match="input#emailCustomer" />
+    <input
+      autofocus
+      placeholder="Email"
+      type="email"
+      name="email"
+      data-testid="email"
+      gg-match="input#emailCustomer"
+    />
     <input
       placeholder="Password"
       type="password"
       name="password"
+      data-testid="password"
       gg-match="input#passwordCustomer"
     />
-    <button type="submit" gg-match="input#signInButton:not([disabled])">Sign in</button>
+    <button type="submit" data-testid="submit" gg-match="input#signInButton:not([disabled])">
+      Sign in
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/safeway-signin.html
+++ b/getgather/mcp/patterns/safeway-signin.html
@@ -11,10 +11,12 @@
       name="email"
       type="text"
       placeholder="Email or mobile number"
+      data-testid="email"
       gg-match="form input#enterUsername"
     />
     <button
       type="submit"
+      data-testid="submit"
       gg-match="//form//button[@type='submit' and not(.//div[contains(@class, 'pp-loading-spinner')])]"
     >
       Sign in

--- a/getgather/mcp/patterns/safeway-signin.html
+++ b/getgather/mcp/patterns/safeway-signin.html
@@ -11,7 +11,7 @@
       name="email"
       type="text"
       placeholder="Email or mobile number"
-      data-testid="email"
+      data-testid="username"
       gg-match="form input#enterUsername"
     />
     <button

--- a/getgather/mcp/patterns/safeway-verification.html
+++ b/getgather/mcp/patterns/safeway-verification.html
@@ -17,10 +17,12 @@
       name="otp"
       type="text"
       placeholder="Verification Code"
+      data-testid="otp"
       gg-match="form input[formcontrolname='otpCode']"
     />
     <button
       type="submit"
+      data-testid="submit"
       gg-match="//form//button[@type='submit' and not(.//div[contains(@class, 'pp-loading-spinner')])]"
     >
       Sign in

--- a/getgather/mcp/patterns/seatgeek-code.html
+++ b/getgather/mcp/patterns/seatgeek-code.html
@@ -13,40 +13,50 @@
           name="otp-1"
           type="text"
           inputmode="numeric"
+          data-testid="otp-0"
           gg-match="input[aria-label='6-digit code digit 1']"
         />
         <input
           name="otp-2"
           type="text"
           inputmode="numeric"
+          data-testid="otp-1"
           gg-match="input[aria-label='6-digit code digit 2']"
         />
         <input
           name="otp-3"
           type="text"
           inputmode="numeric"
+          data-testid="otp-2"
           gg-match="input[aria-label='6-digit code digit 3']"
         />
         <input
           name="otp-4"
           type="text"
           inputmode="numeric"
+          data-testid="otp-3"
           gg-match="input[aria-label='6-digit code digit 4']"
         />
         <input
           name="otp-5"
           type="text"
           inputmode="numeric"
+          data-testid="otp-4"
           gg-match="input[aria-label='6-digit code digit 5']"
         />
         <input
           name="otp-6"
           type="text"
           inputmode="numeric"
+          data-testid="otp-5"
           gg-match="input[aria-label='6-digit code digit 6']"
         />
       </div>
-      <button type="submit" gg-match="//button/span/span[contains(text(), 'Confirm')]">
+      <button
+        type="submit"
+        data-testid="submit"
+        gg-match="//button/span/span[contains(text(), 'Confirm')]"
+      >
         Confirm
       </button>
     </div>

--- a/getgather/mcp/patterns/seatgeek-signin.html
+++ b/getgather/mcp/patterns/seatgeek-signin.html
@@ -9,12 +9,14 @@
       <input
         autofocus
         placeholder="Email"
+        data-testid="email"
         gg-match="input[data-uniform-id='input-email']"
         type="email"
         name="email"
       />
       <button
         type="submit"
+        data-testid="submit"
         gg-match="//button/span/span[contains(text(), 'Instantly log in with email')]"
       >
         Sign in

--- a/getgather/mcp/patterns/sephora-basket-signin-modal.html
+++ b/getgather/mcp/patterns/sephora-basket-signin-modal.html
@@ -9,12 +9,14 @@
     <input
       type="text"
       name="username"
+      data-testid="email"
       gg-match="div#modal-root input#signin_username"
       placeholder="Email Address"
     />
     <input
       type="password"
       name="password"
+      data-testid="password"
       gg-match="div#modal-root input#signin_password"
       placeholder="Password"
     />
@@ -25,7 +27,11 @@
       gg-match="div#modal-root input#signin_ssi"
       style="display: none"
     />
-    <button type="submit" gg-match="div#modal-root button[data-at='sign_in_button']">
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="div#modal-root button[data-at='sign_in_button']"
+    >
       Sign In
     </button>
   </body>

--- a/getgather/mcp/patterns/sephora-basket-signin-modal.html
+++ b/getgather/mcp/patterns/sephora-basket-signin-modal.html
@@ -9,7 +9,7 @@
     <input
       type="text"
       name="username"
-      data-testid="email"
+      data-testid="username"
       gg-match="div#modal-root input#signin_username"
       placeholder="Email Address"
     />

--- a/getgather/mcp/patterns/sephora-signin.html
+++ b/getgather/mcp/patterns/sephora-signin.html
@@ -7,12 +7,14 @@
     <input
       type="text"
       name="username"
+      data-testid="email"
       gg-match="input#signin_username"
       placeholder="Email Address"
     />
     <input
       type="password"
       name="password"
+      data-testid="password"
       gg-match="input#signin_password"
       placeholder="Password"
     />

--- a/getgather/mcp/patterns/sephora-signin.html
+++ b/getgather/mcp/patterns/sephora-signin.html
@@ -7,7 +7,7 @@
     <input
       type="text"
       name="username"
-      data-testid="email"
+      data-testid="username"
       gg-match="input#signin_username"
       placeholder="Email Address"
     />

--- a/getgather/mcp/patterns/shadestore-signin.html
+++ b/getgather/mcp/patterns/shadestore-signin.html
@@ -9,10 +9,17 @@
     <input
       type="text"
       name="username"
+      data-testid="email"
       gg-match="input#login_username"
       placeholder="Email Address"
     />
-    <input type="password" name="password" gg-match="input#login_password" placeholder="Password" />
-    <button type="submit" gg-match="input#login">Login to My Account</button>
+    <input
+      type="password"
+      name="password"
+      data-testid="password"
+      gg-match="input#login_password"
+      placeholder="Password"
+    />
+    <button type="submit" data-testid="submit" gg-match="input#login">Login to My Account</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/shadestore-signin.html
+++ b/getgather/mcp/patterns/shadestore-signin.html
@@ -9,7 +9,7 @@
     <input
       type="text"
       name="username"
-      data-testid="email"
+      data-testid="username"
       gg-match="input#login_username"
       placeholder="Email Address"
     />

--- a/getgather/mcp/patterns/shein-email-not-found.html
+++ b/getgather/mcp/patterns/shein-email-not-found.html
@@ -10,7 +10,11 @@
       value="none"
       style="display: none"
     />
-    <button type="submit" gg-match="div:not([style*='display: none']) > div.go-back">
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="div:not([style*='display: none']) > div.go-back"
+    >
       Go Back
     </button>
   </body>

--- a/getgather/mcp/patterns/shein-password.html
+++ b/getgather/mcp/patterns/shein-password.html
@@ -9,10 +9,12 @@
       placeholder="Password"
       name="password"
       type="password"
+      data-testid="password"
       gg-match="div.sui-dialog__body div.page__login-newUI-emailPannel div.main-content input[type='password'][aria-label='Password:']"
     />
     <button
       type="submit"
+      data-testid="submit"
       gg-match="div.sui-dialog__body div.page__login-newUI-emailPannel div.login-point_button > button"
     >
       Sign In

--- a/getgather/mcp/patterns/shein-signin.html
+++ b/getgather/mcp/patterns/shein-signin.html
@@ -8,8 +8,11 @@
       placeholder="Email"
       type="text"
       name="username"
+      data-testid="email"
       gg-match="input[aria-label='Email Address:']"
     />
-    <button type="submit" gg-match="div.login-point_button > button">Continue</button>
+    <button type="submit" data-testid="submit" gg-match="div.login-point_button > button">
+      Continue
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/shein-verification.html
+++ b/getgather/mcp/patterns/shein-verification.html
@@ -11,8 +11,11 @@
       name="code"
       type="text"
       maxlength="5"
+      data-testid="otp"
       gg-match="div.code-input input[maxlength='5']"
     />
-    <button type="submit" gg-match="div.sui-dialog__body button.confirm-btn">SUBMIT</button>
+    <button type="submit" data-testid="submit" gg-match="div.sui-dialog__body button.confirm-btn">
+      SUBMIT
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/shopee-login.html
+++ b/getgather/mcp/patterns/shopee-login.html
@@ -8,18 +8,21 @@
       autofocus
       name="loginKey"
       type="text"
+      data-testid="email"
       gg-match="input[name='loginKey']"
       placeholder="No. Handphone/Username/Email"
     />
     <input
       name="password"
       type="password"
+      data-testid="password"
       gg-match="input[name='password']"
       placeholder="Password"
     />
 
     <button
       type="submit"
+      data-testid="submit"
       gg-match="//button[contains(normalize-space(.),'Log In') or contains(normalize-space(.),'Log in')]"
     >
       Log in

--- a/getgather/mcp/patterns/shopee-login.html
+++ b/getgather/mcp/patterns/shopee-login.html
@@ -8,7 +8,7 @@
       autofocus
       name="loginKey"
       type="text"
-      data-testid="email"
+      data-testid="username"
       gg-match="input[name='loginKey']"
       placeholder="No. Handphone/Username/Email"
     />

--- a/getgather/mcp/patterns/shopee-verification-link-wa-wait.html
+++ b/getgather/mcp/patterns/shopee-verification-link-wa-wait.html
@@ -7,6 +7,6 @@
     <span gg-match="//div[contains(text(), 'Link verifikasi telah dikirim')]"></span>
     <span gg-match="//div[contains(text(), '+62')]"></span>
     <input type="text" value="submit" name="submit" style="display: none" />
-    <button type="submit">Sudah Verifikasi</button>
+    <button type="submit" data-testid="submit">Sudah Verifikasi</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/starbucks-signin.html
+++ b/getgather/mcp/patterns/starbucks-signin.html
@@ -11,8 +11,21 @@
       Agree
     </div>
     <span gg-optional gg-match="div[class*='alert___']"></span>
-    <input autofocus name="email" type="email" placeholder="Email" gg-match="input#username" />
-    <input name="password" type="password" placeholder="Password" gg-match="input#password" />
-    <button type="submit" gg-match="button[type=submit]">Sign in</button>
+    <input
+      autofocus
+      name="email"
+      type="email"
+      placeholder="Email"
+      data-testid="email"
+      gg-match="input#username"
+    />
+    <input
+      name="password"
+      type="password"
+      placeholder="Password"
+      data-testid="password"
+      gg-match="input#password"
+    />
+    <button type="submit" data-testid="submit" gg-match="button[type=submit]">Sign in</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/starbucks-signin.html
+++ b/getgather/mcp/patterns/starbucks-signin.html
@@ -16,7 +16,7 @@
       name="email"
       type="email"
       placeholder="Email"
-      data-testid="email"
+      data-testid="username"
       gg-match="input#username"
     />
     <input

--- a/getgather/mcp/patterns/thriftbooks-signin.html
+++ b/getgather/mcp/patterns/thriftbooks-signin.html
@@ -7,15 +7,19 @@
     <input
       type="email"
       name="email"
+      data-testid="email"
       gg-match="input#ExistingAccount_EmailAddress"
       placeholder="Email Address"
     />
     <input
       type="password"
       name="password"
+      data-testid="password"
       gg-match="input#ExistingAccount_Password"
       placeholder="Password"
     />
-    <button type="submit" gg-match="div.LoginBox-submitArea input.Button">Log In</button>
+    <button type="submit" data-testid="submit" gg-match="div.LoginBox-submitArea input.Button">
+      Log In
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/tokopedia-login.html
+++ b/getgather/mcp/patterns/tokopedia-login.html
@@ -6,9 +6,12 @@
     <input
       name="login"
       type="text"
+      data-testid="email"
       gg-match="input[name=login]"
       placeholder="Masukkan nomor ponsel atau email"
     />
-    <button type="submit" gg-match="button[data-testid=button-submit]">Selanjutnya</button>
+    <button type="submit" data-testid="submit" gg-match="button[data-testid=button-submit]">
+      Selanjutnya
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/tokopedia-login.html
+++ b/getgather/mcp/patterns/tokopedia-login.html
@@ -6,7 +6,7 @@
     <input
       name="login"
       type="text"
-      data-testid="email"
+      data-testid="username"
       gg-match="input[name=login]"
       placeholder="Masukkan nomor ponsel atau email"
     />

--- a/getgather/mcp/patterns/tokopedia-otp.html
+++ b/getgather/mcp/patterns/tokopedia-otp.html
@@ -5,7 +5,7 @@
   <body>
     <p gg-optional gg-match="//span[contains(text(), 'Kode yang kamu masukkan salah.')]"></p>
     <div gg-match="//div[contains(text(), 'Masukkan Kode Verifikasi')]"></div>
-    <input name="otp" type="tel" gg-match="input[type=tel]" placeholder="OTP" />
-    <button type="submit">Submit</button>
+    <input name="otp" type="tel" data-testid="otp" gg-match="input[type=tel]" placeholder="OTP" />
+    <button type="submit" data-testid="submit">Submit</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/tokopedia-password.html
+++ b/getgather/mcp/patterns/tokopedia-password.html
@@ -5,7 +5,15 @@
   <body>
     <span gg-match="//span[contains(text(), 'Masuk ke Tokopedia')]">Masuk ke Tokopedia</span>
     <p gg-optional gg-match="div#password p"></p>
-    <input name="password" type="password" gg-match="input[type=password]" placeholder="Password" />
-    <button type="submit" gg-match="button[data-testid=button-submit]">Masuk</button>
+    <input
+      name="password"
+      type="password"
+      data-testid="password"
+      gg-match="input[type=password]"
+      placeholder="Password"
+    />
+    <button type="submit" data-testid="submit" gg-match="button[data-testid=button-submit]">
+      Masuk
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/tokopedia-pin-verification.html
+++ b/getgather/mcp/patterns/tokopedia-pin-verification.html
@@ -13,10 +13,11 @@
     <input
       name="pin"
       type="tel"
+      data-testid="otp"
       gg-match="input[type=tel][maxlength='6'][aria-label='pin input']"
       placeholder="PIN"
     />
     <span gg-optional gg-match="span[aria-label='forgot pin']"></span>
-    <button type="submit">Submit</button>
+    <button type="submit" data-testid="submit">Submit</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/traveloka-signin-otp.html
+++ b/getgather/mcp/patterns/traveloka-signin-otp.html
@@ -4,7 +4,13 @@
   </head>
   <body>
     <div gg-match="//h1[contains(text(), 'Input Verification Code')]"></div>
-    <input name="otp" type="tel" gg-match="input[inputmode=decimal]" placeholder="OTP" />
-    <button type="submit">Submit</button>
+    <input
+      name="otp"
+      type="tel"
+      data-testid="otp"
+      gg-match="input[inputmode=decimal]"
+      placeholder="OTP"
+    />
+    <button type="submit" data-testid="submit">Submit</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/traveloka-signin-password.html
+++ b/getgather/mcp/patterns/traveloka-signin-password.html
@@ -8,22 +8,17 @@
       name="pass"
       type="password"
       gg-match="input[data-testid='auth-password']"
-      data-testid="gg-auth-password"
+      data-testid="password"
       placeholder="Password"
     />
-    <button
-      data-testid="gg-loginBtn"
-      type="submit"
-      gg-autoclick
-      gg-match="[data-testid='loginBtn']"
-    >
+    <button data-testid="submit" type="submit" gg-autoclick gg-match="[data-testid='loginBtn']">
       Sign in
     </button>
     <script>
       // 1st attempt: keep as is; 2nd attempt: disable inputs and soft-refresh after 5s.
       document.addEventListener("DOMContentLoaded", function () {
-        const pwdInput = document.querySelector("input[data-testid='gg-auth-password']");
-        const submitBtn = document.querySelector("[data-testid='gg-loginBtn']");
+        const pwdInput = document.querySelector("input[data-testid='password']");
+        const submitBtn = document.querySelector("[data-testid='submit']");
         if (!pwdInput || !submitBtn) return;
 
         const attemptKey = "gg_traveloka_signin_password_attempt";

--- a/getgather/mcp/patterns/traveloka-signin-username.html
+++ b/getgather/mcp/patterns/traveloka-signin-username.html
@@ -6,9 +6,10 @@
     <input
       name="userid"
       type="text"
+      data-testid="email"
       gg-match="input[data-testid='auth-username']"
       placeholder="Email or phone number"
     />
-    <button type="submit">Continue</button>
+    <button type="submit" data-testid="submit">Continue</button>
   </body>
 </html>

--- a/getgather/mcp/patterns/traveloka-signin-username.html
+++ b/getgather/mcp/patterns/traveloka-signin-username.html
@@ -6,7 +6,7 @@
     <input
       name="userid"
       type="text"
-      data-testid="email"
+      data-testid="username"
       gg-match="input[data-testid='auth-username']"
       placeholder="Email or phone number"
     />

--- a/getgather/mcp/patterns/walmart-account.html
+++ b/getgather/mcp/patterns/walmart-account.html
@@ -4,6 +4,8 @@
   </head>
   <body>
     <h3 gg-stop gg-match="//h3[contains(normalize-space(.), 'Purchase History')]"></h3>
-    <button gg-match="button[name='viewPurchaseHistory']">View all orders</button>
+    <button data-testid="submit" gg-match="button[name='viewPurchaseHistory']">
+      View all orders
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/walmart-signin-choose-method.html
+++ b/getgather/mcp/patterns/walmart-signin-choose-method.html
@@ -13,6 +13,7 @@
           name="signin-method"
           id="wm-method-sms"
           value="otp"
+          data-testid="signin-method-sms"
           gg-match="input[name='otp'][type='radio']"
         />
         <div>
@@ -27,6 +28,7 @@
           name="signin-method"
           id="wm-method-email-otp"
           value="otpEmail"
+          data-testid="signin-method-email"
           gg-match="input[name='otpEmail'][type='radio']"
         />
         <div>
@@ -42,6 +44,7 @@
           name="signin-method"
           id="wm-method-password"
           value="password"
+          data-testid="signin-method-password"
           gg-match="input[name='password'][type='radio']"
         />
         <div>
@@ -55,12 +58,14 @@
       type="password"
       name="password"
       placeholder="Password"
+      data-testid="password"
       gg-match="form#sign-in-form input[name='password'][type='password']"
     />
     <button
       id="wm-submit"
       type="submit"
       disabled
+      data-testid="submit"
       gg-match="//button[(contains(text(), 'Sign in') or contains(text(), 'Request code') or contains(text(), 'Send code') or contains(text(), 'Continue') or contains(text(), 'Text me')) and not(@disabled)]"
     >
       Choose a method above

--- a/getgather/mcp/patterns/walmart-signin-email.html
+++ b/getgather/mcp/patterns/walmart-signin-email.html
@@ -18,8 +18,15 @@
       name="email"
       type="text"
       placeholder="Phone number or email (required)"
+      data-testid="email"
       gg-match="input[aria-label='Phone number or email (required)']"
     />
-    <button type="submit" gg-match="button#login-continue-button:not([disabled])">Continue</button>
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="button#login-continue-button:not([disabled])"
+    >
+      Continue
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/walmart-signin-email.html
+++ b/getgather/mcp/patterns/walmart-signin-email.html
@@ -18,7 +18,7 @@
       name="email"
       type="text"
       placeholder="Phone number or email (required)"
-      data-testid="email"
+      data-testid="username"
       gg-match="input[aria-label='Phone number or email (required)']"
     />
     <button

--- a/getgather/mcp/patterns/walmart-signin-otp.html
+++ b/getgather/mcp/patterns/walmart-signin-otp.html
@@ -32,6 +32,7 @@
           font-size: 1.5rem;
           font-weight: bold;
         "
+        data-testid="otp-0"
         gg-match="input#input-verificationCode"
       />
       <input
@@ -48,6 +49,7 @@
           font-size: 1.5rem;
           font-weight: bold;
         "
+        data-testid="otp-1"
         gg-match="input#input-verificationCode-1"
       />
       <input
@@ -64,6 +66,7 @@
           font-size: 1.5rem;
           font-weight: bold;
         "
+        data-testid="otp-2"
         gg-match="input#input-verificationCode-2"
       />
       <input
@@ -80,6 +83,7 @@
           font-size: 1.5rem;
           font-weight: bold;
         "
+        data-testid="otp-3"
         gg-match="input#input-verificationCode-3"
       />
       <input
@@ -96,6 +100,7 @@
           font-size: 1.5rem;
           font-weight: bold;
         "
+        data-testid="otp-4"
         gg-match="input#input-verificationCode-4"
       />
       <input
@@ -112,6 +117,7 @@
           font-size: 1.5rem;
           font-weight: bold;
         "
+        data-testid="otp-5"
         gg-match="input#input-verificationCode-5"
       />
     </div>
@@ -161,7 +167,11 @@
         if (e.target.value && inputs[i + 1]) inputs[i + 1].focus();
       });
     </script>
-    <button type="submit" gg-match="button[type='submit'][form$='-otp-form']:not([disabled])">
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="button[type='submit'][form$='-otp-form']:not([disabled])"
+    >
       Sign in
     </button>
   </body>

--- a/getgather/mcp/patterns/wayfair-email-not-found.html
+++ b/getgather/mcp/patterns/wayfair-email-not-found.html
@@ -16,6 +16,7 @@
       type="submit"
       name="button"
       value="signin"
+      data-testid="submit"
       gg-match="button[data-test-id='SIGN_IN_LINK']"
     >
       Sign In

--- a/getgather/mcp/patterns/wayfair-email-otp.html
+++ b/getgather/mcp/patterns/wayfair-email-otp.html
@@ -7,8 +7,16 @@
     <span gg-match="[data-test-id='READ_ONLY_EMAIL']"></span>
     <span gg-optional gg-match="[data-test-id='CODE_INPUT-validationText']"></span>
 
-    <input type="text" name="otp" gg-match="input[name=otp]" placeholder="Emailed Code" />
-    <button type="submit" gg-match="button[data-test-id='SIGN_IN_BUTTON']">Sign In</button>
+    <input
+      type="text"
+      name="otp"
+      data-testid="otp"
+      gg-match="input[name=otp]"
+      placeholder="Emailed Code"
+    />
+    <button type="submit" data-testid="submit" gg-match="button[data-test-id='SIGN_IN_BUTTON']">
+      Sign In
+    </button>
 
     <div style="display: flex; flex-direction: column; gap: 12px">
       <div style="display: flex; align-items: center; text-align: center">
@@ -20,6 +28,7 @@
         name="button"
         value="password"
         gg-optional
+        data-testid="signin-method-password"
         gg-match="[data-test-id='OTHER_SIGN_IN_METHODS_PASSWORD_LOGIN_BUTTON']"
       >
         Sign In With Your Password

--- a/getgather/mcp/patterns/wayfair-login.html
+++ b/getgather/mcp/patterns/wayfair-login.html
@@ -3,8 +3,18 @@
     <title>Wayfair Login</title>
   </head>
   <body>
-    <input type="email" name="email" gg-match="input[name=email]" placeholder="Email Address" />
-    <button type="submit" gg-match="button[data-test-id='SUBMIT_BUTTON']:not([disabled])">
+    <input
+      type="email"
+      name="email"
+      data-testid="email"
+      gg-match="input[name=email]"
+      placeholder="Email Address"
+    />
+    <button
+      type="submit"
+      data-testid="submit"
+      gg-match="button[data-test-id='SUBMIT_BUTTON']:not([disabled])"
+    >
       Continue
     </button>
   </body>

--- a/getgather/mcp/patterns/wayfair-password.html
+++ b/getgather/mcp/patterns/wayfair-password.html
@@ -7,8 +7,16 @@
     <span gg-match="[data-test-id='READ_ONLY_EMAIL']"></span>
     <span gg-optional gg-match="[data-test-id='login-password-input-validationText']"></span>
 
-    <input type="password" name="password" gg-match="input[name=password]" placeholder="Password" />
-    <button type="submit" gg-match="button[data-test-id='SIGN_IN_BUTTON']">Sign In</button>
+    <input
+      type="password"
+      name="password"
+      data-testid="password"
+      gg-match="input[name=password]"
+      placeholder="Password"
+    />
+    <button type="submit" data-testid="submit" gg-match="button[data-test-id='SIGN_IN_BUTTON']">
+      Sign In
+    </button>
 
     <div style="display: flex; flex-direction: column; gap: 12px">
       <div style="display: flex; align-items: center; text-align: center">
@@ -20,6 +28,7 @@
         name="button"
         value="email"
         gg-optional
+        data-testid="signin-method-sms"
         gg-match="[data-test-id='OTHER_SIGN_IN_METHODS_SMS_BUTTON']"
       >
         Text Me a Code

--- a/getgather/mcp/patterns/wayfair-phone-otp.html
+++ b/getgather/mcp/patterns/wayfair-phone-otp.html
@@ -7,9 +7,17 @@
       <h3 gg-match="[data-test-id='AuthHeaderTitle']">Enter the Code We Texted You</h3>
       <p gg-match="[data-test-id='READ_ONLY_PHONE']"></p>
       <span gg-optional gg-match="[data-test-id='CODE_INPUT-validationText']"></span>
-      <input type="text" name="otp" gg-match="input[name=otp]" placeholder="Texted Code" />
+      <input
+        type="text"
+        name="otp"
+        data-testid="otp"
+        gg-match="input[name=otp]"
+        placeholder="Texted Code"
+      />
     </div>
-    <button type="submit" gg-match="button[data-test-id='SIGN_IN_BUTTON']">Sign In</button>
+    <button type="submit" data-testid="submit" gg-match="button[data-test-id='SIGN_IN_BUTTON']">
+      Sign In
+    </button>
 
     <div style="display: flex; flex-direction: column; gap: 12px">
       <div style="display: flex; align-items: center; text-align: center">
@@ -21,6 +29,7 @@
         name="button"
         value="password"
         gg-optional
+        data-testid="signin-method-password"
         gg-match="[data-test-id='OTHER_SIGN_IN_METHODS_PASSWORD_LOGIN_BUTTON']"
       >
         Sign In With Your Password
@@ -30,6 +39,7 @@
         name="button"
         value="email"
         gg-optional
+        data-testid="signin-method-email"
         gg-match="[data-test-id='OTHER_SIGN_IN_METHODS_EMAIL_BUTTON']"
       >
         Email Me a Code

--- a/getgather/mcp/patterns/youtube-select-channel.html
+++ b/getgather/mcp/patterns/youtube-select-channel.html
@@ -17,6 +17,7 @@
               id="yt-ch-1"
               value="1"
               checked
+              data-testid="option-1"
               gg-match="ytd-account-item-section-renderer #contents ytd-account-item-renderer:nth-of-type(1) tp-yt-paper-icon-item"
             />
           </div>
@@ -35,6 +36,7 @@
               name="youtube-channel"
               id="yt-ch-2"
               value="2"
+              data-testid="option-2"
               gg-match="ytd-account-item-section-renderer #contents ytd-account-item-renderer:nth-of-type(2) tp-yt-paper-icon-item"
             />
           </div>
@@ -54,6 +56,7 @@
               name="youtube-channel"
               id="yt-ch-3"
               value="3"
+              data-testid="option-3"
               gg-match="ytd-account-item-section-renderer #contents ytd-account-item-renderer:nth-of-type(3) tp-yt-paper-icon-item"
             />
           </div>
@@ -66,7 +69,7 @@
           </div>
         </div>
       </div>
-      <button type="submit">Use selected channel</button>
+      <button type="submit" data-testid="submit">Use selected channel</button>
     </div>
   </body>
 </html>

--- a/getgather/mcp/patterns/zillow-password.html
+++ b/getgather/mcp/patterns/zillow-password.html
@@ -3,10 +3,13 @@
     <p gg-optional gg-match="p#password-error"></p>
     <input
       name="password"
+      data-testid="password"
       gg-match="input[data-testid=password-input]"
       type="password"
       placeholder="Password"
     />
-    <button type="submit" gg-match="button#submit-form-button">Continue</button>
+    <button type="submit" data-testid="submit" gg-match="button#submit-form-button">
+      Continue
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/zillow-signin.html
+++ b/getgather/mcp/patterns/zillow-signin.html
@@ -6,9 +6,12 @@
     <input
       type="email"
       name="email"
+      data-testid="email"
       gg-match="input[data-testid=identifier-input]"
       placeholder="Email Address"
     />
-    <button type="submit" gg-match="button#submit-form-button">Continue</button>
+    <button type="submit" data-testid="submit" gg-match="button#submit-form-button">
+      Continue
+    </button>
   </body>
 </html>

--- a/getgather/mcp/patterns/zillow-signin.html
+++ b/getgather/mcp/patterns/zillow-signin.html
@@ -6,7 +6,7 @@
     <input
       type="email"
       name="email"
-      data-testid="email"
+      data-testid="username"
       gg-match="input[data-testid=identifier-input]"
       placeholder="Email Address"
     />

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "backend:check:type-safety": "uv run pyright .",
     "yaml:check:format": "uv run yamlfix --check $(find . -type f -name '*.yml' -o -name '*.yaml' | grep -v -E '\\.venv/|node_modules/|mcp-tools\\.yaml')",
     "yaml:format": "uv run yamlfix $(find . -type f -name '*.yml' -o -name '*.yaml' | grep -v -E '\\.venv/|node_modules/|mcp-tools\\.yaml')",
-    "check:all": "npm run frontend:check:format && npm run backend:check:format && npm run backend:check:type-safety && npm run yaml:check:format",
+    "patterns:check:testids": "uv run python scripts/check_pattern_testids.py",
+    "check:all": "npm run frontend:check:format && npm run backend:check:format && npm run backend:check:type-safety && npm run yaml:check:format && npm run patterns:check:testids",
     "package": "uv run --group dev pyinstaller remotebrowser-mcp.spec",
     "prepare": "husky"
   },

--- a/scripts/check_pattern_testids.py
+++ b/scripts/check_pattern_testids.py
@@ -1,0 +1,118 @@
+"""Check that dpage pattern files use the shared data-testid convention.
+
+Every visible <input> and <button> in getgather/mcp/patterns/*.html must carry a
+data-testid from the shared vocabulary below, so playwright tests can share locator
+code across brands (page.getByTestId("email"), getByTestId("submit"), ...).
+"""
+
+import re
+import sys
+from pathlib import Path
+
+from bs4 import BeautifulSoup, Tag
+
+PATTERNS_DIR = Path(__file__).resolve().parent.parent / "getgather" / "mcp" / "patterns"
+
+EXACT_TESTIDS = {
+    "answer",  # security question answer
+    "email",  # email / username field, also email-or-phone combo fields
+    "otp",  # single verification-code field
+    "password",
+    "phone",
+    "submit",  # the primary submit/continue button of the form
+    "zip-code",
+}
+TESTID_REGEXES = [
+    re.compile(r"^otp-\d+$"),  # one box of a multi-box OTP field, 0-based
+    re.compile(r"^signin-method-[a-z-]+$"),  # sign-in method radio or button
+    re.compile(r"^option-\d+$"),  # generic choice radio (e.g. account/channel pickers), 1-based
+]
+INPUT_TYPE_TESTIDS = {
+    "email": "email",
+    "password": "password",
+}
+OTP_BOX_RE = re.compile(r"^otp-(\d+)$")
+
+
+def allowed(testid: str) -> bool:
+    return testid in EXACT_TESTIDS or any(r.match(testid) for r in TESTID_REGEXES)
+
+
+def is_exempt(el: Tag) -> bool:
+    if el.has_attr("gg-autoclick"):
+        return True
+    style = re.sub(r"\s", "", str(el.get("style") or ""))
+    if "display:none" in style:
+        return True
+    if el.name == "input" and str(el.get("type") or "").lower() == "hidden":
+        return True
+    # match-only placeholders, e.g. an empty <button> that a gg-autoclick sibling clicks
+    if el.name == "button" and not el.get_text(strip=True):
+        return True
+    return False
+
+
+def describe(el: Tag) -> str:
+    name = el.get("name")
+    return f"<{el.name} name={name!r}>" if name else f"<{el.name}>"
+
+
+def check_file(path: Path) -> list[str]:
+    soup = BeautifulSoup(path.read_text(), "html.parser")
+    errors: list[str] = []
+    otp_boxes: list[int] = []
+    for el in soup.find_all(["input", "button"]):
+        if not isinstance(el, Tag) or is_exempt(el):
+            continue
+        raw = el.get("data-testid")
+        if raw is None:
+            errors.append(f"{describe(el)} is missing data-testid")
+            continue
+        testid = str(raw)
+        if not allowed(testid):
+            errors.append(f"{describe(el)} has unknown data-testid {testid!r}")
+            continue
+        if box := OTP_BOX_RE.match(testid):
+            otp_boxes.append(int(box.group(1)))
+        input_type = str(el.get("type") or "").lower()
+        expected = INPUT_TYPE_TESTIDS.get(input_type) if el.name == "input" else None
+        if expected and testid != expected:
+            errors.append(
+                f"{describe(el)} has data-testid {testid!r}, "
+                f"expected {expected!r} for type={input_type!r}"
+            )
+    if otp_boxes and sorted(otp_boxes) != list(range(len(otp_boxes))):
+        errors.append(
+            f"multi-box OTP data-testids must be contiguous and 0-based, got {sorted(otp_boxes)}"
+        )
+    return errors
+
+
+def main() -> int:
+    files = sorted(PATTERNS_DIR.rglob("*.html"))
+    failures: list[str] = []
+    for path in files:
+        name = path.relative_to(PATTERNS_DIR).as_posix()
+        failures.extend(f"{name}: {error}" for error in check_file(path))
+
+    if failures:
+        print(f"{len(failures)} data-testid issue(s) in getgather/mcp/patterns:", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        print(
+            "\nVisible <input>/<button> elements in pattern files need a data-testid from the"
+            f"\nshared vocabulary so playwright tests can share locators: "
+            f"{', '.join(sorted(EXACT_TESTIDS))},"
+            "\notp-<n> (multi-box OTP, 0-based), signin-method-<method> (sign-in method radios"
+            "\nor buttons), option-<n> (generic choice radios, 1-based)."
+            f"\nSee {Path(__file__).name} to extend the vocabulary for a genuinely new field type.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: {len(files)} pattern files checked")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_pattern_testids.py
+++ b/scripts/check_pattern_testids.py
@@ -15,11 +15,12 @@ PATTERNS_DIR = Path(__file__).resolve().parent.parent / "getgather" / "mcp" / "p
 
 EXACT_TESTIDS = {
     "answer",  # security question answer
-    "email",  # email / username field, also email-or-phone combo fields
+    "email",  # field that accepts an email address only
     "otp",  # single verification-code field
     "password",
     "phone",
     "submit",  # the primary submit/continue button of the form
+    "username",  # combo identifier field (email or phone/username/member number)
     "zip-code",
 }
 TESTID_REGEXES = [
@@ -28,8 +29,9 @@ TESTID_REGEXES = [
     re.compile(r"^option-\d+$"),  # generic choice radio (e.g. account/channel pickers), 1-based
 ]
 INPUT_TYPE_TESTIDS = {
-    "email": "email",
-    "password": "password",
+    # some combo identifier fields use type="email" upstream, so both are allowed there
+    "email": frozenset({"email", "username"}),
+    "password": frozenset({"password"}),
 }
 OTP_BOX_RE = re.compile(r"^otp-(\d+)$")
 
@@ -76,10 +78,10 @@ def check_file(path: Path) -> list[str]:
             otp_boxes.append(int(box.group(1)))
         input_type = str(el.get("type") or "").lower()
         expected = INPUT_TYPE_TESTIDS.get(input_type) if el.name == "input" else None
-        if expected and testid != expected:
+        if expected and testid not in expected:
             errors.append(
                 f"{describe(el)} has data-testid {testid!r}, "
-                f"expected {expected!r} for type={input_type!r}"
+                f"expected one of {sorted(expected)} for type={input_type!r}"
             )
     if otp_boxes and sorted(otp_boxes) != list(range(len(otp_boxes))):
         errors.append(


### PR DESCRIPTION
This PR gives every visible `<input>` and `<button>` in `getgather/mcp/patterns` a `data-testid` from a shared vocabulary so automated playwright tests can share locator code across brands. The attributes are additive: distillation returns the pattern skeleton as-is and dpage renders its body verbatim, so nothing existing changes behavior.

The vocabulary:

| data-testid               | Used for                                                       |
| ------------------------- | -------------------------------------------------------------- |
| `email`                   | fields that accept an email address only                       |
| `username`                | combo identifier fields (email or phone/username/member number) |
| `password`                | password fields                                                |
| `phone`                   | phone number fields                                            |
| `otp`                     | single verification-code fields                                |
| `otp-0` … `otp-N`         | multi-box OTP fields, 0-based                                  |
| `submit`                  | the primary submit/continue button                             |
| `signin-method-*`         | sign-in method radios and alternate-method buttons             |
| `option-<n>`              | generic choice radios (e.g. YouTube channel picker)            |
| `zip-code`, `answer`      | Amazon ZIP and security-question fields                        |

For `email` vs `username`, the upstream `gg-match` selector is the source of truth since pattern placeholders can be inaccurate: `input#ap_email` → `email`, `input#enterUsername` / `input#identifierId` / `input[name='loginKey']` → `username`.

Hidden helpers (`display: none`, `type=hidden`), `gg-autoclick` elements, and empty match-only buttons are exempt. Traveloka's pre-existing `gg-*` testids are renamed to the shared vocabulary, including its inline script selectors.

A new script, `scripts/check_pattern_testids.py`, enforces the convention: it fails on missing or unknown `data-testid` values, type mismatches, and non-contiguous or 1-based OTP box ids. It runs in `check:all` (and the pre-push hook) as `patterns:check:testids`, and as a `pattern-testids` job in the static-analysis workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)