### PR TITLE
Add periodic cleanup of idle browser (Podman) containers

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -19,6 +19,7 @@ BROWSER_BACKEND=podman
 # Podman backend
 CONTAINER_IMAGE=ghcr.io/remotebrowser/chromium-live
 CONTAINER_HOST=
+MAX_IDLE_MINUTES=15
 
 # Daytona backend (required when BROWSER_BACKEND=daytona; install the extra: uv sync --extra daytona).
 # DAYTONA_API_URL is optional; leave empty to use the Daytona managed cloud.

--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -13,7 +13,6 @@ from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
 
 DOCKER_INTERNAL_HOST = "172.17.0.1"
-MAX_IDLE = 15 * 60  # seconds
 
 
 def run_podman(args: list[str]) -> subprocess.CompletedProcess[str]:
@@ -330,7 +329,7 @@ class PodmanBackend:
             idle_seconds = now - browser["last_activity_timestamp"]
             idle_minutes = math.ceil(idle_seconds / 60)
             logger.debug(f"Browser {browser['browser_id']} idle for {idle_minutes}m")
-            if idle_seconds > MAX_IDLE:
+            if idle_seconds > settings.MAX_IDLE_MINUTES * 60:
                 logger.info(f"Deleting browser {browser['browser_id']} (idle: {idle_minutes}m)")
                 try:
                     await self.delete_browser(browser["browser_id"])

--- a/getgather/browsers/settings.py
+++ b/getgather/browsers/settings.py
@@ -29,6 +29,7 @@ class BrowserSettings(BaseSettings):
     # Podman backend
     CONTAINER_IMAGE: str = "ghcr.io/remotebrowser/chromium-live"
     CONTAINER_HOST: str = ""
+    MAX_IDLE_MINUTES: int = 15
 
     # Residential proxy (Massive or Oxylabs) and MaxMind GeoIP (podman backend only)
     MASSIVE_PROXY_USERNAME: str = ""

--- a/getgather/main.py
+++ b/getgather/main.py
@@ -27,6 +27,8 @@ from getgather.zen_distill import short_lived_mcp_tool
 # Create MCP apps once and reuse for lifespan and mounting
 mcp_apps = create_mcp_apps()
 
+BACKGROUND_TASK_INTERVAL = 5 * 60  # seconds
+
 
 def custom_generate_unique_id(route: APIRoute) -> str:
     tag = route.tags[0] if route.tags else "no-tag"
@@ -43,9 +45,12 @@ async def lifespan(app: FastAPI):
     async def timer_loop():
         while not stop_event.is_set():
             try:
-                await asyncio.wait_for(stop_event.wait(), timeout=5 * 60)
+                await asyncio.wait_for(stop_event.wait(), timeout=BACKGROUND_TASK_INTERVAL)
             except asyncio.TimeoutError:
-                pass
+                try:
+                    await backend.cleanup_idle()
+                except Exception as e:
+                    logger.error(f"Idle cleanup failed: {e}")
 
     background_task = asyncio.create_task(timer_loop())
 


### PR DESCRIPTION
To verify, run as usual and use its API to create a test browser. Wait for some time and the idle cleanup will kick in:

```
         INFO     Application startup complete.
15:21:15 DEBUG    Retrieving the list of all containers...
         DEBUG    All containers obtained. Total=1
         DEBUG    Browser abc001 idle for 101m
         INFO     Deleting browser abc001 (idle: 101m)
         INFO     Killing Chromium container chromium-abc001...
         INFO     Container killed: name=chromium-abc001
         INFO     Cleanup complete: total=1 deleted=1
```