### PR TITLE
fix: stabilize input fill against React remount on Walmart sign-in

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -961,82 +961,38 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
             el.dispatchEvent(new Event("change", {{ bubbles: true }}));
         }}
 
-        async function setAndSubmit(inputSelector, value, submitSelector, typingDelayMs, idleWindowMs, timeout) {{
-            const hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-            const useHook = hook && typeof hook.onCommitFiberRoot === "function";
+        // For debug logging only — not used in any fill or submit logic.
+        function getReactValue(el) {{
+            const fiberKey = Object.keys(el).find(k => k.startsWith("__reactFiber"));
+            const fiber = fiberKey ? el[fiberKey] : null;
+            return fiber?.memoizedProps?.value ?? null;
+        }}
 
-            let lastCommitAt = Date.now();
-            let fillInProgress = false;
-            let originalOnCommit = null;
+        async function setValueWithPoll(selector, value, typingDelayMs, timeout) {{
+            const el = document.querySelector(selector);
+            if (!el) return {{ success: false, reason: "element not found" }};
+            await fillInput(el, value, typingDelayMs);
 
-            if (useHook) {{
-                originalOnCommit = hook.onCommitFiberRoot.bind(hook);
-                hook.onCommitFiberRoot = function(...args) {{
-                    lastCommitAt = Date.now();
-                    try {{ originalOnCommit(...args); }} catch (_) {{}}
-                    if (!fillInProgress) {{
-                        const el = findCss(inputSelector, document);
-                        if (el && el.value !== value) {{
-                            fillInProgress = true;
-                            fillInput(el, value, typingDelayMs).finally(() => {{ fillInProgress = false; }});
-                        }}
-                    }}
+            let refillCount = 0;
+            const deadline = Date.now() + timeout;
+            while (Date.now() < deadline) {{
+                await sleep(50);
+                const inputEl = document.querySelector(selector);
+                if (!inputEl) continue;
+                if (inputEl.value !== value) {{
+                    refillCount++;
+                    console.log(`set_value: refill #${{refillCount}}, value was "${{inputEl.value}}", expected "${{value}}"`);
+                    await fillInput(inputEl, value, typingDelayMs);
+                    continue;
+                }}
+                return {{
+                    success: true,
+                    actualValue: inputEl.value,
+                    reactValue: getReactValue(inputEl),
+                    refillCount: refillCount,
                 }};
             }}
-
-            try {{
-                const el = findCss(inputSelector, document);
-                if (!el) return {{ success: false, reason: "element not found" }};
-                await fillInput(el, value, typingDelayMs);
-
-                let refillCount = 0;
-                const deadline = Date.now() + timeout;
-                while (Date.now() < deadline) {{
-                    await sleep(50);
-
-                    // With hook: wait for React to go idle before checking/submitting.
-                    // Without hook: poll and re-fill if value was wiped, then submit.
-                    if (useHook && (Date.now() - lastCommitAt) < idleWindowMs) continue;
-
-                    const inputEl = findCss(inputSelector, document);
-                    if (!inputEl) continue;
-
-                    // Re-fill if value was cleared (covers no-hook polling case).
-                    if (inputEl.value !== value && !fillInProgress) {{
-                        refillCount++;
-                        console.log(`set_and_submit: refill #${{refillCount}}, value was "${{inputEl.value}}", expected "${{value}}"`);
-                        fillInProgress = true;
-                        await fillInput(inputEl, value, typingDelayMs);
-                        fillInProgress = false;
-                        if (useHook) lastCommitAt = Date.now(); // reset idle window after re-fill
-                        continue;
-                    }}
-
-                    if (inputEl.value !== value) continue; // fill in progress, wait
-
-                    const submitEl = findCss(submitSelector, document);
-                    if (!submitEl) continue;
-
-                    submitEl.click();
-
-                    const fiberKey = Object.keys(inputEl).find(k => k.startsWith("__reactFiber"));
-                    const fiber = fiberKey ? inputEl[fiberKey] : null;
-                    const reactValue = fiber?.memoizedProps?.value ?? null;
-                    return {{
-                        success: true,
-                        actualValue: inputEl.value,
-                        reactValue: reactValue,
-                        usedHook: useHook,
-                        refillCount: refillCount,
-                    }};
-                }}
-
-                return {{ success: false, reason: "timeout" }};
-            }} finally {{
-                if (useHook && originalOnCommit !== null) {{
-                    hook.onCommitFiberRoot = originalOnCommit;
-                }}
-            }}
+            return {{ success: false, reason: "timeout" }};
         }}
 
         for (const [index, action] of actions.entries()) {{
@@ -1081,26 +1037,15 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
                 if (kind === "click") {{
                     element.click();
                     output[key] = true;
-                }} else if (kind === "set_and_submit") {{
-                    const value = typeof action?.value === "string" ? action.value : "";
-                    const submitSelector = typeof action?.submit_selector === "string" ? action.submit_selector : "";
-                    const requestedDelay = Number(action?.typing_delay_ms);
-                    const typingDelayMs = Number.isFinite(requestedDelay)
-                        ? Math.max(0, Math.min(250, requestedDelay))
-                        : 25;
-                    const idleWindowMs = Number(action?.idle_window_ms) || 300;
-                    const timeout = Number(action?.timeout_ms) || 10000;
-                    if (actionDelayMs > 0) await sleep(actionDelayMs);
-                    output[key] = await setAndSubmit(selector, value, submitSelector, typingDelayMs, idleWindowMs, timeout);
                 }} else if (kind === "set_value") {{
                     const value = typeof action?.value === "string" ? action.value : "";
                     const requestedDelay = Number(action?.typing_delay_ms);
                     const typingDelayMs = Number.isFinite(requestedDelay)
                         ? Math.max(0, Math.min(250, requestedDelay))
                         : 25;
+                    const timeout = Number(action?.timeout_ms) || 5000;
                     if (actionDelayMs > 0) await sleep(actionDelayMs);
-                    await fillInput(element, value, typingDelayMs);
-                    output[key] = true;
+                    output[key] = await setValueWithPoll(selector, value, typingDelayMs, timeout);
                 }} else {{
                     output[key] = false;
                 }}
@@ -1121,9 +1066,9 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
                 if isinstance(v, dict):
                     vd: dict[str, object] = v  # pyright: ignore[reportUnknownVariableType]
                     logger.info(
-                        f"set_and_submit debug: key={k} "
+                        f"set_value debug: key={k} "
                         f"success={vd.get('success')} actualValue={vd.get('actualValue')!r} "
-                        f"reactValue={vd.get('reactValue')!r} usedHook={vd.get('usedHook')} "
+                        f"reactValue={vd.get('reactValue')!r} "
                         f"refillCount={vd.get('refillCount')} reason={vd.get('reason')!r}"
                     )
                     output[str(k)] = vd.get("success") is True  # pyright: ignore[reportUnknownArgumentType]

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -916,6 +916,129 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
             return null;
         }}
 
+        const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+        const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+            window.HTMLInputElement.prototype,
+            "value"
+        )?.set;
+        const nativeTextAreaValueSetter = Object.getOwnPropertyDescriptor(
+            window.HTMLTextAreaElement.prototype,
+            "value"
+        )?.set;
+
+        const setNativeValue = (el, nextValue) => {{
+            if (el instanceof HTMLInputElement && nativeInputValueSetter) {{
+                nativeInputValueSetter.call(el, nextValue);
+            }} else if (el instanceof HTMLTextAreaElement && nativeTextAreaValueSetter) {{
+                nativeTextAreaValueSetter.call(el, nextValue);
+            }} else {{
+                el.value = nextValue;
+            }}
+        }};
+
+        async function fillInput(el, value, typingDelayMs) {{
+            el.focus();
+            setNativeValue(el, "");
+            el.dispatchEvent(new InputEvent("input", {{
+                bubbles: true,
+                inputType: "deleteContentBackward",
+                data: null,
+            }}));
+            let currentValue = "";
+            for (const char of value) {{
+                el.dispatchEvent(new KeyboardEvent("keydown", {{ key: char, bubbles: true }}));
+                currentValue += char;
+                setNativeValue(el, currentValue);
+                el.dispatchEvent(new InputEvent("input", {{
+                    bubbles: true,
+                    inputType: "insertText",
+                    data: char,
+                }}));
+                el.dispatchEvent(new KeyboardEvent("keyup", {{ key: char, bubbles: true }}));
+                if (typingDelayMs > 0) await sleep(typingDelayMs);
+            }}
+            el.dispatchEvent(new Event("change", {{ bubbles: true }}));
+        }}
+
+        async function setAndSubmit(inputSelector, value, submitSelector, typingDelayMs, idleWindowMs, timeout) {{
+            const hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+            const useHook = hook && typeof hook.onCommitFiberRoot === "function";
+
+            let lastCommitAt = Date.now();
+            let fillInProgress = false;
+            let originalOnCommit = null;
+
+            if (useHook) {{
+                originalOnCommit = hook.onCommitFiberRoot.bind(hook);
+                hook.onCommitFiberRoot = function(...args) {{
+                    lastCommitAt = Date.now();
+                    try {{ originalOnCommit(...args); }} catch (_) {{}}
+                    if (!fillInProgress) {{
+                        const el = findCss(inputSelector, document);
+                        if (el && el.value !== value) {{
+                            fillInProgress = true;
+                            fillInput(el, value, typingDelayMs).finally(() => {{ fillInProgress = false; }});
+                        }}
+                    }}
+                }};
+            }}
+
+            try {{
+                const el = findCss(inputSelector, document);
+                if (!el) return {{ success: false, reason: "element not found" }};
+                await fillInput(el, value, typingDelayMs);
+
+                let refillCount = 0;
+                const deadline = Date.now() + timeout;
+                while (Date.now() < deadline) {{
+                    await sleep(50);
+
+                    // With hook: wait for React to go idle before checking/submitting.
+                    // Without hook: poll and re-fill if value was wiped, then submit.
+                    if (useHook && (Date.now() - lastCommitAt) < idleWindowMs) continue;
+
+                    const inputEl = findCss(inputSelector, document);
+                    if (!inputEl) continue;
+
+                    // Re-fill if value was cleared (covers no-hook polling case).
+                    if (inputEl.value !== value && !fillInProgress) {{
+                        refillCount++;
+                        console.log(`set_and_submit: refill #${{refillCount}}, value was "${{inputEl.value}}", expected "${{value}}"`);
+                        fillInProgress = true;
+                        await fillInput(inputEl, value, typingDelayMs);
+                        fillInProgress = false;
+                        if (useHook) lastCommitAt = Date.now(); // reset idle window after re-fill
+                        continue;
+                    }}
+
+                    if (inputEl.value !== value) continue; // fill in progress, wait
+
+                    const submitEl = findCss(submitSelector, document);
+                    if (!submitEl) continue;
+
+                    submitEl.click();
+
+                    const fiberKey = Object.keys(inputEl).find(k => k.startsWith("__reactFiber"));
+                    const fiber = fiberKey ? inputEl[fiberKey] : null;
+                    const reactValue = fiber?.memoizedProps?.value ?? null;
+                    return {{
+                        success: true,
+                        actualValue: inputEl.value,
+                        reactValue: reactValue,
+                        usedHook: useHook,
+                        refillCount: refillCount,
+                    }};
+                }}
+
+                return {{ success: false, reason: "timeout" }};
+            }} finally {{
+                if (useHook && originalOnCommit !== null) {{
+                    hook.onCommitFiberRoot = originalOnCommit;
+                }}
+            }}
+        }}
+
         for (const [index, action] of actions.entries()) {{
             const actionDelayMs = Number(action?.action_delay_ms) || 0;
             if (index > 0 && actionDelayMs > 0) {{
@@ -958,65 +1081,25 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
                 if (kind === "click") {{
                     element.click();
                     output[key] = true;
+                }} else if (kind === "set_and_submit") {{
+                    const value = typeof action?.value === "string" ? action.value : "";
+                    const submitSelector = typeof action?.submit_selector === "string" ? action.submit_selector : "";
+                    const requestedDelay = Number(action?.typing_delay_ms);
+                    const typingDelayMs = Number.isFinite(requestedDelay)
+                        ? Math.max(0, Math.min(250, requestedDelay))
+                        : 25;
+                    const idleWindowMs = Number(action?.idle_window_ms) || 300;
+                    const timeout = Number(action?.timeout_ms) || 10000;
+                    if (actionDelayMs > 0) await sleep(actionDelayMs);
+                    output[key] = await setAndSubmit(selector, value, submitSelector, typingDelayMs, idleWindowMs, timeout);
                 }} else if (kind === "set_value") {{
                     const value = typeof action?.value === "string" ? action.value : "";
                     const requestedDelay = Number(action?.typing_delay_ms);
                     const typingDelayMs = Number.isFinite(requestedDelay)
                         ? Math.max(0, Math.min(250, requestedDelay))
                         : 25;
-                    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-                    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-                        window.HTMLInputElement.prototype,
-                        "value"
-                    )?.set;
-                    const nativeTextAreaValueSetter = Object.getOwnPropertyDescriptor(
-                        window.HTMLTextAreaElement.prototype,
-                        "value"
-                    )?.set;
-
-                    const setNativeValue = (el, nextValue) => {{
-                        if (el instanceof HTMLInputElement && nativeInputValueSetter) {{
-                            nativeInputValueSetter.call(el, nextValue);
-                        }} else if (el instanceof HTMLTextAreaElement && nativeTextAreaValueSetter) {{
-                            nativeTextAreaValueSetter.call(el, nextValue);
-                        }} else {{
-                            el.value = nextValue;
-                        }}
-                    }};
-
-                    element.focus();
-                    if (actionDelayMs > 0) {{
-                        await sleep(actionDelayMs);
-                    }}
-                    element.dispatchEvent(new KeyboardEvent("keydown", {{ key: "Tab", bubbles: true }}));
-
-                    setNativeValue(element, "");
-                    element.dispatchEvent(
-                        new InputEvent("input", {{
-                            bubbles: true,
-                            inputType: "deleteContentBackward",
-                            data: null
-                        }})
-                    );
-
-                    let currentValue = "";
-                    for (const char of value) {{
-                        element.dispatchEvent(new KeyboardEvent("keydown", {{ key: char, bubbles: true }}));
-                        currentValue += char;
-                        setNativeValue(element, currentValue);
-                        element.dispatchEvent(
-                            new InputEvent("input", {{
-                                bubbles: true,
-                                inputType: "insertText",
-                                data: char
-                            }})
-                        );
-                        element.dispatchEvent(new KeyboardEvent("keyup", {{ key: char, bubbles: true }}));
-                        if (typingDelayMs > 0) {{
-                            await sleep(typingDelayMs);
-                        }}
-                    }}
-                    element.dispatchEvent(new Event("change", {{ bubbles: true }}));
+                    if (actionDelayMs > 0) await sleep(actionDelayMs);
+                    await fillInput(element, value, typingDelayMs);
                     output[key] = true;
                 }} else {{
                     output[key] = false;
@@ -1033,7 +1116,21 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
     try:
         result = await page.evaluate(js_code, await_promise=True)
         if isinstance(result, dict):
-            return {str(k): bool(v) for k, v in result.items()}  # pyright: ignore[reportUnknownArgumentType, reportUnknownVariableType]
+            output: dict[str, bool] = {}
+            for k, v in result.items():  # pyright: ignore[reportUnknownVariableType]
+                if isinstance(v, dict):
+                    vd: dict[str, object] = v  # pyright: ignore[reportUnknownVariableType]
+                    logger.info(
+                        f"set_and_submit debug: key={k} "
+                        f"success={vd.get('success')} actualValue={vd.get('actualValue')!r} "
+                        f"reactValue={vd.get('reactValue')!r} usedHook={vd.get('usedHook')} "
+                        f"refillCount={vd.get('refillCount')} reason={vd.get('reason')!r}"
+                    )
+                    output[str(k)] = vd.get("success") is True  # pyright: ignore[reportUnknownArgumentType]
+                else:
+                    output[str(k)] = bool(v)  # pyright: ignore[reportUnknownArgumentType]
+            logger.info(f"Batch actions result: {output}")
+            return output
     except Exception as error:
         logger.error(f"Batch actions failed: {error}")
     return None

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -961,13 +961,6 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
             el.dispatchEvent(new Event("change", {{ bubbles: true }}));
         }}
 
-        // For debug logging only — not used in any fill or submit logic.
-        function getReactValue(el) {{
-            const fiberKey = Object.keys(el).find(k => k.startsWith("__reactFiber"));
-            const fiber = fiberKey ? el[fiberKey] : null;
-            return fiber?.memoizedProps?.value ?? null;
-        }}
-
         async function setValueWithPoll(selector, value, typingDelayMs, timeout) {{
             const el = document.querySelector(selector);
             if (!el) return {{ success: false, reason: "element not found" }};
@@ -988,7 +981,6 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
                 return {{
                     success: true,
                     actualValue: inputEl.value,
-                    reactValue: getReactValue(inputEl),
                     refillCount: refillCount,
                 }};
             }}
@@ -1068,7 +1060,6 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
                     logger.info(
                         f"set_value debug: key={k} "
                         f"success={vd.get('success')} actualValue={vd.get('actualValue')!r} "
-                        f"reactValue={vd.get('reactValue')!r} "
                         f"refillCount={vd.get('refillCount')} reason={vd.get('reason')!r}"
                     )
                     output[str(k)] = vd.get("success") is True  # pyright: ignore[reportUnknownArgumentType]

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -967,22 +967,27 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
             await fillInput(el, value, typingDelayMs);
 
             let refillCount = 0;
+            let stableCount = 0;
             const deadline = Date.now() + timeout;
             while (Date.now() < deadline) {{
                 await sleep(50);
                 const inputEl = document.querySelector(selector);
-                if (!inputEl) continue;
+                if (!inputEl) {{ stableCount = 0; continue; }}
                 if (inputEl.value !== value) {{
+                    stableCount = 0;
                     refillCount++;
                     console.log(`set_value: refill #${{refillCount}}, value was "${{inputEl.value}}", expected "${{value}}"`);
                     await fillInput(inputEl, value, typingDelayMs);
                     continue;
                 }}
-                return {{
-                    success: true,
-                    actualValue: inputEl.value,
-                    refillCount: refillCount,
-                }};
+                stableCount++;
+                if (stableCount >= 5) {{
+                    return {{
+                        success: true,
+                        actualValue: inputEl.value,
+                        refillCount: refillCount,
+                    }};
+                }}
             }}
             return {{ success: false, reason: "timeout" }};
         }}

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -546,25 +546,13 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
         if document.select(SUBMIT_BUTTON):
             if len(names) > 0 and expected_field_count == len(names):
                 logger.info("Submitting form, all fields are filled...")
-                submit_selectors = [
-                    str(sel)
-                    for btn in document.select(SUBMIT_BUTTON)
-                    if (sel := get_selector(str(btn.get("gg-match")))[0]) is not None
-                ]
-                set_value_actions = [a for a in pending_actions if a.get("kind") == "set_value"]
-                if len(set_value_actions) == 1 and len(submit_selectors) == 1:
-                    # Upgrade the single set_value to set_and_submit so the JS layer owns
-                    # the full fill-verify-submit cycle with React commit awareness.
-                    set_value_actions[0]["kind"] = "set_and_submit"
-                    set_value_actions[0]["submit_selector"] = submit_selectors[0]
-                    set_value_actions[0]["timeout_ms"] = "15000"
-                    logger.info("Using set_and_submit for React-aware fill and submit")
-                else:
-                    for submit_selector in submit_selectors:
+                for submit_button in document.select(SUBMIT_BUTTON):
+                    submit_selector, _ = get_selector(str(submit_button.get("gg-match")))
+                    if submit_selector:
                         pending_actions.append({
                             "key": f"click:submit:{len(pending_actions)}",
                             "kind": "click",
-                            "selector": submit_selector,
+                            "selector": str(submit_selector),
                             "action_delay_ms": str(action_delay_ms),
                         })
                 should_submit = True
@@ -599,17 +587,6 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                 elif kind == "set_value":
                     value = action.get("value")
                     await element.type_text(value if isinstance(value, str) else "")
-                elif kind == "set_and_submit":
-                    # set_and_submit failed in JS — fall back to fill + click submit separately
-                    fill_value = action.get("value")
-                    await element.type_text(fill_value if isinstance(fill_value, str) else "")
-                    submit_selector = action.get("submit_selector")
-                    if isinstance(submit_selector, str):
-                        submit_el = await page_query_selector(
-                            page, submit_selector, config=element_config
-                        )
-                        if submit_el:
-                            await submit_el.click()
 
             await asyncio.sleep(0.25)
 

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -546,13 +546,25 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
         if document.select(SUBMIT_BUTTON):
             if len(names) > 0 and expected_field_count == len(names):
                 logger.info("Submitting form, all fields are filled...")
-                for submit_button in document.select(SUBMIT_BUTTON):
-                    submit_selector, _ = get_selector(str(submit_button.get("gg-match")))
-                    if submit_selector:
+                submit_selectors = [
+                    str(sel)
+                    for btn in document.select(SUBMIT_BUTTON)
+                    if (sel := get_selector(str(btn.get("gg-match")))[0]) is not None
+                ]
+                set_value_actions = [a for a in pending_actions if a.get("kind") == "set_value"]
+                if len(set_value_actions) == 1 and len(submit_selectors) == 1:
+                    # Upgrade the single set_value to set_and_submit so the JS layer owns
+                    # the full fill-verify-submit cycle with React commit awareness.
+                    set_value_actions[0]["kind"] = "set_and_submit"
+                    set_value_actions[0]["submit_selector"] = submit_selectors[0]
+                    set_value_actions[0]["timeout_ms"] = "15000"
+                    logger.info("Using set_and_submit for React-aware fill and submit")
+                else:
+                    for submit_selector in submit_selectors:
                         pending_actions.append({
                             "key": f"click:submit:{len(pending_actions)}",
                             "kind": "click",
-                            "selector": str(submit_selector),
+                            "selector": submit_selector,
                             "action_delay_ms": str(action_delay_ms),
                         })
                 should_submit = True
@@ -587,6 +599,17 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                 elif kind == "set_value":
                     value = action.get("value")
                     await element.type_text(value if isinstance(value, str) else "")
+                elif kind == "set_and_submit":
+                    # set_and_submit failed in JS — fall back to fill + click submit separately
+                    fill_value = action.get("value")
+                    await element.type_text(fill_value if isinstance(fill_value, str) else "")
+                    submit_selector = action.get("submit_selector")
+                    if isinstance(submit_selector, str):
+                        submit_el = await page_query_selector(
+                            page, submit_selector, config=element_config
+                        )
+                        if submit_el:
+                            await submit_el.click()
 
             await asyncio.sleep(0.25)
 


### PR DESCRIPTION
## Problem
Walmart remounts its React component tree during hydration, wiping DOM values set before the remount. The email input appeared filled but was cleared before submit.

## Solution
`set_value` now polls `element.value` every 50ms and re-fills if wiped. It waits for 5 consecutive stable ticks (~250ms) before resolving, so the submit only fires once the value has held.

## Flow
<img width="300" height="490" alt="svgviewer-output(8)" src="https://github.com/user-attachments/assets/22186a38-4cd5-4c71-9db7-086f6c18c353" />

## Demo

https://github.com/user-attachments/assets/e7bf0532-ccfe-46e9-947e-697416d231ec

