### PR TITLE
fix(browsers): run all podman subprocesses off the event loop

### DIFF
--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -27,7 +27,7 @@ def run_podman(args: list[str]) -> subprocess.CompletedProcess[str]:
 
 async def get_host_port(container_name: str, container_port: int) -> int | None:
     try:
-        result = run_podman(["port", container_name, str(container_port)])
+        result = await asyncio.to_thread(run_podman, ["port", container_name, str(container_port)])
         port_mapping = result.stdout.strip()
         if not port_mapping:
             return None
@@ -59,7 +59,7 @@ async def launch_container(image_name: str, container_name: str) -> str:
         image_name,
     ])
     try:
-        result = run_podman(cmd)
+        result = await asyncio.to_thread(run_podman, cmd)
         if result.returncode == 0 and result.stdout:
             container_id = result.stdout.strip()
             cdp_port = await get_host_port(container_name, 9222)
@@ -75,7 +75,7 @@ async def launch_container(image_name: str, container_name: str) -> str:
 
 async def container_exists(container_name: str) -> bool:
     try:
-        result = run_podman(["container", "exists", container_name])
+        result = await asyncio.to_thread(run_podman, ["container", "exists", container_name])
         return result.returncode == 0
     except subprocess.CalledProcessError:
         return False
@@ -83,7 +83,10 @@ async def container_exists(container_name: str) -> bool:
 
 async def container_is_running(container_name: str) -> bool:
     try:
-        result = run_podman(["inspect", "--format", "{{.State.Running}}", container_name])
+        result = await asyncio.to_thread(
+            run_podman,
+            ["inspect", "--format", "{{.State.Running}}", container_name],
+        )
         return result.stdout.strip() == "true"
     except subprocess.CalledProcessError:
         return False
@@ -92,7 +95,7 @@ async def container_is_running(container_name: str) -> bool:
 async def kill_container(container_name: str) -> None:
     logger.info(f"Killing Chromium container {container_name}...")
     try:
-        result = run_podman(["kill", container_name])
+        result = await asyncio.to_thread(run_podman, ["kill", container_name])
         if result.returncode == 0 and result.stdout:
             logger.info(f"Container killed: name={container_name}")
         else:
@@ -104,7 +107,7 @@ async def kill_container(container_name: str) -> None:
 async def list_containers() -> list[str]:
     logger.debug("Retrieving the list of all containers...")
     try:
-        result = run_podman(["container", "ls", "--format", "{{.Names}}"])
+        result = await asyncio.to_thread(run_podman, ["container", "ls", "--format", "{{.Names}}"])
         if result.returncode == 0:
             containers = result.stdout.splitlines() if result.stdout else []
             logger.debug(f"All containers obtained. Total={len(containers)}")
@@ -117,21 +120,27 @@ async def list_containers() -> list[str]:
 
 async def get_container_last_activity(container_name: str) -> float | None:
     try:
-        run_podman([
-            "exec",
-            container_name,
-            "sh",
-            "-c",
-            "cp /home/user/chrome-profile/Default/History db",
-        ])
+        await asyncio.to_thread(
+            run_podman,
+            [
+                "exec",
+                container_name,
+                "sh",
+                "-c",
+                "cp /home/user/chrome-profile/Default/History db",
+            ],
+        )
 
-        result = run_podman([
-            "exec",
-            container_name,
-            "sqlite3",
-            "db",
-            "select MAX(last_visit_time) from urls;",
-        ])
+        result = await asyncio.to_thread(
+            run_podman,
+            [
+                "exec",
+                container_name,
+                "sqlite3",
+                "db",
+                "select MAX(last_visit_time) from urls;",
+            ],
+        )
 
         if result.returncode == 0 and result.stdout:
             chromium_time = float(result.stdout.strip())
@@ -152,37 +161,49 @@ async def configure_container(container_name: str, proxy_url: str | None) -> Non
             proxy_url = proxy_url.removeprefix("http://")
             logger.debug(f"Configuring proxy with proxy_url: {proxy_url}")
             logger.info(f"Modifying tinyproxy.conf in {container_name}...")
-            run_podman([
-                "exec",
-                container_name,
-                "sed",
-                "-i",
-                "/^Upstream http/d",
-                "/app/tinyproxy.conf",
-            ])
-            run_podman([
-                "exec",
-                container_name,
-                "sed",
-                "-i",
-                f"$ a\\Upstream http {proxy_url}",
-                "/app/tinyproxy.conf",
-            ])
+            await asyncio.to_thread(
+                run_podman,
+                [
+                    "exec",
+                    container_name,
+                    "sed",
+                    "-i",
+                    "/^Upstream http/d",
+                    "/app/tinyproxy.conf",
+                ],
+            )
+            await asyncio.to_thread(
+                run_podman,
+                [
+                    "exec",
+                    container_name,
+                    "sed",
+                    "-i",
+                    f"$ a\\Upstream http {proxy_url}",
+                    "/app/tinyproxy.conf",
+                ],
+            )
             logger.info(f"Restarting tinyproxy in {container_name}...")
-            run_podman([
-                "exec",
-                container_name,
-                "sh",
-                "-c",
-                "pkill tinyproxy || true",
-            ])
-            run_podman([
-                "exec",
-                container_name,
-                "sh",
-                "-c",
-                "tinyproxy -d -c /app/tinyproxy.conf &",
-            ])
+            await asyncio.to_thread(
+                run_podman,
+                [
+                    "exec",
+                    container_name,
+                    "sh",
+                    "-c",
+                    "pkill tinyproxy || true",
+                ],
+            )
+            await asyncio.to_thread(
+                run_podman,
+                [
+                    "exec",
+                    container_name,
+                    "sh",
+                    "-c",
+                    "tinyproxy -d -c /app/tinyproxy.conf &",
+                ],
+            )
             logger.info(f"Proxy configured successfully in {container_name}.")
         except subprocess.CalledProcessError as e:
             raise Exception(f"Error configuring proxy: {e}")


### PR DESCRIPTION
Every async helper in `podman_browsers.py` called `run_podman()` directly inside an `async def`. `run_podman()` uses `subprocess.run()`, which is blocking — so each call held the asyncio event loop for the full duration of the podman invocation.

This made endpoints backed by these helpers (notably `/api/v1/browsers`, but also create/delete/get-browser and the idle cleanup loop) feel slow under concurrent load, because no other request could be serviced while podman was running.

Wrap every `run_podman()` call in `await asyncio.to_thread(...)`, matching the pattern already used by `get_container_public_ip`. This offloads the blocking subprocess to the default thread-pool executor so the event loop stays responsive.

To verify, hit the API to create a new browser and while doing that, load the web UI (which will invoke the API to enumerate the browsers).

Before this change, the web UI feels very slow since its API call is blocked.

After this change, everything run asynchronously and there is no more blocking of or due to the web UI.