### PR TITLE
fix(dpage): loading overlay covers full card on submit

### DIFF
--- a/getgather/mcp/html_renderer.py
+++ b/getgather/mcp/html_renderer.py
@@ -43,6 +43,7 @@ def render_form(
       }}
 
       .card {{
+        position: relative;
         background: white;
         border-radius: 16px;
         box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);


### PR DESCRIPTION
`.form-overlay` uses `position: absolute; inset: 0` but `.card` had no `position: relative`, so the overlay escaped to `body` and clipped on tall forms. Adds `position: relative` to `.card` to fix it.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="320" alt="Screen Shot 2026-06-17 at 19 30 34" src="https://github.com/user-attachments/assets/d6de2e23-a6a2-45f0-8914-99c58c5c98cf" />
</td>
<td>
<img width="320" alt="Screen Shot 2026-06-18 at 13 22 24" src="https://github.com/user-attachments/assets/e199c97d-1411-4929-aa46-f2e098502b08" />
</td>
</tr>
</table>

