### PR TITLE
CI: Only run Daytona browser backend tests when DAYTONA_API_KEY is set

### DIFF
--- a/.github/workflows/browser-api-e2e-test.yml
+++ b/.github/workflows/browser-api-e2e-test.yml
@@ -13,13 +13,33 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Build the backend matrix dynamically: the daytona choice is only included when DAYTONA_API_KEY is
+  # configured. Secrets can't be referenced in a matrix or job-level `if`, so we emit the backend
+  # list as a job output and feed it into the downstream matrices via fromJSON.
+  setup:
+    runs-on: ubuntu-24.04
+    outputs:
+      browser_backends: ${{ steps.backends.outputs.browser_backends }}
+    steps:
+      - name: Compute browser backends
+        id: backends
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+        run: |
+          if [ -n "$DAYTONA_API_KEY" ]; then
+            echo 'browser_backends=["podman","daytona"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'browser_backends=["podman"]' >> "$GITHUB_OUTPUT"
+          fi
+
   browser-api-e2e-tests-uv:
+    needs: setup
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        browser_backend: [podman, daytona]
+        browser_backend: ${{ fromJSON(needs.setup.outputs.browser_backends) }}
     env:
       BROWSER_BACKEND: ${{ matrix.browser_backend }}
       DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
@@ -59,12 +79,13 @@ jobs:
         run: uv run pytest -v -s tests/test_browser_api_e2e.py
 
   browser-api-e2e-tests-wheel:
+    needs: setup
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        browser_backend: [podman, daytona]
+        browser_backend: ${{ fromJSON(needs.setup.outputs.browser_backends) }}
     env:
       BROWSER_BACKEND: ${{ matrix.browser_backend }}
       DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}

--- a/.github/workflows/extraction-test.yml
+++ b/.github/workflows/extraction-test.yml
@@ -13,13 +13,33 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Build the backend matrix dynamically: the daytona choice is only included when DAYTONA_API_KEY is
+  # configured. Secrets can't be referenced in a matrix or job-level `if`, so we emit the backend
+  # list as a job output and feed it into the downstream matrices via fromJSON.
+  setup:
+    runs-on: ubuntu-24.04
+    outputs:
+      browser_backends: ${{ steps.backends.outputs.browser_backends }}
+    steps:
+      - name: Compute browser backends
+        id: backends
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+        run: |
+          if [ -n "$DAYTONA_API_KEY" ]; then
+            echo 'browser_backends=["podman","daytona"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'browser_backends=["podman"]' >> "$GITHUB_OUTPUT"
+          fi
+
   extraction-tests-uv:
+    needs: setup
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        browser_backend: [podman, daytona]
+        browser_backend: ${{ fromJSON(needs.setup.outputs.browser_backends) }}
     env:
       BROWSER_BACKEND: ${{ matrix.browser_backend }}
       DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
@@ -59,12 +79,13 @@ jobs:
         run: uv run pytest -v -s tests/test_extractions.py
 
   extraction-tests-wheel:
+    needs: setup
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        browser_backend: [podman, daytona]
+        browser_backend: ${{ fromJSON(needs.setup.outputs.browser_backends) }}
     env:
       BROWSER_BACKEND: ${{ matrix.browser_backend }}
       DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}


### PR DESCRIPTION
Add a setup job that computes the backend matrix dynamically and feed it to both E2E test jobs via fromJSON, so the Daytona choice is skipped when the secret is absent.

This way, when someone forks this repo and works on it, and they don't have Daytona account, the CI workflows won't fail on them.