### PR TITLE
fix(walmart): fix OTP input clipping on mobile

### DIFF
--- a/getgather/mcp/patterns/walmart-signin-otp.html
+++ b/getgather/mcp/patterns/walmart-signin-otp.html
@@ -13,7 +13,7 @@
       style="
         display: grid;
         grid-template-columns: repeat(6, minmax(0, 1fr));
-        gap: 10px;
+        gap: clamp(4px, 2vw, 10px);
         width: 100%;
       "
     >
@@ -24,14 +24,7 @@
         inputmode="numeric"
         pattern="[0-9]*"
         maxlength="1"
-        style="
-          width: 100%;
-          box-sizing: border-box;
-          text-align: center;
-          height: 52px;
-          font-size: 1.5rem;
-          font-weight: bold;
-        "
+        style="width: 100%; box-sizing: border-box; text-align: center; aspect-ratio: 1; font-size: clamp(1rem, 5vw, 1.5rem); font-weight: bold; line-height: 1; padding: 0;"
         data-testid="otp-0"
         gg-match="input#input-verificationCode"
       />
@@ -41,14 +34,7 @@
         inputmode="numeric"
         pattern="[0-9]*"
         maxlength="1"
-        style="
-          width: 100%;
-          box-sizing: border-box;
-          text-align: center;
-          height: 52px;
-          font-size: 1.5rem;
-          font-weight: bold;
-        "
+        style="width: 100%; box-sizing: border-box; text-align: center; aspect-ratio: 1; font-size: clamp(1rem, 5vw, 1.5rem); font-weight: bold; line-height: 1; padding: 0;"
         data-testid="otp-1"
         gg-match="input#input-verificationCode-1"
       />
@@ -58,14 +44,7 @@
         inputmode="numeric"
         pattern="[0-9]*"
         maxlength="1"
-        style="
-          width: 100%;
-          box-sizing: border-box;
-          text-align: center;
-          height: 52px;
-          font-size: 1.5rem;
-          font-weight: bold;
-        "
+        style="width: 100%; box-sizing: border-box; text-align: center; aspect-ratio: 1; font-size: clamp(1rem, 5vw, 1.5rem); font-weight: bold; line-height: 1; padding: 0;"
         data-testid="otp-2"
         gg-match="input#input-verificationCode-2"
       />
@@ -75,14 +54,7 @@
         inputmode="numeric"
         pattern="[0-9]*"
         maxlength="1"
-        style="
-          width: 100%;
-          box-sizing: border-box;
-          text-align: center;
-          height: 52px;
-          font-size: 1.5rem;
-          font-weight: bold;
-        "
+        style="width: 100%; box-sizing: border-box; text-align: center; aspect-ratio: 1; font-size: clamp(1rem, 5vw, 1.5rem); font-weight: bold; line-height: 1; padding: 0;"
         data-testid="otp-3"
         gg-match="input#input-verificationCode-3"
       />
@@ -92,14 +64,7 @@
         inputmode="numeric"
         pattern="[0-9]*"
         maxlength="1"
-        style="
-          width: 100%;
-          box-sizing: border-box;
-          text-align: center;
-          height: 52px;
-          font-size: 1.5rem;
-          font-weight: bold;
-        "
+        style="width: 100%; box-sizing: border-box; text-align: center; aspect-ratio: 1; font-size: clamp(1rem, 5vw, 1.5rem); font-weight: bold; line-height: 1; padding: 0;"
         data-testid="otp-4"
         gg-match="input#input-verificationCode-4"
       />
@@ -109,14 +74,7 @@
         inputmode="numeric"
         pattern="[0-9]*"
         maxlength="1"
-        style="
-          width: 100%;
-          box-sizing: border-box;
-          text-align: center;
-          height: 52px;
-          font-size: 1.5rem;
-          font-weight: bold;
-        "
+        style="width: 100%; box-sizing: border-box; text-align: center; aspect-ratio: 1; font-size: clamp(1rem, 5vw, 1.5rem); font-weight: bold; line-height: 1; padding: 0;"
         data-testid="otp-5"
         gg-match="input#input-verificationCode-5"
       />

--- a/getgather/mcp/patterns/walmart-signin-otp.html
+++ b/getgather/mcp/patterns/walmart-signin-otp.html
@@ -24,7 +24,16 @@
         inputmode="numeric"
         pattern="[0-9]*"
         maxlength="1"
-        style="width: 100%; box-sizing: border-box; text-align: center; aspect-ratio: 1; font-size: clamp(1rem, 5vw, 1.5rem); font-weight: bold; line-height: 1; padding: 0;"
+        style="
+          width: 100%;
+          box-sizing: border-box;
+          text-align: center;
+          aspect-ratio: 1;
+          font-size: clamp(1rem, 5vw, 1.5rem);
+          font-weight: bold;
+          line-height: 1;
+          padding: 0;
+        "
         data-testid="otp-0"
         gg-match="input#input-verificationCode"
       />
