### PR TITLE
fix: add pattern empty watch list

### DIFF
--- a/getgather/mcp/patterns/amazon-prime-watchlist-empty.html
+++ b/getgather/mcp/patterns/amazon-prime-watchlist-empty.html
@@ -1,6 +1,6 @@
 <html gg-domain="amazon">
   <head>
-    <title>Prime Video: Your Watchlist</title>
+    <title>Prime Video: Your watchlist is empty</title>
   </head>
   <body>
     <div>

--- a/getgather/mcp/patterns/amazon-prime-watchlist-empty.html
+++ b/getgather/mcp/patterns/amazon-prime-watchlist-empty.html
@@ -1,0 +1,13 @@
+<html gg-domain="amazon">
+  <head>
+    <title>Prime Video: Your Watchlist</title>
+  </head>
+  <body>
+    <div>
+      <div
+        gg-stop
+        gg-match-html="//p[@data-testid='section-description-title'][contains(text(), 'Your Watchlist is currently empty')]"
+      ></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Handle pattern watchlist empty

Backport of #1330 to `local-amazon` (legacy deployment).

## Test

https://github.com/user-attachments/assets/7924022f-3d8e-425f-a1ce-33743e7d5966
