### PR TITLE
fix: match Amazon Prime empty-purchases pattern

### DIFF
--- a/getgather/mcp/patterns/amazon-prime-library-empty.html
+++ b/getgather/mcp/patterns/amazon-prime-library-empty.html
@@ -1,4 +1,4 @@
-<html gg-domain="amazon" gg-priority="2">
+<html gg-domain="amazon">
   <head>
     <title>Prime Video: You don't have any purchases</title>
   </head>

--- a/getgather/mcp/patterns/amazon-prime-library-empty.html
+++ b/getgather/mcp/patterns/amazon-prime-library-empty.html
@@ -1,0 +1,13 @@
+<html gg-domain="amazon" gg-priority="2">
+  <head>
+    <title>Prime Video: You don't have any purchases</title>
+  </head>
+  <body>
+    <div>
+      <div
+        gg-stop
+        gg-match-html="//p[contains(text(), 'You don\'t have any Purchases')]"
+      ></div>
+    </div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/amazon-prime-library-empty.html
+++ b/getgather/mcp/patterns/amazon-prime-library-empty.html
@@ -6,7 +6,7 @@
     <div>
       <div
         gg-stop
-        gg-match-html="//p[contains(text(), 'You don\'t have any Purchases')]"
+        gg-match-html="//p[contains(text(), concat('You don', &quot;'&quot;, 't have any Purchases'))]"
       ></div>
     </div>
   </body>


### PR DESCRIPTION
Add a distill pattern for the Prime Video "You don't have any Purchases & Rentals" empty state. Uses XPath concat() to embed the apostrophe (XPath 1.0 has no string escaping).

## Test

https://github.com/user-attachments/assets/0c783470-2f60-4500-97f2-5f76b66d0530



