### PR TITLE
feat(proxy): add residential proxy support to DaytonaBackend

### DIFF
--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -16,6 +16,11 @@ from getgather.browsers.backend import BROWSER_NAME_PREFIX, BrowserNotFound
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
 
+
+class ProxyVerificationError(Exception):
+    """Raised when egress IP is unchanged after proxy configuration."""
+
+
 CDP_PORT = 9222
 
 # Chrome stores last_visit_time as microseconds since 1601-01-01; this offset converts to unix epoch.
@@ -108,7 +113,9 @@ async def _configure_remote_sandbox(
     if ip_before and ip_after and ip_before != ip_after:
         logger.info(f"Sandbox {sandbox.name} IP changed: {ip_before} -> {ip_after}")
     elif ip_before == ip_after:
-        logger.warning(f"Sandbox {sandbox.name} IP unchanged after proxy: {ip_before}")
+        raise ProxyVerificationError(
+            f"Sandbox {sandbox.name} IP unchanged after proxy: {ip_before}"
+        )
 
 
 def _browser_id_from_name(name: str) -> str:
@@ -143,7 +150,10 @@ class DaytonaBackend:
         lock = self._locks.setdefault(browser_id, asyncio.Lock())
         async with lock:
             sandbox = await self._ensure(browser_id)
-            await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+            try:
+                await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+            except ProxyVerificationError as e:
+                logger.warning(str(e))
             return await self._get_info(sandbox)
 
     async def get_browser(
@@ -153,7 +163,10 @@ class DaytonaBackend:
         if sandbox is None:
             raise BrowserNotFound(browser_id)
         if origin_ip:
-            await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+            try:
+                await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+            except ProxyVerificationError as e:
+                logger.warning(str(e))
         return await self._get_info(sandbox)
 
     async def delete_browser(self, browser_id: str) -> dict[str, Any]:

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -89,24 +89,25 @@ async def _configure_remote_sandbox(
     browser_id: str,
     origin_ip: str | None,
     target_domain: str | None,
-) -> str | None:
+) -> None:
     proxy_config = await get_proxy_config(origin_ip, target_domain, settings)
     proxy_url = proxy_config.get_proxy_url(browser_id) if proxy_config else None
+
+    if not proxy_url:
+        return
 
     ip_before = await _get_sandbox_public_ip(sandbox)
     logger.debug(f"Sandbox {sandbox.name} IP before proxy: {ip_before}")
 
-    if proxy_url:
-        ok = await _configure_sandbox_proxy(sandbox, proxy_url)
-        if not ok:
-            return ip_before
-        ip_after = await _get_sandbox_public_ip(sandbox)
-        if ip_before and ip_after and ip_before != ip_after:
-            logger.info(f"Sandbox {sandbox.name} IP changed: {ip_before} -> {ip_after}")
-        elif ip_before == ip_after:
-            logger.warning(f"Sandbox {sandbox.name} IP unchanged after proxy: {ip_before}")
-        return ip_after
-    return ip_before
+    ok = await _configure_sandbox_proxy(sandbox, proxy_url)
+    if not ok:
+        return
+
+    ip_after = await _get_sandbox_public_ip(sandbox)
+    if ip_before and ip_after and ip_before != ip_after:
+        logger.info(f"Sandbox {sandbox.name} IP changed: {ip_before} -> {ip_after}")
+    elif ip_before == ip_after:
+        logger.warning(f"Sandbox {sandbox.name} IP unchanged after proxy: {ip_before}")
 
 
 def _browser_id_from_name(name: str) -> str:
@@ -141,10 +142,8 @@ class DaytonaBackend:
         lock = self._locks.setdefault(browser_id, asyncio.Lock())
         async with lock:
             sandbox = await self._ensure(browser_id)
-            ip = await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
-            info = await self._get_info(sandbox)
-            info["ip_address"] = ip
-            return info
+            await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+            return await self._get_info(sandbox)
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
@@ -153,12 +152,8 @@ class DaytonaBackend:
         if sandbox is None:
             raise BrowserNotFound(browser_id)
         if origin_ip:
-            ip = await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
-        else:
-            ip = await _get_sandbox_public_ip(sandbox)
-        info = await self._get_info(sandbox)
-        info["ip_address"] = ip
-        return info
+            await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+        return await self._get_info(sandbox)
 
     async def delete_browser(self, browser_id: str) -> dict[str, Any]:
         name = _sandbox_name(browser_id)

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -51,6 +51,7 @@ async def _configure_sandbox_proxy(sandbox: AsyncSandbox, proxy_url: str) -> boo
         "sed -i '/^Upstream http/d' /app/tinyproxy.conf",
         f"sed -i '$ a\\Upstream http {stripped}' /app/tinyproxy.conf",
         "sudo /command/s6-svc -r /run/service/tinyproxy",
+        "while ! curl -s -o /dev/null -x http://localhost:8119 http://tinyproxy.stats; do sleep 0.1; done",
     ]
     for cmd in cmds:
         try:

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -13,6 +13,8 @@ from daytona import (
 from loguru import logger
 
 from getgather.browsers.backend import BROWSER_NAME_PREFIX, BrowserNotFound
+from getgather.browsers.residential_proxy import get_proxy_config
+from getgather.config import settings
 
 CDP_PORT = 9222
 
@@ -43,6 +45,70 @@ def _sandbox_name(browser_id: str) -> str:
     return f"{BROWSER_NAME_PREFIX}{browser_id}"
 
 
+async def _configure_sandbox_proxy(sandbox: AsyncSandbox, proxy_url: str) -> bool:
+    stripped = proxy_url.removeprefix("http://")
+    cmds = [
+        "sed -i '/^Upstream http/d' /app/tinyproxy.conf",
+        f"sed -i '$ a\\Upstream http {stripped}' /app/tinyproxy.conf",
+        "sudo /command/s6-svc -r /run/service/tinyproxy",
+    ]
+    for cmd in cmds:
+        try:
+            response = await sandbox.process.exec(cmd)
+        except Exception as e:
+            logger.warning(f"Proxy config failed on {sandbox.name}: {type(e).__name__}: {e}")
+            return False
+        if response.exit_code != 0:
+            logger.warning(
+                f"Proxy config exit={response.exit_code} on {sandbox.name}: cmd={cmd!r} stderr={response.result!r}"
+            )
+            return False
+    return True
+
+
+async def _get_sandbox_public_ip(
+    sandbox: AsyncSandbox, *, retries: int = 5, retry_delay: float = 2.0
+) -> str | None:
+    cmd = "curl -s --max-time 10 --proxy http://127.0.0.1:8119 https://ip.fly.dev"
+    for attempt in range(1, retries + 1):
+        try:
+            response = await sandbox.process.exec(cmd)
+            ip = response.result.strip() if response.exit_code == 0 else ""
+            if ip:
+                return ip
+        except Exception as e:
+            logger.debug(f"IP check {attempt}/{retries} on {sandbox.name} failed: {e}")
+        if attempt < retries:
+            await asyncio.sleep(retry_delay)
+    logger.warning(f"IP check on {sandbox.name} failed after {retries} attempts")
+    return None
+
+
+async def _configure_remote_sandbox(
+    sandbox: AsyncSandbox,
+    browser_id: str,
+    origin_ip: str | None,
+    target_domain: str | None,
+) -> str | None:
+    proxy_config = await get_proxy_config(origin_ip, target_domain, settings)
+    proxy_url = proxy_config.get_proxy_url(browser_id) if proxy_config else None
+
+    ip_before = await _get_sandbox_public_ip(sandbox)
+    logger.debug(f"Sandbox {sandbox.name} IP before proxy: {ip_before}")
+
+    if proxy_url:
+        ok = await _configure_sandbox_proxy(sandbox, proxy_url)
+        if not ok:
+            return ip_before
+        ip_after = await _get_sandbox_public_ip(sandbox)
+        if ip_before and ip_after and ip_before != ip_after:
+            logger.info(f"Sandbox {sandbox.name} IP changed: {ip_before} -> {ip_after}")
+        elif ip_before == ip_after:
+            logger.warning(f"Sandbox {sandbox.name} IP unchanged after proxy: {ip_before}")
+        return ip_after
+    return ip_before
+
+
 def _browser_id_from_name(name: str) -> str:
     return name.removeprefix(BROWSER_NAME_PREFIX)
 
@@ -53,7 +119,8 @@ class DaytonaBackend:
     The browser_id -> sandbox mapping is the deterministic sandbox name plus labels, so there is
     no local state. CDP is reached over a Daytona signed preview URL: a public, internet-reachable,
     self-authenticating HTTPS reverse proxy to port 9222 (no inbound networking into the sandbox is
-    required). VNC and residential-proxy/geo-IP are podman-only and unavailable here.
+    required). VNC is unavailable; residential proxy/geo-IP are supported via tinyproxy
+    (preconfigured in the snapshot, same as podman).
 
     Sandbox teardown is owned by Daytona: auto_stop_interval stops idle sandboxes and
     auto_delete_interval deletes them once continuously stopped past the TTL (both set at create
@@ -74,7 +141,10 @@ class DaytonaBackend:
         lock = self._locks.setdefault(browser_id, asyncio.Lock())
         async with lock:
             sandbox = await self._ensure(browser_id)
-            return await self._get_info(sandbox)
+            ip = await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+            info = await self._get_info(sandbox)
+            info["ip_address"] = ip
+            return info
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
@@ -82,7 +152,13 @@ class DaytonaBackend:
         sandbox = await self._get(_sandbox_name(browser_id))
         if sandbox is None:
             raise BrowserNotFound(browser_id)
-        return await self._get_info(sandbox)
+        if origin_ip:
+            ip = await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+        else:
+            ip = await _get_sandbox_public_ip(sandbox)
+        info = await self._get_info(sandbox)
+        info["ip_address"] = ip
+        return info
 
     async def delete_browser(self, browser_id: str) -> dict[str, Any]:
         name = _sandbox_name(browser_id)
@@ -144,7 +220,6 @@ class DaytonaBackend:
         )
         return {
             "hostname": sandbox.name,
-            "ip_address": None,  # the sandbox IP is not reachable; CDP is via the signed preview URL
             "cdp_url": signed.url,  # public, internet-reachable; bearer secret (see SIGNED_URL_TTL_SECONDS)
             "app_state": sandbox.state,
             "last_activity_timestamp": await self._get_last_activity(sandbox),

--- a/getgather/browsers/settings.py
+++ b/getgather/browsers/settings.py
@@ -30,7 +30,7 @@ class BrowserSettings(BaseSettings):
     CONTAINER_IMAGE: str = "ghcr.io/remotebrowser/chromium-live"
     CONTAINER_HOST: str = ""
 
-    # Residential proxy (Massive or Oxylabs) and MaxMind GeoIP (podman backend only)
+    # Residential proxy (Massive or Oxylabs) and MaxMind GeoIP
     MASSIVE_PROXY_USERNAME: str = ""
     MASSIVE_PROXY_PASSWORD: str = ""
     OXYLABS_USERNAME: str = ""


### PR DESCRIPTION
## Summary

- Adds residential proxy support to `DaytonaBackend`, mirroring `PodmanBackend` behaviour
- On `create_browser` (always) and `get_browser` (when `origin_ip` provided): MaxMind geo-IP → provider selection → rewrite `/app/tinyproxy.conf` upstream → restart tinyproxy via `s6-svc` → verify public IP before/after
- Failure logs a warning and continues without proxy (no exception surfaced to caller)
- Drops `(podman backend only)` qualifier from `BrowserSettings` proxy comment

## Test plan

- [x] `npm run backend:check:format && npm run backend:check:type-safety` — ruff + pyright strict clean
- [x] `uv run pytest -m "not api and not webui and not mcp and not distill"` — 64 unit tests pass
- [x] Manual E2E with `BROWSER_BACKEND=daytona` + MaxMind + proxy creds + `x-origin-ip`/`x-target-domains` headers — verify logs show IP change

## Test Result

```pytjon
20:58:35 INFO     [CDP] Browser Ez7sku3d not found — launching                    router.py:411
20:58:36 INFO     Creating Daytona sandbox chromium-Ez7sku3d from       daytona_browsers.py:279
                  snapshot chrome-live-daytona                                                 
20:58:38 INFO     MaxMind resolved 45.131.194.160 -> country=us         residential_proxy.py:82
         INFO     Proxy selected: provider=oxylabs                     residential_proxy.py:186
                  reason=domain-routed (www.amazon.com) country=us                             
20:58:45 INFO     Sandbox chromium-Ez7sku3d IP changed: 67.213.119.5 -> 68.193.21.126                 daytona_browsers.py:109
         WARNING  Failed to fetch last activity for chromium-Ez7sku3d: exit=0 result=''               daytona_browsers.py:253
         INFO     [CDP] Browser Ez7sku3d started                                                                router.py:416
20:58:47 INFO     [CDP] Got remote URL:                                                                         router.py:436
                  wss://9222-gywstneldpvw1dot.daytonaproxy01.net/devtools/browser/18afbef8-efc1-47ef-8f64-f491b              
                  bcf99cd                                                                                                    
         INFO     [CDP] Client connected, proxying to                                                           router.py:455
                  wss://9222-gywstneldpvw1dot.daytonaproxy01.net/devtools/browser/18afbef8-efc1-47ef-8f64-f491b              
                  bcf99cd                                                                                                    
         INFO     CDP websocket headers attached                                                                browser.py:46
                  target_domain: null                                                                                        
                  open_timeout: 30.0                                                                                         
                  keys: []                                                                                                   
                                                                                                                             
         INFO     [CDP] Connected to remote WebSocket                                                           router.py:158
```

<img width="1579" height="975" alt="image" src="https://github.com/user-attachments/assets/031ab13f-602b-4ba6-9891-bd95636b7af2" />
