### PR TITLE
fix: use Daytona signed preview iframe for live view

### DIFF
--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -48,6 +48,8 @@ class Backend(Protocol):
 
     async def get_vnc_endpoint(self, browser_id: str) -> tuple[str, int] | None: ...
 
+    async def get_live_view_url(self, browser_id: str) -> str | None: ...
+
 
 def create_backend() -> Backend:
     if settings.CHROMEFLEET_URL:

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from typing import Any
 
 from daytona import (
@@ -35,6 +36,14 @@ TTL_MINUTES = 60
 # itself, so anyone who obtains the cdp_url can drive the browser's CDP until the token expires.
 # Treat cdp_url as a bearer secret. The token is stateless and survives sandbox restarts.
 SIGNED_URL_TTL_SECONDS = 3600
+
+# An open live-view iframe streams noVNC over port 8080, which Daytona counts as sandbox activity
+# and uses to reset auto_stop_interval. The dashboard embeds a live view per browser, so without a
+# gate just viewing it would keep every sandbox alive indefinitely (defeating auto-stop). Only hand
+# out the live URL when the browser has had real Chrome activity within this window; otherwise let
+# the idle sandbox auto-stop. A sandbox with no history yet (e.g. a fresh sign-in) is treated as
+# active so the primary "watch the sign-in" flow keeps working.
+LIVE_VIEW_MAX_IDLE_SECONDS = 3600
 
 LABEL_FLEET = "fleet"
 
@@ -131,6 +140,22 @@ class DaytonaBackend:
         sandbox = await self._get(_sandbox_name(browser_id))
         if sandbox is None:
             raise BrowserNotFound(browser_id)
+        if sandbox.state != "started":
+            return None  # a stopped sandbox has nothing to show and must not be woken to watch it
+
+        # Gate on recent activity so an embedded live view can't keep an idle sandbox alive. A
+        # missing timestamp (no history yet / read error) is treated as active to avoid hiding the
+        # live view for a fresh sign-in.
+        last_activity = await self._get_last_activity(sandbox)
+        if last_activity is not None:
+            idle_seconds = time.time() - last_activity
+            if idle_seconds > LIVE_VIEW_MAX_IDLE_SECONDS:
+                logger.info(
+                    f"Skipping live view for idle sandbox {sandbox.name}: "
+                    f"last activity {idle_seconds:.0f}s ago (> {LIVE_VIEW_MAX_IDLE_SECONDS}s)"
+                )
+                return None
+
         signed = await sandbox.create_signed_preview_url(
             VNC_PORT, expires_in_seconds=SIGNED_URL_TTL_SECONDS
         )

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -15,6 +15,7 @@ from loguru import logger
 from getgather.browsers.backend import BROWSER_NAME_PREFIX, BrowserNotFound
 
 CDP_PORT = 9222
+VNC_PORT = 8080
 
 # Chrome stores last_visit_time as microseconds since 1601-01-01; this offset converts to unix epoch.
 CHROMIUM_EPOCH_OFFSET_SECONDS = 11644473600
@@ -32,8 +33,7 @@ TTL_MINUTES = 60
 # SECURITY: this URL is PUBLICLY reachable on the internet. The sandbox is created public=False,
 # but a signed preview URL bypasses that — the only credential is the token embedded in the URL
 # itself, so anyone who obtains the cdp_url can drive the browser's CDP until the token expires.
-# Treat cdp_url as a bearer secret. The token is stateless and survives sandbox restarts, so we
-# mint one per get_info (no cache) with a generous TTL so it outlives a browser session.
+# Treat cdp_url as a bearer secret. The token is stateless and survives sandbox restarts.
 SIGNED_URL_TTL_SECONDS = 3600
 
 LABEL_FLEET = "fleet"
@@ -53,7 +53,8 @@ class DaytonaBackend:
     The browser_id -> sandbox mapping is the deterministic sandbox name plus labels, so there is
     no local state. CDP is reached over a Daytona signed preview URL: a public, internet-reachable,
     self-authenticating HTTPS reverse proxy to port 9222 (no inbound networking into the sandbox is
-    required). VNC and residential-proxy/geo-IP are podman-only and unavailable here.
+    required). Live view embeds the snapshot's built-in noVNC on port 8080 via a signed preview URL.
+    Residential-proxy/geo-IP are podman-only.
 
     Sandbox teardown is owned by Daytona: auto_stop_interval stops idle sandboxes and
     auto_delete_interval deletes them once continuously stopped past the TTL (both set at create
@@ -124,7 +125,16 @@ class DaytonaBackend:
         return None
 
     async def get_vnc_endpoint(self, browser_id: str) -> tuple[str, int] | None:
-        return None  # no VNC: the sandbox is reached over an HTTPS signed URL, not a raw TCP port
+        return None  # no raw VNC port; live view uses get_live_view_url (noVNC on VNC_PORT)
+
+    async def get_live_view_url(self, browser_id: str) -> str | None:
+        sandbox = await self._get(_sandbox_name(browser_id))
+        if sandbox is None:
+            raise BrowserNotFound(browser_id)
+        signed = await sandbox.create_signed_preview_url(
+            VNC_PORT, expires_in_seconds=SIGNED_URL_TTL_SECONDS
+        )
+        return signed.url
 
     async def _ensure(self, browser_id: str) -> AsyncSandbox:
         name = _sandbox_name(browser_id)

--- a/getgather/browsers/fleet_browsers.py
+++ b/getgather/browsers/fleet_browsers.py
@@ -148,3 +148,6 @@ class FleetBackend:
 
     async def get_vnc_endpoint(self, browser_id: str) -> tuple[str, int] | None:
         return None
+
+    async def get_live_view_url(self, browser_id: str) -> str | None:
+        return None

--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -354,3 +354,6 @@ class PodmanBackend:
         if not vnc_port:
             return None
         return (container_host(), vnc_port)
+
+    async def get_live_view_url(self, browser_id: str) -> str | None:
+        return None

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -1,4 +1,5 @@
 import asyncio
+import html
 import json
 import os
 import urllib.parse
@@ -507,9 +508,31 @@ async def cdp_devtools_websocket_proxy(client_ws: WebSocket, path: str) -> None:
     logger.debug("[CDP] cdp_devtools_websocket_proxy exiting")
 
 
-@router.get("/live/{browser_id}")
+@router.get("/live/{browser_id}", response_model=None)
 async def vnc_live_viewer(browser_id: str) -> HTMLResponse:
-    html = f"""<!DOCTYPE html>
+    try:
+        live_url = await backend.get_live_view_url(browser_id)
+    except BrowserNotFound:
+        raise HTTPException(status_code=404, detail=f"Browser {browser_id} not found!")
+
+    if live_url:
+        safe_url = html.escape(live_url, quote=True)
+        page = f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>{browser_id} - Live View</title>
+    <style>
+        html, body {{ margin: 0; height: 100%; overflow: hidden; background: #000; }}
+        iframe {{ border: none; width: 100%; height: 100%; }}
+    </style>
+</head>
+<body>
+    <iframe src="{safe_url}" allow="clipboard-read; clipboard-write"></iframe>
+</body>
+</html>"""
+        return HTMLResponse(page)
+
+    page = f"""<!DOCTYPE html>
 <html>
 <head>
     <title>{browser_id} - Live View</title>
@@ -534,7 +557,7 @@ async def vnc_live_viewer(browser_id: str) -> HTMLResponse:
     </script>
 </body>
 </html>"""
-    return HTMLResponse(html)
+    return HTMLResponse(page)
 
 
 @router.websocket("/websockify/{browser_id}")

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -532,7 +532,8 @@ async def vnc_live_viewer(browser_id: str) -> HTMLResponse:
 </html>"""
         return HTMLResponse(page)
 
-    page = f"""<!DOCTYPE html>
+    if await backend.get_vnc_endpoint(browser_id) is not None:
+        page = f"""<!DOCTYPE html>
 <html>
 <head>
     <title>{browser_id} - Live View</title>
@@ -555,6 +556,28 @@ async def vnc_live_viewer(browser_id: str) -> HTMLResponse:
         );
         rfb.scaleViewport = true;
     </script>
+</body>
+</html>"""
+        return HTMLResponse(page)
+
+    # No external live URL and no local VNC port: either a backend without live view, or an idle
+    # sandbox gated off so it can auto-stop. Show a placeholder instead of a dead noVNC screen.
+    page = f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>{browser_id} - Live View</title>
+    <style>
+        html, body {{
+            margin: 0; height: 100%;
+            display: flex; align-items: center; justify-content: center;
+            background: #111; color: #aaa;
+            font-family: system-ui, sans-serif; text-align: center;
+        }}
+        .msg {{ padding: 1rem; font-size: 0.9rem; line-height: 1.5; }}
+    </style>
+</head>
+<body>
+    <div class="msg">Live view unavailable<br>The browser is idle or stopped. Use it to resume.</div>
 </body>
 </html>"""
     return HTMLResponse(page)


### PR DESCRIPTION
# Daytona Live View in Iframe

## Summary
- Use Daytona signed preview URL (port `8080`) for live view.
- Show Daytona live view inside `/live/{browser_id}` using an iframe.
- Keep podman live view unchanged (`rfb.min.js` + `/websockify/{browser_id}`).

## Why
- Avoid Daytona preview auth errors in the dashboard.
- Keep the main app page on our domain while still showing live desktop.
- Keep backend behavior clear per provider.

## Changes
- Add `get_live_view_url()` to browser backend interface.
- Implement Daytona `get_live_view_url()` using `create_signed_preview_url(8080)`.
- Return `None` for fleet/podman in `get_live_view_url()`.
- Update `/live/{browser_id}` route:
  - Daytona: render iframe with signed preview URL.
  - Podman: keep existing local noVNC flow.

## Test Plan
- [x] `uv run ruff check getgather/browsers/router.py getgather/browsers/daytona_browsers.py`
- [x] `uv run pyright getgather/browsers/daytona_browsers.py`
- [x] Open `http://localhost:23456/` with `BROWSER_BACKEND=daytona` and verify live views load.

## Test Result

<img width="988" height="859" alt="Screenshot 2026-06-17 at 15 40 22" src="https://github.com/user-attachments/assets/d7e01215-9353-4945-90ca-b19650942ee7" />
<img width="783" height="508" alt="Screenshot 2026-06-17 at 15 40 13" src="https://github.com/user-attachments/assets/6cfe438c-5fb9-4ded-83f7-002d031added" />