@@ -34,7 +43,16 @@
         inputmode="numeric"
         pattern="[0-9]*"
         maxlength="1"
-        style="width: 100%; box-sizing: border-box; text-align: center; aspect-ratio: 1; font-size: clamp(1rem, 5vw, 1.5rem); font-weight: bold; line-height: 1; padding: 0;"
+        style="
+          width: 100%;
+          box-sizing: border-box;
+          text-align: center;
+          aspect-ratio: 1;
+          font-size: clamp(1rem, 5vw, 1.5rem);
+          font-weight: bold;
+          line-height: 1;
+          padding: 0;
+        "
         data-testid="otp-1"
         gg-match="input#input-verificationCode-1"
       />
@@ -44,7 +62,16 @@
         inputmode="numeric"
         pattern="[0-9]*"
         maxlength="1"
-        style="width: 100%; box-sizing: border-box; text-align: center; aspect-ratio: 1; font-size: clamp(1rem, 5vw, 1.5rem); font-weight: bold; line-height: 1; padding: 0;"
+        style="
+          width: 100%;
+          box-sizing: border-box;
+          text-align: center;
+          aspect-ratio: 1;
+          font-size: clamp(1rem, 5vw, 1.5rem);
+          font-weight: bold;
+          line-height: 1;
+          padding: 0;
+        "
         data-testid="otp-2"
         gg-match="input#input-verificationCode-2"
       />
@@ -54,7 +81,16 @@
         inputmode="numeric"
         pattern="[0-9]*"
         maxlength="1"
-        style="width: 100%; box-sizing: border-box; text-align: center; aspect-ratio: 1; font-size: clamp(1rem, 5vw, 1.5rem); font-weight: bold; line-height: 1; padding: 0;"
+        style="
+          width: 100%;
+          box-sizing: border-box;
+          text-align: center;
+          aspect-ratio: 1;
+          font-size: clamp(1rem, 5vw, 1.5rem);
+          font-weight: bold;
+          line-height: 1;
+          padding: 0;
+        "
         data-testid="otp-3"
         gg-match="input#input-verificationCode-3"
       />
@@ -64,7 +100,16 @@
         inputmode="numeric"
         pattern="[0-9]*"
         maxlength="1"
-        style="width: 100%; box-sizing: border-box; text-align: center; aspect-ratio: 1; font-size: clamp(1rem, 5vw, 1.5rem); font-weight: bold; line-height: 1; padding: 0;"
+        style="
+          width: 100%;
+          box-sizing: border-box;
+          text-align: center;
+          aspect-ratio: 1;
+          font-size: clamp(1rem, 5vw, 1.5rem);
+          font-weight: bold;
+          line-height: 1;
+          padding: 0;
+        "
         data-testid="otp-4"
         gg-match="input#input-verificationCode-4"
       />
@@ -74,7 +119,16 @@
         inputmode="numeric"
         pattern="[0-9]*"
         maxlength="1"
-        style="width: 100%; box-sizing: border-box; text-align: center; aspect-ratio: 1; font-size: clamp(1rem, 5vw, 1.5rem); font-weight: bold; line-height: 1; padding: 0;"
+        style="
+          width: 100%;
+          box-sizing: border-box;
+          text-align: center;
+          aspect-ratio: 1;
+          font-size: clamp(1rem, 5vw, 1.5rem);
+          font-weight: bold;
+          line-height: 1;
+          padding: 0;
+        "
         data-testid="otp-5"
         gg-match="input#input-verificationCode-5"
       />


### PR DESCRIPTION
OTP input cells had a fixed height that clipped digit characters on narrow mobile screens. Switched to `aspect-ratio: 1` so each cell stays square and scales with its column width, and used `clamp()` on gap and font-size.

## Before

<img width="510" height="566" alt="Firefox Developer Edition 2026-06-17 11 41 52" src="https://github.com/user-attachments/assets/8c583bbd-3d8a-4306-9025-9d064039188e" />

## After

<table>
<tr>
<th>iPhone 17 Preview</th>
<th>iPhone SE Preview</th>
</tr>
<tr>
<td>
<img width="1206" height="2622" alt="Screen Shot 2026-06-17 at 11 46 18" src="https://github.com/user-attachments/assets/cd5a3d5a-3ef3-4472-8ef2-bd86bc7267e9" />
</td>
<td>
<img width="750" height="1334" alt="Screen Shot 2026-06-17 at 11 46 25" src="https://github.com/user-attachments/assets/7baef121-364f-4257-8d9b-1781cddc4550" />
</td>
</tr>
</table>
