### PR TITLE
Add patterns CRUD API

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,50 @@ _Example_: `curl -X POST 'localhost:23456/api/v1/browsers/test/pages/96FDE4162B8
 
 _Example_: `curl localhost:23456/api/v1/browsers/test/pages/96FDE4162B8EEEBF98E26756D21CF0C5/distilled`
 
+### List all patterns
+
+`GET /api/v1/patterns` returns a JSON array of all pattern filenames (sorted alphabetically), including the extension (`.html` or `.json`).
+
+_Example_: `curl localhost:8300/api/v1/patterns` returns:
+
+```json
+["amazon_signin.html", "amazon_signin.json", "goodreads_signin.html"]
+```
+
+### Get a pattern
+
+`GET /api/v1/patterns/{pattern_name}` returns the content of the named pattern. Accepts an optional `ext` query parameter (`html` or `json`, defaults to `html`). Returns HTTP 404 if the pattern is not found, HTTP 400 if the name contains invalid characters or the extension is unsupported.
+
+_Example_: `curl localhost:8300/api/v1/patterns/amazon_signin` returns the raw HTML of `amazon_signin.html`.
+
+_Example_: `curl localhost:8300/api/v1/patterns/amazon_signin?ext=json` returns the JSON content of `amazon_signin.json`.
+
+### Create or update a pattern
+
+`POST /api/v1/patterns/{pattern_name}` writes content to the named pattern file, creating it if it does not exist. Accepts an optional `ext` query parameter (`html` or `json`, defaults to `html`). Returns HTTP 400 if the name contains invalid characters or the extension is unsupported.
+
+_Example_: `curl -X POST localhost:8300/api/v1/patterns/amazon_signin -H 'Content-Type: application/json' -d '{"content": "<div gg-match=\"...\">"}'` returns:
+
+```json
+{ "pattern_name": "amazon_signin", "status": "created" }
+```
+
+On subsequent calls the status field is `"updated"`.
+
+_Example (JSON)_: `curl -X POST 'localhost:8300/api/v1/patterns/amazon_signin?ext=json' -H 'Content-Type: application/json' -d '{"content": "{\"rows\": \"tr\"}"}'`
+
+### Delete a pattern
+
+`DELETE /api/v1/patterns/{pattern_name}` removes the named pattern file. Accepts an optional `ext` query parameter (`html` or `json`, defaults to `html`). Returns HTTP 404 if the pattern is not found, HTTP 400 if the name contains invalid characters or the extension is unsupported.
+
+_Example_: `curl -X DELETE localhost:8300/api/v1/patterns/amazon_signin` returns:
+
+```json
+{ "pattern_name": "amazon_signin", "status": "deleted" }
+```
+
+_Example (JSON)_: `curl -X DELETE 'localhost:8300/api/v1/patterns/amazon_signin?ext=json'`
+
 ## Backends
 
 The browser API runs on one of three backends, selected at startup:

--- a/getgather/main.py
+++ b/getgather/main.py
@@ -20,6 +20,7 @@ from getgather.config import PROJECT_DIR, settings
 from getgather.logs import MCPLoggingContextMiddleware
 from getgather.mcp.dpage import router as dpage_router
 from getgather.mcp.main import MCPDoc, create_mcp_apps, mcp_app_docs
+from getgather.patterns_api_router import router as patterns_router
 from getgather.tracing import MCPSessionTraceMiddleware, instrument_fastapi
 from getgather.zen_distill import short_lived_mcp_tool
 
@@ -115,6 +116,7 @@ async def mcp_slash_middleware(
 
 # Mount routers and apps AFTER middleware
 app.include_router(browsers_router)
+app.include_router(patterns_router)
 app.include_router(dpage_router)
 
 for mcp_app in mcp_apps:

--- a/getgather/patterns_api_router.py
+++ b/getgather/patterns_api_router.py
@@ -1,0 +1,108 @@
+import os
+import re
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import JSONResponse, PlainTextResponse
+from loguru import logger
+from pydantic import BaseModel
+
+router = APIRouter()
+
+PATTERNS_DIR = os.path.join(os.path.dirname(__file__), "mcp", "patterns")
+
+_VALID_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
+_SUPPORTED_EXTENSIONS = (".html", ".json")
+_MEDIA_TYPES: dict[str, str] = {".html": "text/html", ".json": "application/json"}
+
+
+def _validate_name(pattern_name: str) -> None:
+    if not _VALID_NAME.match(pattern_name):
+        raise HTTPException(status_code=400, detail="Invalid pattern name")
+
+
+def _validate_ext(ext: str) -> str:
+    suffix = f".{ext}"
+    if suffix not in _SUPPORTED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid extension '.{ext}'. Must be one of: {', '.join(_SUPPORTED_EXTENSIONS)}",
+        )
+    return suffix
+
+
+def _pattern_path(pattern_name: str, suffix: str) -> str:
+    return os.path.join(PATTERNS_DIR, f"{pattern_name}{suffix}")
+
+
+class PatternBody(BaseModel):
+    content: str
+
+
+@router.get("/api/v1/patterns")
+async def list_patterns() -> JSONResponse:
+    logger.info("Listing all patterns...")
+    try:
+        names = sorted(
+            f
+            for f in os.listdir(PATTERNS_DIR)
+            if any(f.endswith(ext) for ext in _SUPPORTED_EXTENSIONS)
+        )
+        return JSONResponse(names)
+    except Exception as e:
+        detail = "Unable to list patterns"
+        logger.error(f"{detail} Exception={e}")
+        raise HTTPException(status_code=500, detail=detail)
+
+
+@router.get("/api/v1/patterns/{pattern_name}")
+async def get_pattern(pattern_name: str, ext: str = Query("html")) -> PlainTextResponse:
+    _validate_name(pattern_name)
+    suffix = _validate_ext(ext)
+    path = _pattern_path(pattern_name, suffix)
+    if not os.path.isfile(path):
+        raise HTTPException(status_code=404, detail=f"Pattern {pattern_name!r} not found")
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
+        return PlainTextResponse(content, media_type=_MEDIA_TYPES[suffix])
+    except Exception as e:
+        detail = f"Unable to read pattern {pattern_name!r}"
+        logger.error(f"{detail} Exception={e}")
+        raise HTTPException(status_code=500, detail=detail)
+
+
+@router.post("/api/v1/patterns/{pattern_name}")
+async def upsert_pattern(
+    pattern_name: str, body: PatternBody, ext: str = Query("html")
+) -> dict[str, str]:
+    _validate_name(pattern_name)
+    suffix = _validate_ext(ext)
+    path = _pattern_path(pattern_name, suffix)
+    exists = os.path.isfile(path)
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(body.content)
+        action = "updated" if exists else "created"
+        logger.info(f"Pattern {pattern_name!r} {action}.")
+        return {"pattern_name": pattern_name, "status": action}
+    except Exception as e:
+        detail = f"Unable to write pattern {pattern_name!r}"
+        logger.error(f"{detail} Exception={e}")
+        raise HTTPException(status_code=500, detail=detail)
+
+
+@router.delete("/api/v1/patterns/{pattern_name}")
+async def delete_pattern(pattern_name: str, ext: str = Query("html")) -> dict[str, str]:
+    _validate_name(pattern_name)
+    suffix = _validate_ext(ext)
+    path = _pattern_path(pattern_name, suffix)
+    if not os.path.isfile(path):
+        raise HTTPException(status_code=404, detail=f"Pattern {pattern_name!r} not found")
+    try:
+        os.remove(path)
+        logger.info(f"Pattern {pattern_name!r} deleted.")
+        return {"pattern_name": pattern_name, "status": "deleted"}
+    except Exception as e:
+        detail = f"Unable to delete pattern {pattern_name!r}"
+        logger.error(f"{detail} Exception={e}")
+        raise HTTPException(status_code=500, detail=detail)

--- a/tests/test_extractions.py
+++ b/tests/test_extractions.py
@@ -171,3 +171,51 @@ class TestCNN:
         assert "link" in first
         assert isinstance(first["link"], str)
         assert first["link"]
+
+
+@pytest.mark.distill
+class TestCBC:
+    @pytest.fixture(autouse=True)
+    def upload_cbc_patterns(self, client: httpx.Client) -> Generator[None, None, None]:
+        html_content = """<html gg-domain="cbc">
+  <head>
+    <title>CBC Headlines</title>
+  </head>
+  <body>
+    <ul gg-stop gg-convert="cbc-headlines.json" gg-match-html="main ul"></ul>
+  </body>
+</html>
+"""
+        json_content = """{
+  "rows": "ul li",
+  "columns": [
+    { "name": "title", "selector": "li a" },
+    { "name": "link", "selector": "li a", "attribute": "href" }
+  ]
+}
+"""
+        client.post("/api/v1/patterns/cbc-headlines", json={"content": html_content})
+        client.post(
+            "/api/v1/patterns/cbc-headlines",
+            params={"ext": "json"},
+            json={"content": json_content},
+        )
+        yield
+        client.delete("/api/v1/patterns/cbc-headlines")
+        client.delete("/api/v1/patterns/cbc-headlines", params={"ext": "json"})
+
+    def test_navigate_and_distill(self, client: httpx.Client, browser_ids: list[str]) -> None:
+        browser_id, page_id = prepare_new_browser(client, "cbc", browser_ids)
+
+        navigate_page(client, browser_id, page_id, "https://www.cbc.ca/lite/news")
+
+        data = get_distilled_json(client, browser_id, page_id)
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        first = data[0]
+        assert isinstance(first, dict)
+        assert "title" in first
+        assert "link" in first
+        assert isinstance(first["link"], str)
+        assert first["link"]

--- a/tests/test_patterns_api_router.py
+++ b/tests/test_patterns_api_router.py
@@ -1,0 +1,219 @@
+import os
+import tempfile
+from collections.abc import Generator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import getgather.patterns_api_router as patterns_module
+from getgather.patterns_api_router import router
+
+
+@pytest.fixture
+def patterns_dir() -> Generator[str, None, None]:
+    with tempfile.TemporaryDirectory() as d:
+        yield d
+
+
+@pytest.fixture
+def client(patterns_dir: str, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setattr(patterns_module, "PATTERNS_DIR", patterns_dir)
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+class TestListPatterns:
+    def test_empty_directory(self, client: TestClient) -> None:
+        response = client.get("/api/v1/patterns")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_returns_sorted_names(self, client: TestClient, patterns_dir: str) -> None:
+        for name in ["zebra", "alpha", "middle"]:
+            open(os.path.join(patterns_dir, f"{name}.html"), "w").close()
+        response = client.get("/api/v1/patterns")
+        assert response.status_code == 200
+        assert response.json() == ["alpha.html", "middle.html", "zebra.html"]
+
+    def test_includes_html_and_json(self, client: TestClient, patterns_dir: str) -> None:
+        open(os.path.join(patterns_dir, "amazon.html"), "w").close()
+        open(os.path.join(patterns_dir, "amazon.json"), "w").close()
+        open(os.path.join(patterns_dir, "goodreads.html"), "w").close()
+        response = client.get("/api/v1/patterns")
+        assert response.json() == ["amazon.html", "amazon.json", "goodreads.html"]
+
+    def test_ignores_unsupported_files(self, client: TestClient, patterns_dir: str) -> None:
+        open(os.path.join(patterns_dir, "valid.html"), "w").close()
+        open(os.path.join(patterns_dir, "data.json"), "w").close()
+        open(os.path.join(patterns_dir, "ignore.txt"), "w").close()
+        open(os.path.join(patterns_dir, "ignore.py"), "w").close()
+        response = client.get("/api/v1/patterns")
+        assert response.json() == ["data.json", "valid.html"]
+
+
+class TestGetPattern:
+    def test_returns_html_content(self, client: TestClient, patterns_dir: str) -> None:
+        path = os.path.join(patterns_dir, "example.html")
+        with open(path, "w") as f:
+            f.write("<div>hello</div>")
+        response = client.get("/api/v1/patterns/example")
+        assert response.status_code == 200
+        assert response.text == "<div>hello</div>"
+        assert "text/html" in response.headers["content-type"]
+
+    def test_returns_json_content(self, client: TestClient, patterns_dir: str) -> None:
+        path = os.path.join(patterns_dir, "converter.json")
+        with open(path, "w") as f:
+            f.write('{"rows": "tr"}')
+        response = client.get("/api/v1/patterns/converter?ext=json")
+        assert response.status_code == 200
+        assert response.text == '{"rows": "tr"}'
+        assert "application/json" in response.headers["content-type"]
+
+    def test_not_found(self, client: TestClient) -> None:
+        response = client.get("/api/v1/patterns/missing")
+        assert response.status_code == 404
+
+    def test_not_found_json(self, client: TestClient) -> None:
+        response = client.get("/api/v1/patterns/missing?ext=json")
+        assert response.status_code == 404
+
+    def test_invalid_name_rejected(self, client: TestClient) -> None:
+        response = client.get("/api/v1/patterns/bad%20name")
+        assert response.status_code == 400
+
+    def test_invalid_name_with_slash(self, client: TestClient) -> None:
+        response = client.get("/api/v1/patterns/foo/bar")
+        assert response.status_code == 404
+
+    def test_invalid_name_with_dots(self, client: TestClient) -> None:
+        response = client.get("/api/v1/patterns/foo.bar")
+        assert response.status_code == 400
+
+    def test_invalid_ext_rejected(self, client: TestClient) -> None:
+        response = client.get("/api/v1/patterns/example?ext=xml")
+        assert response.status_code == 400
+
+    def test_html_and_json_are_independent(self, client: TestClient, patterns_dir: str) -> None:
+        with open(os.path.join(patterns_dir, "dual.html"), "w") as f:
+            f.write("<p>html</p>")
+        with open(os.path.join(patterns_dir, "dual.json"), "w") as f:
+            f.write('{"key": "val"}')
+        html_resp = client.get("/api/v1/patterns/dual")
+        json_resp = client.get("/api/v1/patterns/dual?ext=json")
+        assert html_resp.text == "<p>html</p>"
+        assert json_resp.text == '{"key": "val"}'
+
+
+class TestUpsertPattern:
+    def test_create_new_pattern(self, client: TestClient, patterns_dir: str) -> None:
+        response = client.post("/api/v1/patterns/new-pattern", json={"content": "<p>test</p>"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pattern_name"] == "new-pattern"
+        assert data["status"] == "created"
+        assert os.path.isfile(os.path.join(patterns_dir, "new-pattern.html"))
+
+    def test_file_content_written(self, client: TestClient, patterns_dir: str) -> None:
+        client.post("/api/v1/patterns/mypattern", json={"content": "<span>hi</span>"})
+        with open(os.path.join(patterns_dir, "mypattern.html")) as f:
+            assert f.read() == "<span>hi</span>"
+
+    def test_update_existing_pattern(self, client: TestClient, patterns_dir: str) -> None:
+        path = os.path.join(patterns_dir, "existing.html")
+        with open(path, "w") as f:
+            f.write("old")
+        response = client.post("/api/v1/patterns/existing", json={"content": "new"})
+        assert response.status_code == 200
+        assert response.json()["status"] == "updated"
+        with open(path) as f:
+            assert f.read() == "new"
+
+    def test_create_json_pattern(self, client: TestClient, patterns_dir: str) -> None:
+        response = client.post(
+            "/api/v1/patterns/converter?ext=json",
+            json={"content": '{"rows": "tr", "columns": ["name"]}'},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pattern_name"] == "converter"
+        assert data["status"] == "created"
+        path = os.path.join(patterns_dir, "converter.json")
+        assert os.path.isfile(path)
+        with open(path) as f:
+            assert f.read() == '{"rows": "tr", "columns": ["name"]}'
+
+    def test_update_json_pattern(self, client: TestClient, patterns_dir: str) -> None:
+        path = os.path.join(patterns_dir, "data.json")
+        with open(path, "w") as f:
+            f.write('{"old": true}')
+        response = client.post("/api/v1/patterns/data?ext=json", json={"content": '{"new": true}'})
+        assert response.status_code == 200
+        assert response.json()["status"] == "updated"
+        with open(path) as f:
+            assert f.read() == '{"new": true}'
+
+    def test_invalid_name_rejected(self, client: TestClient) -> None:
+        response = client.post("/api/v1/patterns/bad name!", json={"content": "x"})
+        assert response.status_code == 400
+
+    def test_invalid_ext_rejected(self, client: TestClient) -> None:
+        response = client.post("/api/v1/patterns/test?ext=xml", json={"content": "<x/>"})
+        assert response.status_code == 400
+
+    def test_html_and_json_independent(self, client: TestClient, patterns_dir: str) -> None:
+        client.post("/api/v1/patterns/dual", json={"content": "<p>html</p>"})
+        client.post("/api/v1/patterns/dual?ext=json", json={"content": '{"k":"v"}'})
+        with open(os.path.join(patterns_dir, "dual.html")) as f:
+            assert f.read() == "<p>html</p>"
+        with open(os.path.join(patterns_dir, "dual.json")) as f:
+            assert f.read() == '{"k":"v"}'
+
+
+class TestDeletePattern:
+    def test_delete_existing_pattern(self, client: TestClient, patterns_dir: str) -> None:
+        path = os.path.join(patterns_dir, "todelete.html")
+        open(path, "w").close()
+        response = client.delete("/api/v1/patterns/todelete")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pattern_name"] == "todelete"
+        assert data["status"] == "deleted"
+        assert not os.path.exists(path)
+
+    def test_delete_json_pattern(self, client: TestClient, patterns_dir: str) -> None:
+        path = os.path.join(patterns_dir, "converter.json")
+        open(path, "w").close()
+        response = client.delete("/api/v1/patterns/converter?ext=json")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pattern_name"] == "converter"
+        assert data["status"] == "deleted"
+        assert not os.path.exists(path)
+
+    def test_delete_nonexistent_pattern(self, client: TestClient) -> None:
+        response = client.delete("/api/v1/patterns/ghost")
+        assert response.status_code == 404
+
+    def test_delete_nonexistent_json_pattern(self, client: TestClient) -> None:
+        response = client.delete("/api/v1/patterns/ghost?ext=json")
+        assert response.status_code == 404
+
+    def test_invalid_name_rejected(self, client: TestClient) -> None:
+        response = client.delete("/api/v1/patterns/bad%21name")
+        assert response.status_code == 400
+
+    def test_invalid_ext_rejected(self, client: TestClient) -> None:
+        response = client.delete("/api/v1/patterns/test?ext=xml")
+        assert response.status_code == 400
+
+    def test_delete_html_does_not_affect_json(self, client: TestClient, patterns_dir: str) -> None:
+        html_path = os.path.join(patterns_dir, "dual.html")
+        json_path = os.path.join(patterns_dir, "dual.json")
+        open(html_path, "w").close()
+        open(json_path, "w").close()
+        client.delete("/api/v1/patterns/dual")
+        assert not os.path.exists(html_path)
+        assert os.path.exists(json_path)


### PR DESCRIPTION
Add `/api/v1/patterns` endpoints (list, get, upsert, delete) backed by the existing patterns directory, with name validation to prevent path traversal. Update README with API documentation.

Add a CBC distillation E2E test that uploads custom patterns (`.html` and `.json` converter) before running extraction, demonstrating the full upload-then-distill workflow for sites without built-in patterns.

<img width="1980" height="1580" alt="image" src="https://github.com/user-attachments/assets/c066a9d0-1c2b-4140-ac60-d806bf337e53" />
<img width="1980" height="1580" alt="image" src="https://github.com/user-attachments/assets/c066a9d0-1c2b-4140-ac60-d806bf337e53" />
