### PR TITLE
Return HTML or JSON distillation

### DIFF
--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -316,8 +316,8 @@ async def get_page_html(browser_id: str, page_id: str) -> HTMLResponse:
         await client.aclose()
 
 
-@router.get("/api/v1/browsers/{browser_id}/pages/{page_id}/distilled")
-async def get_page_distilled(browser_id: str, page_id: str) -> JSONResponse:
+@router.get("/api/v1/browsers/{browser_id}/pages/{page_id}/distilled", response_model=None)
+async def get_page_distilled(browser_id: str, page_id: str) -> JSONResponse | HTMLResponse:
     page_id = strip_browser_id_from_target_id(page_id)
     try:
         client = await open_cdp(browser_id)
@@ -352,7 +352,7 @@ async def get_page_distilled(browser_id: str, page_id: str) -> JSONResponse:
             if converted:
                 return JSONResponse(converted)
 
-            return JSONResponse({"distilled": match.distilled})
+            return HTMLResponse(content=match.distilled)
         except HTTPException:
             raise
         except Exception as e:


### PR DESCRIPTION
Stop forcing JSON-only responses when conversion is available. The HTML output is useful for processing the distilled page (within the distillation loop).

To verify, use the API to start a new browser and navigate to:

```
https://www.wayfair.com/v/customer/login
```

Calling `/distilled` now yields the pattern-matched login form:

```html
<html gg-domain="wayfair" priority="2">
<head><title>Wayfair Login</title></head>
<body>
<input name="email" gg-match="input[name=email]" .../>
<button gg-match="button[data-test-id='SUBMIT_BUTTON']:not([disabled])">Continue</button>
</body>
</html>
```