### PR TITLE
fix: close tab on timeout

### DIFF
--- a/getgather/config.py
+++ b/getgather/config.py
@@ -38,7 +38,8 @@ class Settings(AuthSettings, BaseSettings):
     # Overall wall-clock deadline for a single MCP tool call, in seconds.
     # Guards against a stuck tool call (e.g. a hung page navigation) running
     # indefinitely and pinning its browser.
-    MCP_TOOL_CALL_TIMEOUT: int = 300
+    MCP_TOOL_CALL_TIMEOUT: int = 600
+    MCP_ACTION_TIMEOUT: int = 300
 
     @property
     def data_dir(self) -> Path:

--- a/getgather/config.py
+++ b/getgather/config.py
@@ -38,7 +38,7 @@ class Settings(AuthSettings, BaseSettings):
     # Overall wall-clock deadline for a single MCP tool call, in seconds.
     # Guards against a stuck tool call (e.g. a hung page navigation) running
     # indefinitely and pinning its browser.
-    MCP_TOOL_CALL_TIMEOUT: int = 600
+    MCP_TOOL_CALL_TIMEOUT: int = 900
     MCP_ACTION_TIMEOUT: int = 300
 
     @property

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -90,6 +90,17 @@ def _target_domain_from_initial_url(initial_url: str) -> str:
     return hostname or ""
 
 
+async def _run_action_with_timeout(
+    action: Any, page: zd.Tab, browser: zd.Browser
+) -> dict[str, Any]:
+    timeout = settings.MCP_ACTION_TIMEOUT
+    try:
+        async with asyncio.timeout(timeout):
+            return await action(page, browser)
+    except TimeoutError:
+        raise TimeoutError(f"Action timed out after {timeout}s") from None
+
+
 async def _try_action_with_probe(
     browser: zd.Browser,
     initial_url: str,
@@ -110,11 +121,14 @@ async def _try_action_with_probe(
             location=initial_url, page=page, browser=browser, timeout=timeout
         )
         if terminated:
-            result = await action(page, browser)
+            result = await _run_action_with_timeout(action, page, browser)
             await safe_close_page(page)
             return result
         await safe_close_page(page)
         return None
+    except TimeoutError:
+        await safe_close_page(page)
+        raise
     except Exception as e:
         logger.info(f"Stateless probe failed for {initial_url}: {e}")
         await safe_close_page(page)
@@ -726,13 +740,18 @@ async def zen_dpage_with_action(
     # 2a. Explicit signin_id: reuse that session directly.
     if signin_id:
         browser = await init_zendriver_browser(signin_id)
+        page: zd.Tab | None = None
         try:
             page = await get_new_page(browser)
             await zen_navigate_with_retry(page, initial_url)
-            result = await action(page, browser)
+            result = await _run_action_with_timeout(action, page, browser)
             await safe_close_page(page)
             logger.info("Action succeeded with existing signin_id session!")
             return result
+        except TimeoutError:
+            if page is not None:
+                await safe_close_page(page)
+            raise
         except Exception as e:
             logger.info(f"zen_dpage_with_action failed with signin_id session: {e}")
 

--- a/getgather/mcp/main.py
+++ b/getgather/mcp/main.py
@@ -159,7 +159,6 @@ class LocationProxyMiddleware(Middleware):
                 f"Tool call '{context.message.name}' exceeded {timeout}s timeout; "
                 f"aborting and releasing browser"
             )
-            await self._release_session_browser(signin_id)
             raise TimeoutError(
                 f"Tool call '{context.message.name}' timed out after {timeout}s"
             ) from None

--- a/getgather/mcp/main.py
+++ b/getgather/mcp/main.py
@@ -159,6 +159,7 @@ class LocationProxyMiddleware(Middleware):
                 f"Tool call '{context.message.name}' exceeded {timeout}s timeout; "
                 f"aborting and releasing browser"
             )
+            await self._release_session_browser(signin_id)
             raise TimeoutError(
                 f"Tool call '{context.message.name}' timed out after {timeout}s"
             ) from None


### PR DESCRIPTION
# Close tab (not browser) when a custom action times out

## Summary

When an MCP tool call hangs inside a custom browser action, the middleware’s overall timeout can fire and release the entire browser session. The demo app often issues follow-up tool calls against that same session, so those calls fail because the browser is already gone.

This PR adds a shorter, action-level timeout that fails fast, closes only the tab that was opened for the action, and leaves the browser session intact for subsequent tool calls.

## Problem

MCP tool calls are bounded by `MCP_TOOL_CALL_TIMEOUT` in middleware (`getgather/mcp/main.py`). On expiry, the middleware logs the failure and calls `_release_session_browser`, which terminates the incognito/session browser.

That behavior is correct for a truly stuck tool call, but it is too aggressive when the hang is inside a **custom action** (e.g. Amazon pagination, scraping loops in `zen_dpage_with_action`). In practice:

1. Tool A starts a custom action on a signed-in browser.
2. The action hangs or runs longer than expected.
3. Middleware hits the tool-call timeout and releases the browser.
4. The demo app retries or calls Tool B with the same `x-signin-id`.
5. Tool B fails because the browser session no longer exists.

## Solution

Introduce a separate, shorter deadline for custom actions and handle timeouts at the tab level before the middleware needs to tear down the browser.

### Two-tier timeouts

| Setting | Default | Scope |
|---|---|---|
| `MCP_ACTION_TIMEOUT` | 300s | Custom `action(page, browser)` callbacks in `dpage.py` |
| `MCP_TOOL_CALL_TIMEOUT` | 900s | Entire MCP tool call (middleware) |

The action timeout is intentionally shorter than the tool-call timeout. A hung custom action should fail at 300s, close its tab, and return an error — without waiting for the 900s middleware deadline that would release the browser.

Applied in:

- `_try_action_with_probe` — stateless probe path on the shared global browser
- `zen_dpage_with_action` — explicit `x-signin-id` session path

On `TimeoutError`:

- Call `safe_close_page(page)` to close **only the tab** used for that action
- Re-raise the error so the client gets a clear timeout failure
- Do **not** terminate the browser session

`TimeoutError` is excluded from broad `except Exception` handlers so it is not swallowed as a failed probe or silent fallback.

## Files changed

- `getgather/config.py` — add `MCP_ACTION_TIMEOUT` (300s); set `MCP_TOOL_CALL_TIMEOUT` to 900s
- `getgather/mcp/dpage.py` — wrap custom actions with `asyncio.wait_for`; close tab on action timeout

