### PR TITLE
Fix: missing daytona dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "py-key-value-aio[redis]>=0.4.4",
   "websockets>=15.0.1",
   "geoip2>=5.2.0",
+  "daytona>=0.183.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -2442,6 +2442,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "beautifulsoup4" },
+    { name = "daytona" },
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "geoip2" },
@@ -2486,6 +2487,7 @@ dev = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "beautifulsoup4", specifier = ">=4.13.4" },
+    { name = "daytona", specifier = ">=0.183.0" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.183.0" },
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "fastmcp", specifier = ">=3.0.0,<4" },


### PR DESCRIPTION
## Issue
<img width="605" height="415" alt="image" src="https://github.com/user-attachments/assets/232b6935-554d-43c5-ba6b-bf1c6db3cc81" />

got this error after rebase from main branch

## Summary
- **`pyproject.toml`** — add `daytona>=0.183.0` runtime dependency
- **`uv.lock`** — update lockfile for daytona dependency change

## Test Plan
- [x] `npm run check:all`