### PR TITLE
feat(daytona): warm pool for incognito browsers

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -222,30 +222,6 @@ async def create_remote_browser(
     return browser
 
 
-async def acquire_incognito_remote_browser(
-    target_domain: str | None = None,
-) -> tuple[str, zd.Browser]:
-    """Acquire an ephemeral browser from the fleet (warm pool when available), returning its
-    server-minted browser_id and a connected zendriver Browser.
-
-    Unlike create_remote_browser, the id is assigned by the fleet so a pooled sandbox can be
-    handed out as-is instead of cold-creating one per request.
-    """
-    headers = build_chromefleet_headers(target_domain=target_domain)
-    response = await call_chromefleet_api(
-        "POST", path="/api/v1/browsers-incognito", headers=headers
-    )
-    if response is None:
-        raise RuntimeError("Failed to acquire incognito browser from Chrome Fleet")
-    browser_id = str(response.json()["browser_id"])
-    logger.info(f"Acquired incognito browser: {browser_id}")
-    cdp_websocket_url = _setup_cdp_url(browser_id)
-    browser = await _create_browser_from_cdp_websocket(
-        browser_id=browser_id, websocket_url=cdp_websocket_url, target_domain=target_domain
-    )
-    return browser_id, browser
-
-
 async def terminate_remote_browser(browser: zd.Browser) -> None:
     """Terminate an existing remote Chrome via ChromeFleet."""
     browser_id = cast(str, browser.id)  # type: ignore[attr-defined]

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -222,6 +222,30 @@ async def create_remote_browser(
     return browser
 
 
+async def acquire_incognito_remote_browser(
+    target_domain: str | None = None,
+) -> tuple[str, zd.Browser]:
+    """Acquire an ephemeral browser from the fleet (warm pool when available), returning its
+    server-minted browser_id and a connected zendriver Browser.
+
+    Unlike create_remote_browser, the id is assigned by the fleet so a pooled sandbox can be
+    handed out as-is instead of cold-creating one per request.
+    """
+    headers = build_chromefleet_headers(target_domain=target_domain)
+    response = await call_chromefleet_api(
+        "POST", path="/api/v1/browsers-incognito", headers=headers
+    )
+    if response is None:
+        raise RuntimeError("Failed to acquire incognito browser from Chrome Fleet")
+    browser_id = str(response.json()["browser_id"])
+    logger.info(f"Acquired incognito browser: {browser_id}")
+    cdp_websocket_url = _setup_cdp_url(browser_id)
+    browser = await _create_browser_from_cdp_websocket(
+        browser_id=browser_id, websocket_url=cdp_websocket_url, target_domain=target_domain
+    )
+    return browser_id, browser
+
+
 async def terminate_remote_browser(browser: zd.Browser) -> None:
     """Terminate an existing remote Chrome via ChromeFleet."""
     browser_id = cast(str, browser.id)  # type: ignore[attr-defined]

--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -1,7 +1,5 @@
 from typing import Any, Protocol, runtime_checkable
 
-from nanoid import generate
-
 from getgather.config import settings
 
 # Shared name prefix: a browser with id `abc` is a podman container / Daytona sandbox named
@@ -11,16 +9,6 @@ BROWSER_NAME_PREFIX = "chromium-"
 # Incognito (ephemeral) browser ids carry an `E` prefix (minted by dpage). The pool only needs to
 # recognize this prefix on a requested id to decide whether to claim a spare.
 INCOGNITO_PREFIX = "E"
-_FRIENDLY_CHARS = "23456789abcdefghijkmnpqrstuvwxyz"
-
-# Pool spares get a self-describing `spare-` name so an unclaimed pool sandbox is obvious in the
-# Daytona dashboard. The name is only ever used internally (resolved via the claimed_as label), so
-# it does not need the incognito prefix.
-SPARE_PREFIX = "spare-"
-
-
-def mint_spare_browser_id() -> str:
-    return SPARE_PREFIX + generate(_FRIENDLY_CHARS, 8)
 
 
 class BrowserNotFound(Exception):

--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -1,10 +1,21 @@
 from typing import Any, Protocol, runtime_checkable
 
+from nanoid import generate
+
 from getgather.config import settings
 
 # Shared name prefix: a browser with id `abc` is a podman container / Daytona sandbox named
 # `chromium-abc`. Both local backends derive names and parse ids from this single prefix.
 BROWSER_NAME_PREFIX = "chromium-"
+
+# Incognito (ephemeral) browser ids are an `E` prefix plus a random suffix. Kept in sync with the
+# id dpage previously minted inline (FRIENDLY_CHARS, length 7).
+INCOGNITO_PREFIX = "E"
+_FRIENDLY_CHARS = "23456789abcdefghijkmnpqrstuvwxyz"
+
+
+def mint_incognito_browser_id() -> str:
+    return INCOGNITO_PREFIX + generate(_FRIENDLY_CHARS, 7)
 
 
 class BrowserNotFound(Exception):
@@ -24,11 +35,23 @@ class Backend(Protocol):
     these methods.
     """
 
+    async def startup(self) -> None: ...
+
     async def shutdown(self) -> None: ...
 
     async def create_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]: ...
+
+    async def acquire_incognito_browser(
+        self, origin_ip: str | None, target_domain: str | None
+    ) -> dict[str, Any]:
+        """Return a ready ephemeral browser, minting its (E-prefixed) browser_id.
+
+        Backends with a warm pool hand out a pre-booted sandbox; others cold-create one. The
+        returned dict is the same shape as `create_browser` plus a `browser_id` key.
+        """
+        ...
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None

--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -8,14 +8,19 @@ from getgather.config import settings
 # `chromium-abc`. Both local backends derive names and parse ids from this single prefix.
 BROWSER_NAME_PREFIX = "chromium-"
 
-# Incognito (ephemeral) browser ids are an `E` prefix plus a random suffix. Kept in sync with the
-# id dpage previously minted inline (FRIENDLY_CHARS, length 7).
+# Incognito (ephemeral) browser ids carry an `E` prefix (minted by dpage). The pool only needs to
+# recognize this prefix on a requested id to decide whether to claim a spare.
 INCOGNITO_PREFIX = "E"
 _FRIENDLY_CHARS = "23456789abcdefghijkmnpqrstuvwxyz"
 
+# Pool spares get a self-describing `spare-` name so an unclaimed pool sandbox is obvious in the
+# Daytona dashboard. The name is only ever used internally (resolved via the claimed_as label), so
+# it does not need the incognito prefix.
+SPARE_PREFIX = "spare-"
 
-def mint_incognito_browser_id() -> str:
-    return INCOGNITO_PREFIX + generate(_FRIENDLY_CHARS, 7)
+
+def mint_spare_browser_id() -> str:
+    return SPARE_PREFIX + generate(_FRIENDLY_CHARS, 8)
 
 
 class BrowserNotFound(Exception):

--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -6,10 +6,6 @@ from getgather.config import settings
 # `chromium-abc`. Both local backends derive names and parse ids from this single prefix.
 BROWSER_NAME_PREFIX = "chromium-"
 
-# Incognito (ephemeral) browser ids carry an `E` prefix (minted by dpage). The pool only needs to
-# recognize this prefix on a requested id to decide whether to claim a spare.
-INCOGNITO_PREFIX = "E"
-
 
 class BrowserNotFound(Exception):
     """Raised by a backend when a browser does not exist; endpoints map it to HTTP 404."""

--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -43,16 +43,6 @@ class Backend(Protocol):
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]: ...
 
-    async def acquire_incognito_browser(
-        self, origin_ip: str | None, target_domain: str | None
-    ) -> dict[str, Any]:
-        """Return a ready ephemeral browser, minting its (E-prefixed) browser_id.
-
-        Backends with a warm pool hand out a pre-booted sandbox; others cold-create one. The
-        returned dict is the same shape as `create_browser` plus a `browser_id` key.
-        """
-        ...
-
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]: ...

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -20,6 +20,11 @@ from getgather.browsers.backend import BROWSER_NAME_PREFIX, BrowserNotFound
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
 
+
+class ProxyVerificationError(Exception):
+    """Raised when egress IP is unchanged after proxy configuration."""
+
+
 CDP_PORT = 9222
 VNC_PORT = 8080
 
@@ -121,22 +126,32 @@ async def _get_sandbox_public_ip(
     return None
 
 
-async def _apply_proxy(
+async def _configure_remote_sandbox(
     sandbox: AsyncSandbox,
     browser_id: str,
     origin_ip: str | None,
     target_domain: str | None,
-) -> bool:
-    """Point the sandbox's tinyproxy at the residential upstream. Returns True if a proxy was set.
-
-    Fast path only (sed + service reload); the egress-IP check is done off the hot path — it was
-    purely diagnostic (logged, never gated anything) yet cost ~5s of curl-through-proxy round-trips.
-    """
+) -> None:
     proxy_config = await get_proxy_config(origin_ip, target_domain, settings)
     proxy_url = proxy_config.get_proxy_url(browser_id) if proxy_config else None
+
     if not proxy_url:
-        return False
-    return await _configure_sandbox_proxy(sandbox, proxy_url)
+        return
+
+    ip_before = await _get_sandbox_public_ip(sandbox)
+    logger.debug(f"Sandbox {sandbox.name} IP before proxy: {ip_before}")
+
+    ok = await _configure_sandbox_proxy(sandbox, proxy_url)
+    if not ok:
+        return
+
+    ip_after = await _get_sandbox_public_ip(sandbox)
+    if ip_before and ip_after and ip_before != ip_after:
+        logger.info(f"Sandbox {sandbox.name} IP changed: {ip_before} -> {ip_after}")
+    elif ip_before == ip_after:
+        raise ProxyVerificationError(
+            f"Sandbox {sandbox.name} IP unchanged after proxy: {ip_before}"
+        )
 
 
 def _browser_id_from_name(name: str) -> str:
@@ -170,17 +185,14 @@ class DaytonaBackend:
         # Collapses concurrent reconcile calls into one; separate so a slow backfill (each spawn
         # cold-boots a sandbox, ~9s) never blocks anything else.
         self._reconcile_lock = asyncio.Lock()
-        # Strong refs to background tasks; asyncio only holds weak refs, so an unreferenced task can
-        # be garbage-collected mid-flight (e.g. the reconcile that fills the pool would never run).
+        # Strong refs to background reconcile tasks; asyncio only holds weak refs, so an unreferenced
+        # task can be garbage-collected mid-flight (and the pool would never fill).
         self._bg_tasks: set[asyncio.Task[None]] = set()
 
-    def _spawn_bg(self, coro: Any) -> None:
-        task = asyncio.create_task(coro)
+    def _spawn_reconcile(self) -> None:
+        task = asyncio.create_task(self._reconcile_pool())
         self._bg_tasks.add(task)
         task.add_done_callback(self._bg_tasks.discard)
-
-    def _spawn_reconcile(self) -> None:
-        self._spawn_bg(self._reconcile_pool())
 
     def _pool_eligible(self, browser_id: str) -> bool:
         """A non-empty pool only ever serves incognito ids; everything else cold-creates."""
@@ -207,23 +219,21 @@ class DaytonaBackend:
     ) -> None:
         """Configure the residential proxy once per sandbox.
 
-        Skips the (tinyproxy reload) work if the sandbox already carries the proxied label — proxy is
-        sticky per browser_id, so re-running on every query is wasted. The egress-IP verification runs
-        in the background (log-only) so it stays off the request's critical path.
+        Skips the work (a tinyproxy reload + two IP-verify round-trips, several seconds) if the
+        sandbox already carries the proxied label — proxy is sticky per browser_id, so re-running on
+        every query is wasted time.
         """
         if (sandbox.labels or {}).get(LABEL_PROXIED) == "1":
             return
-        applied = await _apply_proxy(sandbox, browser_id, origin_ip, target_domain)
-        if applied:
-            self._spawn_bg(self._log_egress_ip(sandbox))
+        try:
+            await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+        except ProxyVerificationError as e:
+            logger.warning(str(e))
+        # Mark proxied even if verification was inconclusive — a retry yields the same upstream IP.
         try:
             await sandbox.set_labels({**(sandbox.labels or {}), LABEL_PROXIED: "1"})
         except Exception as e:
             logger.warning(f"Failed to mark {sandbox.name} proxied: {e}")
-
-    async def _log_egress_ip(self, sandbox: AsyncSandbox) -> None:
-        ip = await _get_sandbox_public_ip(sandbox)
-        logger.info(f"Sandbox {sandbox.name} egress IP via proxy: {ip}")
 
     async def _resolve(self, browser_id: str) -> str:
         """Resolve a requested browser_id to the real sandbox id backing it.
@@ -251,24 +261,12 @@ class DaytonaBackend:
     async def create_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]:
-        t0 = time.monotonic()  # [TIMING] temporary
         effective_id = await self._claim_spare_for(browser_id)
-        t_claim = time.monotonic()  # [TIMING] temporary
         lock = self._locks.setdefault(effective_id, asyncio.Lock())
         async with lock:
             sandbox = await self._ensure(effective_id)
-            t_ensure = time.monotonic()  # [TIMING] temporary
             await self._ensure_proxy(sandbox, effective_id, origin_ip, target_domain)
-            t_proxy = time.monotonic()  # [TIMING] temporary
-            info = await self._get_info(sandbox)
-            # [TIMING] temporary — remove before merge
-            logger.info(
-                f"[TIMING] create_browser {browser_id}: "
-                f"claim={t_claim - t0:.1f}s ensure={t_ensure - t_claim:.1f}s "
-                f"proxy={t_proxy - t_ensure:.1f}s info={time.monotonic() - t_proxy:.1f}s "
-                f"total={time.monotonic() - t0:.1f}s"
-            )
-            return info
+            return await self._get_info(sandbox)
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -15,11 +15,7 @@ from daytona import (
 from loguru import logger
 from nanoid import generate
 
-from getgather.browsers.backend import (
-    BROWSER_NAME_PREFIX,
-    INCOGNITO_PREFIX,
-    BrowserNotFound,
-)
+from getgather.browsers.backend import BROWSER_NAME_PREFIX, BrowserNotFound
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
 
@@ -76,6 +72,10 @@ SPARE_LABELS = {LABEL_FLEET: "1", LABEL_POOL: POOL_SPARE}
 # does not need the incognito prefix.
 SPARE_NAME_PREFIX = "spare-"
 _SPARE_ID_CHARS = "23456789abcdefghijkmnpqrstuvwxyz"
+
+# Incognito (ephemeral) browser ids carry this prefix (minted by dpage). The pool only serves
+# incognito requests, so the claim path keys off it. Must match the prefix dpage uses.
+INCOGNITO_PREFIX = "E"
 
 
 def _sandbox_name(browser_id: str) -> str:

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -1,4 +1,5 @@
 import asyncio
+import random
 import time
 from collections.abc import AsyncIterator
 from typing import Any
@@ -178,12 +179,11 @@ class DaytonaBackend:
         self._locks: dict[str, asyncio.Lock] = {}
         self._pool_size = settings.DAYTONA_INCOGNITO_POOL_SIZE
         # Pool inventory and the claimed-id binding both live in Daytona labels (see LABEL_CLAIMED),
-        # so the backend holds no durable state and survives restarts. This lock only serializes the
-        # claim within one process; cross-instance claim races are possible (last writer wins) and
-        # self-heal — a future deployment that needs hard cross-instance safety would add a CAS store.
-        self._pool_lock = asyncio.Lock()
-        # Separate from _pool_lock so a slow backfill (each spawn cold-boots a sandbox, ~9s) never
-        # blocks a claim. Just collapses concurrent reconcile calls into one.
+        # so the backend holds no durable state and survives restarts. Claims are NOT serialized:
+        # concurrent claimers race optimistically and _try_claim's confirm step resolves collisions,
+        # so requests don't queue behind one lock (cross-instance races self-heal the same way).
+        # Collapses concurrent reconcile calls into one; separate so a slow backfill (each spawn
+        # cold-boots a sandbox, ~9s) never blocks anything else.
         self._reconcile_lock = asyncio.Lock()
         # Strong refs to background reconcile tasks; asyncio only holds weak refs, so an unreferenced
         # task can be garbage-collected mid-flight (and the pool would never fill).
@@ -316,20 +316,19 @@ class DaytonaBackend:
         if not self._pool_eligible(browser_id):
             return browser_id
 
-        spare_id: str | None = None
-        async with self._pool_lock:
-            async for candidate in self._iter_sandboxes(SPARE_LABELS, started_only=True):
-                if await self._try_claim(candidate.name, browser_id):
-                    spare_id = _browser_id_from_name(candidate.name)
-                    break
+        # Shuffle so concurrent claimers don't all target the same spare first (each collision costs
+        # a wasted set_labels + retry). Claims run unserialized; _try_claim confirms exclusive ownership.
+        candidates = [sb async for sb in self._iter_sandboxes(SPARE_LABELS, started_only=True)]
+        random.shuffle(candidates)
+        for sb in candidates:
+            if sb.name and await self._try_claim(sb.name, browser_id):
+                spare_id = _browser_id_from_name(sb.name)
+                logger.info(f"Claimed pooled spare {spare_id} for incognito browser {browser_id}")
+                self._spawn_reconcile()
+                return spare_id
 
-        if spare_id is None:
-            logger.info(f"Pool empty; cold-creating incognito browser {browser_id}")
-            return browser_id
-
-        logger.info(f"Claimed pooled spare {spare_id} for incognito browser {browser_id}")
-        self._spawn_reconcile()
-        return spare_id
+        logger.info(f"Pool empty; cold-creating incognito browser {browser_id}")
+        return browser_id
 
     async def _try_claim(self, name: str, browser_id: str) -> bool:
         """Claim one spare candidate, guarding against Daytona's eventually-consistent label list.

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -63,6 +63,9 @@ LABEL_FLEET = "fleet"
 LABEL_POOL = "pool"
 POOL_SPARE = "spare"
 LABEL_CLAIMED = "claimed_as"
+# Set once the residential proxy has been configured on a sandbox, so a later get_browser query
+# doesn't re-run the (slow) proxy setup + IP-verify round-trip. Proxy is sticky per browser_id.
+LABEL_PROXIED = "proxied"
 
 FLEET_LABELS = {LABEL_FLEET: "1"}
 SPARE_LABELS = {LABEL_FLEET: "1", LABEL_POOL: POOL_SPARE}
@@ -207,6 +210,31 @@ class DaytonaBackend:
                 continue
             yield sandbox
 
+    async def _ensure_proxy(
+        self,
+        sandbox: AsyncSandbox,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+    ) -> None:
+        """Configure the residential proxy once per sandbox.
+
+        Skips the work (a tinyproxy reload + two IP-verify round-trips, several seconds) if the
+        sandbox already carries the proxied label — proxy is sticky per browser_id, so re-running on
+        every query is wasted time.
+        """
+        if (sandbox.labels or {}).get(LABEL_PROXIED) == "1":
+            return
+        try:
+            await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+        except ProxyVerificationError as e:
+            logger.warning(str(e))
+        # Mark proxied even if verification was inconclusive — a retry yields the same upstream IP.
+        try:
+            await sandbox.set_labels({**(sandbox.labels or {}), LABEL_PROXIED: "1"})
+        except Exception as e:
+            logger.warning(f"Failed to mark {sandbox.name} proxied: {e}")
+
     async def _resolve(self, browser_id: str) -> str:
         """Resolve a requested browser_id to the real sandbox id backing it.
 
@@ -237,10 +265,7 @@ class DaytonaBackend:
         lock = self._locks.setdefault(effective_id, asyncio.Lock())
         async with lock:
             sandbox = await self._ensure(effective_id)
-            try:
-                await _configure_remote_sandbox(sandbox, effective_id, origin_ip, target_domain)
-            except ProxyVerificationError as e:
-                logger.warning(str(e))
+            await self._ensure_proxy(sandbox, effective_id, origin_ip, target_domain)
             return await self._get_info(sandbox)
 
     async def get_browser(
@@ -251,10 +276,7 @@ class DaytonaBackend:
         if sandbox is None:
             raise BrowserNotFound(browser_id)
         if origin_ip:
-            try:
-                await _configure_remote_sandbox(sandbox, effective_id, origin_ip, target_domain)
-            except ProxyVerificationError as e:
-                logger.warning(str(e))
+            await self._ensure_proxy(sandbox, effective_id, origin_ip, target_domain)
         return await self._get_info(sandbox)
 
     async def delete_browser(self, browser_id: str) -> dict[str, Any]:

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -513,21 +513,17 @@ class DaytonaBackend:
         return sandbox
 
     async def _get_info(self, sandbox: AsyncSandbox) -> dict[str, Any]:
-        _t0 = time.monotonic()  # [TIMING] temporary
         signed = await sandbox.create_signed_preview_url(
             CDP_PORT, expires_in_seconds=SIGNED_URL_TTL_SECONDS
         )
-        _t_signed = time.monotonic()  # [TIMING] temporary
-        last_activity = await self._get_last_activity(sandbox)
-        logger.info(  # [TIMING] temporary
-            f"[TIMING] _get_info {sandbox.name}: signed_url={_t_signed - _t0:.1f}s "
-            f"last_activity={time.monotonic() - _t_signed:.1f}s"
-        )
+        # last_activity is intentionally not computed here: it cost ~1s (a `cp History + sqlite3`
+        # exec that usually returns empty on a fresh browser) on the create/get hot path and nothing
+        # consumes the field. The live-view idle gate reads it on demand via _get_last_activity.
         return {
             "hostname": sandbox.name,
             "cdp_url": signed.url,  # public, internet-reachable; bearer secret (see SIGNED_URL_TTL_SECONDS)
             "app_state": sandbox.state,
-            "last_activity_timestamp": last_activity,
+            "last_activity_timestamp": None,
         }
 
     async def _get_last_activity(self, sandbox: AsyncSandbox) -> float | None:

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -20,11 +20,6 @@ from getgather.browsers.backend import BROWSER_NAME_PREFIX, BrowserNotFound
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
 
-
-class ProxyVerificationError(Exception):
-    """Raised when egress IP is unchanged after proxy configuration."""
-
-
 CDP_PORT = 9222
 VNC_PORT = 8080
 
@@ -126,32 +121,22 @@ async def _get_sandbox_public_ip(
     return None
 
 
-async def _configure_remote_sandbox(
+async def _apply_proxy(
     sandbox: AsyncSandbox,
     browser_id: str,
     origin_ip: str | None,
     target_domain: str | None,
-) -> None:
+) -> bool:
+    """Point the sandbox's tinyproxy at the residential upstream. Returns True if a proxy was set.
+
+    Fast path only (sed + service reload); the egress-IP check is done off the hot path — it was
+    purely diagnostic (logged, never gated anything) yet cost ~5s of curl-through-proxy round-trips.
+    """
     proxy_config = await get_proxy_config(origin_ip, target_domain, settings)
     proxy_url = proxy_config.get_proxy_url(browser_id) if proxy_config else None
-
     if not proxy_url:
-        return
-
-    ip_before = await _get_sandbox_public_ip(sandbox)
-    logger.debug(f"Sandbox {sandbox.name} IP before proxy: {ip_before}")
-
-    ok = await _configure_sandbox_proxy(sandbox, proxy_url)
-    if not ok:
-        return
-
-    ip_after = await _get_sandbox_public_ip(sandbox)
-    if ip_before and ip_after and ip_before != ip_after:
-        logger.info(f"Sandbox {sandbox.name} IP changed: {ip_before} -> {ip_after}")
-    elif ip_before == ip_after:
-        raise ProxyVerificationError(
-            f"Sandbox {sandbox.name} IP unchanged after proxy: {ip_before}"
-        )
+        return False
+    return await _configure_sandbox_proxy(sandbox, proxy_url)
 
 
 def _browser_id_from_name(name: str) -> str:
@@ -185,14 +170,17 @@ class DaytonaBackend:
         # Collapses concurrent reconcile calls into one; separate so a slow backfill (each spawn
         # cold-boots a sandbox, ~9s) never blocks anything else.
         self._reconcile_lock = asyncio.Lock()
-        # Strong refs to background reconcile tasks; asyncio only holds weak refs, so an unreferenced
-        # task can be garbage-collected mid-flight (and the pool would never fill).
+        # Strong refs to background tasks; asyncio only holds weak refs, so an unreferenced task can
+        # be garbage-collected mid-flight (e.g. the reconcile that fills the pool would never run).
         self._bg_tasks: set[asyncio.Task[None]] = set()
 
-    def _spawn_reconcile(self) -> None:
-        task = asyncio.create_task(self._reconcile_pool())
+    def _spawn_bg(self, coro: Any) -> None:
+        task = asyncio.create_task(coro)
         self._bg_tasks.add(task)
         task.add_done_callback(self._bg_tasks.discard)
+
+    def _spawn_reconcile(self) -> None:
+        self._spawn_bg(self._reconcile_pool())
 
     def _pool_eligible(self, browser_id: str) -> bool:
         """A non-empty pool only ever serves incognito ids; everything else cold-creates."""
@@ -219,21 +207,23 @@ class DaytonaBackend:
     ) -> None:
         """Configure the residential proxy once per sandbox.
 
-        Skips the work (a tinyproxy reload + two IP-verify round-trips, several seconds) if the
-        sandbox already carries the proxied label — proxy is sticky per browser_id, so re-running on
-        every query is wasted time.
+        Skips the (tinyproxy reload) work if the sandbox already carries the proxied label — proxy is
+        sticky per browser_id, so re-running on every query is wasted. The egress-IP verification runs
+        in the background (log-only) so it stays off the request's critical path.
         """
         if (sandbox.labels or {}).get(LABEL_PROXIED) == "1":
             return
-        try:
-            await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
-        except ProxyVerificationError as e:
-            logger.warning(str(e))
-        # Mark proxied even if verification was inconclusive — a retry yields the same upstream IP.
+        applied = await _apply_proxy(sandbox, browser_id, origin_ip, target_domain)
+        if applied:
+            self._spawn_bg(self._log_egress_ip(sandbox))
         try:
             await sandbox.set_labels({**(sandbox.labels or {}), LABEL_PROXIED: "1"})
         except Exception as e:
             logger.warning(f"Failed to mark {sandbox.name} proxied: {e}")
+
+    async def _log_egress_ip(self, sandbox: AsyncSandbox) -> None:
+        ip = await _get_sandbox_public_ip(sandbox)
+        logger.info(f"Sandbox {sandbox.name} egress IP via proxy: {ip}")
 
     async def _resolve(self, browser_id: str) -> str:
         """Resolve a requested browser_id to the real sandbox id backing it.
@@ -261,12 +251,24 @@ class DaytonaBackend:
     async def create_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]:
+        t0 = time.monotonic()  # [TIMING] temporary
         effective_id = await self._claim_spare_for(browser_id)
+        t_claim = time.monotonic()  # [TIMING] temporary
         lock = self._locks.setdefault(effective_id, asyncio.Lock())
         async with lock:
             sandbox = await self._ensure(effective_id)
+            t_ensure = time.monotonic()  # [TIMING] temporary
             await self._ensure_proxy(sandbox, effective_id, origin_ip, target_domain)
-            return await self._get_info(sandbox)
+            t_proxy = time.monotonic()  # [TIMING] temporary
+            info = await self._get_info(sandbox)
+            # [TIMING] temporary — remove before merge
+            logger.info(
+                f"[TIMING] create_browser {browser_id}: "
+                f"claim={t_claim - t0:.1f}s ensure={t_ensure - t_claim:.1f}s "
+                f"proxy={t_proxy - t_ensure:.1f}s info={time.monotonic() - t_proxy:.1f}s "
+                f"total={time.monotonic() - t0:.1f}s"
+            )
+            return info
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -17,7 +17,7 @@ from getgather.browsers.backend import (
     BROWSER_NAME_PREFIX,
     INCOGNITO_PREFIX,
     BrowserNotFound,
-    mint_incognito_browser_id,
+    mint_spare_browser_id,
 )
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
@@ -322,7 +322,7 @@ class DaytonaBackend:
                     break
 
     async def _spawn_spare(self) -> str:
-        browser_id = mint_incognito_browser_id()
+        browser_id = mint_spare_browser_id()
         name = _sandbox_name(browser_id)
         logger.info(f"Spawning pool spare {name}")
         await self._create(name, labels={LABEL_FLEET: "1", LABEL_POOL: POOL_SPARE})

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -155,10 +155,11 @@ def _browser_id_from_name(name: str) -> str:
 
 
 class DaytonaBackend:
-    """Launch a Daytona sandbox per browser on demand (no pool).
+    """Launch a Daytona sandbox per browser, optionally serving incognito requests from a warm pool.
 
-    The browser_id -> sandbox mapping is the deterministic sandbox name plus labels, so there is
-    no local state. CDP is reached over a Daytona signed preview URL: a public, internet-reachable,
+    The browser_id -> sandbox mapping is the deterministic sandbox name plus labels (incognito ids
+    that claimed a pool spare are bound via a claimed_as label), so there is no in-process state and
+    resolution survives restarts. CDP is reached over a Daytona signed preview URL: a public, internet-reachable,
     self-authenticating HTTPS reverse proxy to port 9222 (no inbound networking into the sandbox is
     required). Live view embeds the snapshot's built-in noVNC on port 8080 via a signed preview URL.
     Residential proxy/geo-IP are supported via tinyproxy (preconfigured in the snapshot, same as podman).
@@ -329,12 +330,10 @@ class DaytonaBackend:
                     logger.warning(f"Failed to spawn pool spare: {type(e).__name__}: {e}")
                     break
 
-    async def _spawn_spare(self) -> str:
-        browser_id = SPARE_NAME_PREFIX + generate(_SPARE_ID_CHARS, 8)
-        name = _sandbox_name(browser_id)
+    async def _spawn_spare(self) -> None:
+        name = _sandbox_name(SPARE_NAME_PREFIX + generate(_SPARE_ID_CHARS, 8))
         logger.info(f"Spawning pool spare {name}")
-        await self._create(name, labels={LABEL_FLEET: "1", LABEL_POOL: POOL_SPARE})
-        return browser_id
+        await self._create(name, labels=SPARE_LABELS)
 
     async def get_cdp_base_url(self, browser_id: str) -> str:
         sandbox = await self._get(_sandbox_name(await self._resolve(browser_id)))

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -13,12 +13,12 @@ from daytona import (
     ListSandboxesQuery,
 )
 from loguru import logger
+from nanoid import generate
 
 from getgather.browsers.backend import (
     BROWSER_NAME_PREFIX,
     INCOGNITO_PREFIX,
     BrowserNotFound,
-    mint_spare_browser_id,
 )
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
@@ -70,6 +70,12 @@ LABEL_CLAIMED = "claimed_as"
 
 FLEET_LABELS = {LABEL_FLEET: "1"}
 SPARE_LABELS = {LABEL_FLEET: "1", LABEL_POOL: POOL_SPARE}
+
+# Pool spares get a self-describing `spare-<rand>` name so an unclaimed pool sandbox is obvious in
+# the Daytona dashboard. The name is only used internally (resolved via the claimed_as label), so it
+# does not need the incognito prefix.
+SPARE_NAME_PREFIX = "spare-"
+_SPARE_ID_CHARS = "23456789abcdefghijkmnpqrstuvwxyz"
 
 
 def _sandbox_name(browser_id: str) -> str:
@@ -324,7 +330,7 @@ class DaytonaBackend:
                     break
 
     async def _spawn_spare(self) -> str:
-        browser_id = mint_spare_browser_id()
+        browser_id = SPARE_NAME_PREFIX + generate(_SPARE_ID_CHARS, 8)
         name = _sandbox_name(browser_id)
         logger.info(f"Spawning pool spare {name}")
         await self._create(name, labels={LABEL_FLEET: "1", LABEL_POOL: POOL_SPARE})

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -17,7 +17,7 @@ from loguru import logger
 from nanoid import generate
 
 from getgather.browsers.backend import BROWSER_NAME_PREFIX, BrowserNotFound
-from getgather.browsers.residential_proxy import get_proxy_config
+from getgather.browsers.residential_proxy import default_proxy_config, get_proxy_config
 from getgather.config import settings
 
 
@@ -64,9 +64,12 @@ LABEL_FLEET = "fleet"
 LABEL_POOL = "pool"
 POOL_SPARE = "spare"
 LABEL_CLAIMED = "claimed_as"
-# Set once the residential proxy has been configured on a sandbox, so a later get_browser query
-# doesn't re-run the (slow) proxy setup + IP-verify round-trip. Proxy is sticky per browser_id.
+# Records that a residential proxy is configured, and which (provider, country). A claim whose
+# resolved proxy matches reuses it as-is — letting a pool spare be pre-proxied at spawn so the slow
+# setup + IP-verify never lands on the request's hot path. A mismatch reconfigures.
 LABEL_PROXIED = "proxied"
+LABEL_PROXY_TYPE = "proxy_type"
+LABEL_PROXY_CC = "proxy_cc"
 
 FLEET_LABELS = {LABEL_FLEET: "1"}
 SPARE_LABELS = {LABEL_FLEET: "1", LABEL_POOL: POOL_SPARE}
@@ -126,18 +129,8 @@ async def _get_sandbox_public_ip(
     return None
 
 
-async def _configure_remote_sandbox(
-    sandbox: AsyncSandbox,
-    browser_id: str,
-    origin_ip: str | None,
-    target_domain: str | None,
-) -> None:
-    proxy_config = await get_proxy_config(origin_ip, target_domain, settings)
-    proxy_url = proxy_config.get_proxy_url(browser_id) if proxy_config else None
-
-    if not proxy_url:
-        return
-
+async def _apply_and_verify_proxy(sandbox: AsyncSandbox, proxy_url: str) -> None:
+    """Point tinyproxy at the upstream and verify the egress IP actually changed."""
     ip_before = await _get_sandbox_public_ip(sandbox)
     logger.debug(f"Sandbox {sandbox.name} IP before proxy: {ip_before}")
 
@@ -217,21 +210,42 @@ class DaytonaBackend:
         origin_ip: str | None,
         target_domain: str | None,
     ) -> None:
-        """Configure the residential proxy once per sandbox.
+        """Configure the residential proxy for this request, reusing a pre-applied one when it matches.
 
-        Skips the work (a tinyproxy reload + two IP-verify round-trips, several seconds) if the
-        sandbox already carries the proxied label — proxy is sticky per browser_id, so re-running on
-        every query is wasted time.
+        A pool spare is pre-proxied at spawn with the default (provider, country). If the request
+        resolves to the same pair, the proxy is already correct and we skip the slow setup + IP-verify
+        entirely — the whole point of pre-warming. Otherwise (different provider/country, or never
+        proxied) we (re)configure and re-tag.
         """
-        if (sandbox.labels or {}).get(LABEL_PROXIED) == "1":
-            return
+        proxy_config = await get_proxy_config(origin_ip, target_domain, settings)
+        if proxy_config is None:
+            return  # no proxy desired (no origin ip / MaxMind off)
+        desired_type = proxy_config.type_
+        desired_cc = proxy_config.location.country or ""
+
+        labels = sandbox.labels or {}
+        if (
+            labels.get(LABEL_PROXIED) == "1"
+            and labels.get(LABEL_PROXY_TYPE) == desired_type
+            and labels.get(LABEL_PROXY_CC) == desired_cc
+        ):
+            return  # pre-applied proxy already matches this request
+
         try:
-            await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+            await _apply_and_verify_proxy(sandbox, proxy_config.get_proxy_url(browser_id))
         except ProxyVerificationError as e:
             logger.warning(str(e))
+        await self._mark_proxied(sandbox, desired_type, desired_cc)
+
+    async def _mark_proxied(self, sandbox: AsyncSandbox, proxy_type: str, country: str) -> None:
         # Mark proxied even if verification was inconclusive — a retry yields the same upstream IP.
         try:
-            await sandbox.set_labels({**(sandbox.labels or {}), LABEL_PROXIED: "1"})
+            await sandbox.set_labels({
+                **(sandbox.labels or {}),
+                LABEL_PROXIED: "1",
+                LABEL_PROXY_TYPE: proxy_type,
+                LABEL_PROXY_CC: country,
+            })
         except Exception as e:
             logger.warning(f"Failed to mark {sandbox.name} proxied: {e}")
 
@@ -344,9 +358,13 @@ class DaytonaBackend:
         labels = fresh.labels or {}
         if labels.get(LABEL_POOL) != POOL_SPARE or LABEL_CLAIMED in labels:
             return False  # stale list entry — already claimed by someone else
-        # Replace labels: drops pool=spare (leaves the pool) and records the binding.
+        # Drop pool=spare (leaves the pool) and record the binding, but keep the rest — notably the
+        # proxied/proxy_type/proxy_cc tags so the pre-applied proxy survives the claim.
+        new_labels = {k: v for k, v in labels.items() if k != LABEL_POOL}
+        new_labels[LABEL_FLEET] = "1"
+        new_labels[LABEL_CLAIMED] = browser_id
         try:
-            await fresh.set_labels({LABEL_FLEET: "1", LABEL_CLAIMED: browser_id})
+            await fresh.set_labels(new_labels)
         except Exception as e:
             logger.warning(f"Failed to claim spare {name}: {e}")
             return False
@@ -377,9 +395,21 @@ class DaytonaBackend:
                     break
 
     async def _spawn_spare(self) -> None:
-        name = _sandbox_name(SPARE_NAME_PREFIX + generate(_SPARE_ID_CHARS, 8))
+        spare_id = SPARE_NAME_PREFIX + generate(_SPARE_ID_CHARS, 8)
+        name = _sandbox_name(spare_id)
         logger.info(f"Spawning pool spare {name}")
-        await self._create(name, labels=SPARE_LABELS)
+        sandbox = await self._create(name, labels=SPARE_LABELS)
+        # Pre-apply the default proxy now (off the hot path). A claim that resolves to the same
+        # (provider, country) reuses it via the proxy_type/proxy_cc labels and skips proxy setup.
+        # Session id is the spare's own id, which becomes the claimed browser's effective id.
+        config = default_proxy_config(settings)
+        if config is None:
+            return
+        try:
+            await _apply_and_verify_proxy(sandbox, config.get_proxy_url(spare_id))
+        except ProxyVerificationError as e:
+            logger.warning(str(e))
+        await self._mark_proxied(sandbox, config.type_, config.location.country or "")
 
     async def get_cdp_base_url(self, browser_id: str) -> str:
         sandbox = await self._get(_sandbox_name(await self._resolve(browser_id)))

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from collections.abc import AsyncIterator
 from typing import Any
 
 from daytona import (
@@ -66,6 +67,9 @@ LABEL_FLEET = "fleet"
 LABEL_POOL = "pool"
 POOL_SPARE = "spare"
 LABEL_CLAIMED = "claimed_as"
+
+FLEET_LABELS = {LABEL_FLEET: "1"}
+SPARE_LABELS = {LABEL_FLEET: "1", LABEL_POOL: POOL_SPARE}
 
 
 def _sandbox_name(browser_id: str) -> str:
@@ -172,6 +176,22 @@ class DaytonaBackend:
         # blocks a claim. Just collapses concurrent reconcile calls into one.
         self._reconcile_lock = asyncio.Lock()
 
+    def _pool_eligible(self, browser_id: str) -> bool:
+        """A non-empty pool only ever serves incognito ids; everything else cold-creates."""
+        return self._pool_size > 0 and browser_id.startswith(INCOGNITO_PREFIX)
+
+    async def _iter_sandboxes(
+        self, labels: dict[str, str], *, started_only: bool = False
+    ) -> AsyncIterator[AsyncSandbox]:
+        """Yield our sandboxes matching `labels`, skipping non-fleet names (e.g. a just-deleted
+        `DESTROYED_<name>_<ts>`) and, when asked, anything Daytona has auto-stopped."""
+        async for sandbox in self.client.list(ListSandboxesQuery(labels=labels)):
+            if not (sandbox.name and sandbox.name.startswith(BROWSER_NAME_PREFIX)):
+                continue
+            if started_only and sandbox.state != "started":
+                continue
+            yield sandbox
+
     async def _resolve(self, browser_id: str) -> str:
         """Resolve a requested browser_id to the real sandbox id backing it.
 
@@ -179,13 +199,10 @@ class DaytonaBackend:
         binding is recorded as a claimed_as=<browser_id> label. Per-user ids, unclaimed ids, and
         cold-created incognito ids resolve to themselves. One Daytona lookup for incognito, none else.
         """
-        if self._pool_size <= 0 or not browser_id.startswith(INCOGNITO_PREFIX):
+        if not self._pool_eligible(browser_id):
             return browser_id
-        async for sandbox in self.client.list(
-            ListSandboxesQuery(labels={LABEL_CLAIMED: browser_id})
-        ):
-            if sandbox.name and sandbox.name.startswith(BROWSER_NAME_PREFIX):
-                return _browser_id_from_name(sandbox.name)
+        async for sandbox in self._iter_sandboxes({LABEL_CLAIMED: browser_id}):
+            return _browser_id_from_name(sandbox.name)
         return browser_id
 
     async def startup(self) -> None:
@@ -242,12 +259,10 @@ class DaytonaBackend:
         return await self._get(_sandbox_name(await self._resolve(browser_id))) is not None
 
     async def list_browser_ids(self) -> list[str]:
-        browser_ids: list[str] = []
-        async for sandbox in self.client.list(ListSandboxesQuery(labels={LABEL_FLEET: "1"})):
-            # A just-deleted sandbox lingers briefly as `DESTROYED_<name>_<ts>`; only our names count.
-            if sandbox.name and sandbox.name.startswith(BROWSER_NAME_PREFIX):
-                browser_ids.append(_browser_id_from_name(sandbox.name))
-        return browser_ids
+        return [
+            _browser_id_from_name(sandbox.name)
+            async for sandbox in self._iter_sandboxes(FLEET_LABELS)
+        ]
 
     async def cleanup_idle(self) -> list[str]:
         # Teardown is owned by Daytona's native auto_stop_interval + auto_delete_interval (set in
@@ -264,18 +279,12 @@ class DaytonaBackend:
         path). Only incognito ids are eligible; per-user ids always cold-create under their own
         deterministic name. The lock serializes claims within this process.
         """
-        if self._pool_size <= 0 or not browser_id.startswith(INCOGNITO_PREFIX):
+        if not self._pool_eligible(browser_id):
             return browser_id
 
         spare_id: str | None = None
         async with self._pool_lock:
-            async for sandbox in self.client.list(
-                ListSandboxesQuery(labels={LABEL_FLEET: "1", LABEL_POOL: POOL_SPARE})
-            ):
-                if not (sandbox.name and sandbox.name.startswith(BROWSER_NAME_PREFIX)):
-                    continue
-                if sandbox.state != "started":
-                    continue  # auto-stopped/stale; the reconcile sweep will replace it
+            async for sandbox in self._iter_sandboxes(SPARE_LABELS, started_only=True):
                 # Replace labels: drops pool=spare (so it leaves the pool) and records the binding.
                 # Done under the lock so a concurrent claim in this process can't take the same one.
                 try:
@@ -302,16 +311,9 @@ class DaytonaBackend:
         block a claim, while concurrent reconcile calls collapse into one.
         """
         async with self._reconcile_lock:
-            spare_count = 0
-            async for sandbox in self.client.list(
-                ListSandboxesQuery(labels={LABEL_FLEET: "1", LABEL_POOL: POOL_SPARE})
-            ):
-                if (
-                    sandbox.name
-                    and sandbox.name.startswith(BROWSER_NAME_PREFIX)
-                    and sandbox.state == "started"
-                ):
-                    spare_count += 1
+            spare_count = sum([
+                1 async for _ in self._iter_sandboxes(SPARE_LABELS, started_only=True)
+            ])
             deficit = self._pool_size - spare_count
 
             for _ in range(max(0, deficit)):

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -182,6 +182,14 @@ class DaytonaBackend:
         # Separate from _pool_lock so a slow backfill (each spawn cold-boots a sandbox, ~9s) never
         # blocks a claim. Just collapses concurrent reconcile calls into one.
         self._reconcile_lock = asyncio.Lock()
+        # Strong refs to background reconcile tasks; asyncio only holds weak refs, so an unreferenced
+        # task can be garbage-collected mid-flight (and the pool would never fill).
+        self._bg_tasks: set[asyncio.Task[None]] = set()
+
+    def _spawn_reconcile(self) -> None:
+        task = asyncio.create_task(self._reconcile_pool())
+        self._bg_tasks.add(task)
+        task.add_done_callback(self._bg_tasks.discard)
 
     def _pool_eligible(self, browser_id: str) -> bool:
         """A non-empty pool only ever serves incognito ids; everything else cold-creates."""
@@ -217,7 +225,7 @@ class DaytonaBackend:
             return
         # Adopt spares that survived a restart, then backfill — both in the background so server
         # startup is never blocked on Daytona.
-        asyncio.create_task(self._reconcile_pool())
+        self._spawn_reconcile()
 
     async def shutdown(self) -> None:
         await self.client.close()
@@ -304,7 +312,7 @@ class DaytonaBackend:
             return browser_id
 
         logger.info(f"Claimed pooled spare {spare_id} for incognito browser {browser_id}")
-        asyncio.create_task(self._reconcile_pool())
+        self._spawn_reconcile()
         return spare_id
 
     async def _reconcile_pool(self) -> None:

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -296,16 +296,10 @@ class DaytonaBackend:
 
         spare_id: str | None = None
         async with self._pool_lock:
-            async for sandbox in self._iter_sandboxes(SPARE_LABELS, started_only=True):
-                # Replace labels: drops pool=spare (so it leaves the pool) and records the binding.
-                # Done under the lock so a concurrent claim in this process can't take the same one.
-                try:
-                    await sandbox.set_labels({LABEL_FLEET: "1", LABEL_CLAIMED: browser_id})
-                except Exception as e:
-                    logger.warning(f"Failed to claim spare {sandbox.name}: {e}")
-                    continue
-                spare_id = _browser_id_from_name(sandbox.name)
-                break
+            async for candidate in self._iter_sandboxes(SPARE_LABELS, started_only=True):
+                if await self._try_claim(candidate.name, browser_id):
+                    spare_id = _browser_id_from_name(candidate.name)
+                    break
 
         if spare_id is None:
             logger.info(f"Pool empty; cold-creating incognito browser {browser_id}")
@@ -314,6 +308,32 @@ class DaytonaBackend:
         logger.info(f"Claimed pooled spare {spare_id} for incognito browser {browser_id}")
         self._spawn_reconcile()
         return spare_id
+
+    async def _try_claim(self, name: str, browser_id: str) -> bool:
+        """Claim one spare candidate, guarding against Daytona's eventually-consistent label list.
+
+        The list query can return a sandbox that was already claimed or deleted seconds ago, so re-GET
+        it (object reads are far more consistent than the label index): skip it unless it is still a
+        live, unclaimed spare. After claiming, re-read once more to confirm the label stuck (lost a
+        race otherwise). Returns True only when this caller now exclusively owns the sandbox.
+        """
+        fresh = await self._get(name)
+        if fresh is None or fresh.state != "started":
+            return False  # stale list entry — already deleted/stopped
+        labels = fresh.labels or {}
+        if labels.get(LABEL_POOL) != POOL_SPARE or LABEL_CLAIMED in labels:
+            return False  # stale list entry — already claimed by someone else
+        # Replace labels: drops pool=spare (leaves the pool) and records the binding.
+        try:
+            await fresh.set_labels({LABEL_FLEET: "1", LABEL_CLAIMED: browser_id})
+        except Exception as e:
+            logger.warning(f"Failed to claim spare {name}: {e}")
+            return False
+        confirmed = await self._get(name)
+        if confirmed is None or (confirmed.labels or {}).get(LABEL_CLAIMED) != browser_id:
+            logger.warning(f"Lost claim race for spare {name}; skipping")
+            return False
+        return True
 
     async def _reconcile_pool(self) -> None:
         """Backfill the pool to POOL_SIZE from Daytona's current spare count.

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -225,9 +225,6 @@ class DaytonaBackend:
     async def create_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]:
-        # Incognito requests claim a warm-pool spare when one is ready: the spare keeps its own
-        # sandbox name and the requested id -> spare binding is recorded in a Daytona label
-        # (resolved on every later lookup). Per-user ids and an empty pool fall through to cold-create.
         effective_id = await self._claim_spare_for(browser_id)
         lock = self._locks.setdefault(effective_id, asyncio.Lock())
         async with lock:

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -13,7 +13,11 @@ from daytona import (
 )
 from loguru import logger
 
-from getgather.browsers.backend import BROWSER_NAME_PREFIX, BrowserNotFound
+from getgather.browsers.backend import (
+    BROWSER_NAME_PREFIX,
+    BrowserNotFound,
+    mint_incognito_browser_id,
+)
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
 
@@ -53,6 +57,10 @@ SIGNED_URL_TTL_SECONDS = 3600
 LIVE_VIEW_MAX_IDLE_SECONDS = 3600
 
 LABEL_FLEET = "fleet"
+# A spare carries pool=spare; on claim the label is dropped so it reads as a normal browser and the
+# 15m auto-stop / 60m auto-delete teardown applies unchanged.
+LABEL_POOL = "pool"
+POOL_SPARE = "spare"
 
 
 def _sandbox_name(browser_id: str) -> str:
@@ -149,6 +157,18 @@ class DaytonaBackend:
         self.snapshot = snapshot
         self.client = AsyncDaytona(DaytonaConfig(api_key=api_key, api_url=api_url or None))
         self._locks: dict[str, asyncio.Lock] = {}
+        self._pool_size = settings.DAYTONA_INCOGNITO_POOL_SIZE
+        # In-memory set of ready spare browser_ids. Single-process pool: the lock makes claim
+        # atomic within this process; a multi-instance deployment would need a shared store.
+        self._spares: set[str] = set()
+        self._pool_lock = asyncio.Lock()
+
+    async def startup(self) -> None:
+        if self._pool_size <= 0:
+            return
+        # Adopt spares that survived a restart, then backfill — both in the background so server
+        # startup is never blocked on Daytona.
+        asyncio.create_task(self._reconcile_pool())
 
     async def shutdown(self) -> None:
         await self.client.close()
@@ -200,8 +220,83 @@ class DaytonaBackend:
 
     async def cleanup_idle(self) -> list[str]:
         # Teardown is owned by Daytona's native auto_stop_interval + auto_delete_interval (set in
-        # _create), so there is no reconcile sweep to run here.
+        # _create). The only periodic work is keeping the warm pool topped up (spares that Daytona
+        # auto-stopped after idle are dropped and respawned here).
+        if self._pool_size > 0:
+            await self._reconcile_pool()
         return []
+
+    async def acquire_incognito_browser(
+        self, origin_ip: str | None, target_domain: str | None
+    ) -> dict[str, Any]:
+        browser_id, sandbox = await self._claim_or_create()
+        # Drop the spare label so normal teardown applies; best-effort (claim already succeeded).
+        try:
+            await sandbox.set_labels({LABEL_FLEET: "1"})
+        except Exception as e:
+            logger.warning(f"Failed to clear pool label on {sandbox.name}: {e}")
+        # Proxy is applied at claim time (spares run proxy-free), so each incognito gets a fresh IP.
+        try:
+            await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+        except ProxyVerificationError as e:
+            logger.warning(str(e))
+        if self._pool_size > 0:
+            asyncio.create_task(self._reconcile_pool())
+        info = await self._get_info(sandbox)
+        info["browser_id"] = browser_id
+        return info
+
+    async def _claim_or_create(self) -> tuple[str, AsyncSandbox]:
+        """Pop a ready spare, or cold-create a fresh incognito sandbox if the pool is empty/stale."""
+        async with self._pool_lock:
+            while self._spares:
+                browser_id = self._spares.pop()
+                sandbox = await self._get(_sandbox_name(browser_id))
+                if sandbox is not None and sandbox.state == "started":
+                    logger.info(f"Claimed pooled incognito browser {browser_id}")
+                    return browser_id, sandbox
+                # Stale (auto-stopped or reaped); discard and try the next spare.
+                logger.info(f"Discarding stale spare {browser_id} (state unavailable)")
+        browser_id = mint_incognito_browser_id()
+        logger.info(f"Pool empty; cold-creating incognito browser {browser_id}")
+        sandbox = await self._ensure(browser_id)
+        return browser_id, sandbox
+
+    async def _reconcile_pool(self) -> None:
+        """Sync the in-memory spare set with Daytona, then backfill to POOL_SIZE.
+
+        Idempotent and safe to call repeatedly. Serialized under the pool lock so concurrent
+        callers (startup, periodic sweep, post-claim backfill) don't over-provision.
+        """
+        async with self._pool_lock:
+            live: set[str] = set()
+            async for sandbox in self.client.list(
+                ListSandboxesQuery(labels={LABEL_FLEET: "1", LABEL_POOL: POOL_SPARE})
+            ):
+                if (
+                    sandbox.name
+                    and sandbox.name.startswith(BROWSER_NAME_PREFIX)
+                    and sandbox.state == "started"
+                ):
+                    live.add(_browser_id_from_name(sandbox.name))
+            self._spares = live
+            deficit = self._pool_size - len(self._spares)
+
+        for _ in range(max(0, deficit)):
+            try:
+                browser_id = await self._spawn_spare()
+            except Exception as e:
+                logger.warning(f"Failed to spawn pool spare: {type(e).__name__}: {e}")
+                break
+            async with self._pool_lock:
+                self._spares.add(browser_id)
+
+    async def _spawn_spare(self) -> str:
+        browser_id = mint_incognito_browser_id()
+        name = _sandbox_name(browser_id)
+        logger.info(f"Spawning pool spare {name}")
+        await self._create(name, labels={LABEL_FLEET: "1", LABEL_POOL: POOL_SPARE})
+        return browser_id
 
     async def get_cdp_base_url(self, browser_id: str) -> str:
         sandbox = await self._get(_sandbox_name(browser_id))
@@ -305,11 +400,11 @@ class DaytonaBackend:
         except DaytonaNotFoundError:
             return None
 
-    async def _create(self, name: str) -> AsyncSandbox:
+    async def _create(self, name: str, labels: dict[str, str] | None = None) -> AsyncSandbox:
         params = CreateSandboxFromSnapshotParams(
             snapshot=self.snapshot,
             name=name,
-            labels={LABEL_FLEET: "1"},
+            labels=labels or {LABEL_FLEET: "1"},
             public=False,
             auto_stop_interval=AUTO_STOP_MINUTES,
             # delete after TTL_MINUTES continuously stopped; Daytona owns teardown

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -58,10 +58,14 @@ SIGNED_URL_TTL_SECONDS = 3600
 LIVE_VIEW_MAX_IDLE_SECONDS = 3600
 
 LABEL_FLEET = "fleet"
-# A spare carries pool=spare; on claim the label is dropped so it reads as a normal browser and the
-# 15m auto-stop / 60m auto-delete teardown applies unchanged.
+# A spare carries pool=spare. On claim the labels are replaced with claimed_as=<requested id>, which
+# (a) removes it from the spare list and (b) records the requested incognito id -> this sandbox
+# binding IN Daytona, so resolution is stateless: no in-memory map, survives restarts. The requested
+# id is unique per request, so the binding is unambiguous. Teardown (15m auto-stop / 60m auto-delete)
+# applies unchanged once it is no longer a spare.
 LABEL_POOL = "pool"
 POOL_SPARE = "spare"
+LABEL_CLAIMED = "claimed_as"
 
 
 def _sandbox_name(browser_id: str) -> str:
@@ -159,17 +163,30 @@ class DaytonaBackend:
         self.client = AsyncDaytona(DaytonaConfig(api_key=api_key, api_url=api_url or None))
         self._locks: dict[str, asyncio.Lock] = {}
         self._pool_size = settings.DAYTONA_INCOGNITO_POOL_SIZE
-        # In-memory set of ready spare browser_ids. Single-process pool: the lock makes claim
-        # atomic within this process; a multi-instance deployment would need a shared store.
-        self._spares: set[str] = set()
+        # Pool inventory and the claimed-id binding both live in Daytona labels (see LABEL_CLAIMED),
+        # so the backend holds no durable state and survives restarts. This lock only serializes the
+        # claim within one process; cross-instance claim races are possible (last writer wins) and
+        # self-heal — a future deployment that needs hard cross-instance safety would add a CAS store.
         self._pool_lock = asyncio.Lock()
-        # Maps a requested incognito browser_id -> the claimed spare's real browser_id. A spare
-        # keeps its own (immutable) sandbox name, so every lookup resolves through this map. In
-        # memory only: a future multi-instance deployment would move it to a shared store.
-        self._id_map: dict[str, str] = {}
+        # Separate from _pool_lock so a slow backfill (each spawn cold-boots a sandbox, ~9s) never
+        # blocks a claim. Just collapses concurrent reconcile calls into one.
+        self._reconcile_lock = asyncio.Lock()
 
-    def _effective_id(self, browser_id: str) -> str:
-        return self._id_map.get(browser_id, browser_id)
+    async def _resolve(self, browser_id: str) -> str:
+        """Resolve a requested browser_id to the real sandbox id backing it.
+
+        Incognito ids may have claimed a pool spare whose sandbox keeps its own (immutable) name; the
+        binding is recorded as a claimed_as=<browser_id> label. Per-user ids, unclaimed ids, and
+        cold-created incognito ids resolve to themselves. One Daytona lookup for incognito, none else.
+        """
+        if self._pool_size <= 0 or not browser_id.startswith(INCOGNITO_PREFIX):
+            return browser_id
+        async for sandbox in self.client.list(
+            ListSandboxesQuery(labels={LABEL_CLAIMED: browser_id})
+        ):
+            if sandbox.name and sandbox.name.startswith(BROWSER_NAME_PREFIX):
+                return _browser_id_from_name(sandbox.name)
+        return browser_id
 
     async def startup(self) -> None:
         if self._pool_size <= 0:
@@ -185,8 +202,8 @@ class DaytonaBackend:
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]:
         # Incognito requests claim a warm-pool spare when one is ready: the spare keeps its own
-        # sandbox name and we map the requested id -> the spare's id (resolved on every later
-        # lookup). Non-incognito (per-user) ids and an empty pool fall through to cold-create.
+        # sandbox name and the requested id -> spare binding is recorded in a Daytona label
+        # (resolved on every later lookup). Per-user ids and an empty pool fall through to cold-create.
         effective_id = await self._claim_spare_for(browser_id)
         lock = self._locks.setdefault(effective_id, asyncio.Lock())
         async with lock:
@@ -200,7 +217,7 @@ class DaytonaBackend:
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]:
-        effective_id = self._effective_id(browser_id)
+        effective_id = await self._resolve(browser_id)
         sandbox = await self._get(_sandbox_name(effective_id))
         if sandbox is None:
             raise BrowserNotFound(browser_id)
@@ -212,17 +229,17 @@ class DaytonaBackend:
         return await self._get_info(sandbox)
 
     async def delete_browser(self, browser_id: str) -> dict[str, Any]:
-        effective_id = self._effective_id(browser_id)
+        effective_id = await self._resolve(browser_id)
         sandbox = await self._get(_sandbox_name(effective_id))
         self._locks.pop(effective_id, None)
-        self._id_map.pop(browser_id, None)
         if sandbox is None:
             return {"status": "not found"}
+        # Deleting the sandbox also removes its claimed_as label, so no binding is left behind.
         await sandbox.delete()
         return {"status": "deleted"}
 
     async def browser_exists(self, browser_id: str) -> bool:
-        return await self._get(_sandbox_name(self._effective_id(browser_id))) is not None
+        return await self._get(_sandbox_name(await self._resolve(browser_id))) is not None
 
     async def list_browser_ids(self) -> list[str]:
         browser_ids: list[str] = []
@@ -241,50 +258,51 @@ class DaytonaBackend:
         return []
 
     async def _claim_spare_for(self, browser_id: str) -> str:
-        """For an incognito request, claim a ready spare and map browser_id -> the spare's id.
+        """For an incognito request, claim a ready spare and record the binding in a Daytona label.
 
         Returns the spare's id when one was claimed, else the original browser_id (cold-create
         path). Only incognito ids are eligible; per-user ids always cold-create under their own
-        deterministic name.
+        deterministic name. The lock serializes claims within this process.
         """
         if self._pool_size <= 0 or not browser_id.startswith(INCOGNITO_PREFIX):
             return browser_id
 
         spare_id: str | None = None
         async with self._pool_lock:
-            while self._spares:
-                candidate = self._spares.pop()
-                sandbox = await self._get(_sandbox_name(candidate))
-                if sandbox is not None and sandbox.state == "started":
-                    spare_id = candidate
-                    break
-                logger.info(f"Discarding stale spare {candidate} (state unavailable)")
+            async for sandbox in self.client.list(
+                ListSandboxesQuery(labels={LABEL_FLEET: "1", LABEL_POOL: POOL_SPARE})
+            ):
+                if not (sandbox.name and sandbox.name.startswith(BROWSER_NAME_PREFIX)):
+                    continue
+                if sandbox.state != "started":
+                    continue  # auto-stopped/stale; the reconcile sweep will replace it
+                # Replace labels: drops pool=spare (so it leaves the pool) and records the binding.
+                # Done under the lock so a concurrent claim in this process can't take the same one.
+                try:
+                    await sandbox.set_labels({LABEL_FLEET: "1", LABEL_CLAIMED: browser_id})
+                except Exception as e:
+                    logger.warning(f"Failed to claim spare {sandbox.name}: {e}")
+                    continue
+                spare_id = _browser_id_from_name(sandbox.name)
+                break
 
         if spare_id is None:
             logger.info(f"Pool empty; cold-creating incognito browser {browser_id}")
             return browser_id
 
-        # Drop the spare label so normal teardown applies; best-effort (claim already succeeded).
-        try:
-            spare = await self._get(_sandbox_name(spare_id))
-            if spare is not None:
-                await spare.set_labels({LABEL_FLEET: "1"})
-        except Exception as e:
-            logger.warning(f"Failed to clear pool label on {spare_id}: {e}")
-
-        self._id_map[browser_id] = spare_id
         logger.info(f"Claimed pooled spare {spare_id} for incognito browser {browser_id}")
         asyncio.create_task(self._reconcile_pool())
         return spare_id
 
     async def _reconcile_pool(self) -> None:
-        """Sync the in-memory spare set with Daytona, then backfill to POOL_SIZE.
+        """Backfill the pool to POOL_SIZE from Daytona's current spare count.
 
-        Idempotent and safe to call repeatedly. Serialized under the pool lock so concurrent
-        callers (startup, periodic sweep, post-claim backfill) don't over-provision.
+        Stateless: the spare count is read from Daytona labels, not memory. Idempotent and safe to
+        call repeatedly; serialized under its own lock (not the claim lock) so the slow spawns never
+        block a claim, while concurrent reconcile calls collapse into one.
         """
-        async with self._pool_lock:
-            live: set[str] = set()
+        async with self._reconcile_lock:
+            spare_count = 0
             async for sandbox in self.client.list(
                 ListSandboxesQuery(labels={LABEL_FLEET: "1", LABEL_POOL: POOL_SPARE})
             ):
@@ -293,18 +311,15 @@ class DaytonaBackend:
                     and sandbox.name.startswith(BROWSER_NAME_PREFIX)
                     and sandbox.state == "started"
                 ):
-                    live.add(_browser_id_from_name(sandbox.name))
-            self._spares = live
-            deficit = self._pool_size - len(self._spares)
+                    spare_count += 1
+            deficit = self._pool_size - spare_count
 
-        for _ in range(max(0, deficit)):
-            try:
-                browser_id = await self._spawn_spare()
-            except Exception as e:
-                logger.warning(f"Failed to spawn pool spare: {type(e).__name__}: {e}")
-                break
-            async with self._pool_lock:
-                self._spares.add(browser_id)
+            for _ in range(max(0, deficit)):
+                try:
+                    await self._spawn_spare()
+                except Exception as e:
+                    logger.warning(f"Failed to spawn pool spare: {type(e).__name__}: {e}")
+                    break
 
     async def _spawn_spare(self) -> str:
         browser_id = mint_incognito_browser_id()
@@ -314,7 +329,7 @@ class DaytonaBackend:
         return browser_id
 
     async def get_cdp_base_url(self, browser_id: str) -> str:
-        sandbox = await self._get(_sandbox_name(self._effective_id(browser_id)))
+        sandbox = await self._get(_sandbox_name(await self._resolve(browser_id)))
         if sandbox is None:
             raise BrowserNotFound(browser_id)
         signed = await sandbox.create_signed_preview_url(
@@ -331,7 +346,7 @@ class DaytonaBackend:
         return None  # no raw VNC port; live view uses get_live_view_url (noVNC on VNC_PORT)
 
     async def get_live_view_url(self, browser_id: str) -> str | None:
-        sandbox = await self._get(_sandbox_name(self._effective_id(browser_id)))
+        sandbox = await self._get(_sandbox_name(await self._resolve(browser_id)))
         if sandbox is None:
             raise BrowserNotFound(browser_id)
         if sandbox.state != "started":

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -15,6 +15,7 @@ from loguru import logger
 
 from getgather.browsers.backend import (
     BROWSER_NAME_PREFIX,
+    INCOGNITO_PREFIX,
     BrowserNotFound,
     mint_incognito_browser_id,
 )
@@ -162,6 +163,13 @@ class DaytonaBackend:
         # atomic within this process; a multi-instance deployment would need a shared store.
         self._spares: set[str] = set()
         self._pool_lock = asyncio.Lock()
+        # Maps a requested incognito browser_id -> the claimed spare's real browser_id. A spare
+        # keeps its own (immutable) sandbox name, so every lookup resolves through this map. In
+        # memory only: a future multi-instance deployment would move it to a shared store.
+        self._id_map: dict[str, str] = {}
+
+    def _effective_id(self, browser_id: str) -> str:
+        return self._id_map.get(browser_id, browser_id)
 
     async def startup(self) -> None:
         if self._pool_size <= 0:
@@ -176,11 +184,15 @@ class DaytonaBackend:
     async def create_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]:
-        lock = self._locks.setdefault(browser_id, asyncio.Lock())
+        # Incognito requests claim a warm-pool spare when one is ready: the spare keeps its own
+        # sandbox name and we map the requested id -> the spare's id (resolved on every later
+        # lookup). Non-incognito (per-user) ids and an empty pool fall through to cold-create.
+        effective_id = await self._claim_spare_for(browser_id)
+        lock = self._locks.setdefault(effective_id, asyncio.Lock())
         async with lock:
-            sandbox = await self._ensure(browser_id)
+            sandbox = await self._ensure(effective_id)
             try:
-                await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+                await _configure_remote_sandbox(sandbox, effective_id, origin_ip, target_domain)
             except ProxyVerificationError as e:
                 logger.warning(str(e))
             return await self._get_info(sandbox)
@@ -188,27 +200,29 @@ class DaytonaBackend:
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]:
-        sandbox = await self._get(_sandbox_name(browser_id))
+        effective_id = self._effective_id(browser_id)
+        sandbox = await self._get(_sandbox_name(effective_id))
         if sandbox is None:
             raise BrowserNotFound(browser_id)
         if origin_ip:
             try:
-                await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+                await _configure_remote_sandbox(sandbox, effective_id, origin_ip, target_domain)
             except ProxyVerificationError as e:
                 logger.warning(str(e))
         return await self._get_info(sandbox)
 
     async def delete_browser(self, browser_id: str) -> dict[str, Any]:
-        name = _sandbox_name(browser_id)
-        sandbox = await self._get(name)
-        self._locks.pop(browser_id, None)
+        effective_id = self._effective_id(browser_id)
+        sandbox = await self._get(_sandbox_name(effective_id))
+        self._locks.pop(effective_id, None)
+        self._id_map.pop(browser_id, None)
         if sandbox is None:
             return {"status": "not found"}
         await sandbox.delete()
         return {"status": "deleted"}
 
     async def browser_exists(self, browser_id: str) -> bool:
-        return await self._get(_sandbox_name(browser_id)) is not None
+        return await self._get(_sandbox_name(self._effective_id(browser_id))) is not None
 
     async def list_browser_ids(self) -> list[str]:
         browser_ids: list[str] = []
@@ -226,41 +240,42 @@ class DaytonaBackend:
             await self._reconcile_pool()
         return []
 
-    async def acquire_incognito_browser(
-        self, origin_ip: str | None, target_domain: str | None
-    ) -> dict[str, Any]:
-        browser_id, sandbox = await self._claim_or_create()
-        # Drop the spare label so normal teardown applies; best-effort (claim already succeeded).
-        try:
-            await sandbox.set_labels({LABEL_FLEET: "1"})
-        except Exception as e:
-            logger.warning(f"Failed to clear pool label on {sandbox.name}: {e}")
-        # Proxy is applied at claim time (spares run proxy-free), so each incognito gets a fresh IP.
-        try:
-            await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
-        except ProxyVerificationError as e:
-            logger.warning(str(e))
-        if self._pool_size > 0:
-            asyncio.create_task(self._reconcile_pool())
-        info = await self._get_info(sandbox)
-        info["browser_id"] = browser_id
-        return info
+    async def _claim_spare_for(self, browser_id: str) -> str:
+        """For an incognito request, claim a ready spare and map browser_id -> the spare's id.
 
-    async def _claim_or_create(self) -> tuple[str, AsyncSandbox]:
-        """Pop a ready spare, or cold-create a fresh incognito sandbox if the pool is empty/stale."""
+        Returns the spare's id when one was claimed, else the original browser_id (cold-create
+        path). Only incognito ids are eligible; per-user ids always cold-create under their own
+        deterministic name.
+        """
+        if self._pool_size <= 0 or not browser_id.startswith(INCOGNITO_PREFIX):
+            return browser_id
+
+        spare_id: str | None = None
         async with self._pool_lock:
             while self._spares:
-                browser_id = self._spares.pop()
-                sandbox = await self._get(_sandbox_name(browser_id))
+                candidate = self._spares.pop()
+                sandbox = await self._get(_sandbox_name(candidate))
                 if sandbox is not None and sandbox.state == "started":
-                    logger.info(f"Claimed pooled incognito browser {browser_id}")
-                    return browser_id, sandbox
-                # Stale (auto-stopped or reaped); discard and try the next spare.
-                logger.info(f"Discarding stale spare {browser_id} (state unavailable)")
-        browser_id = mint_incognito_browser_id()
-        logger.info(f"Pool empty; cold-creating incognito browser {browser_id}")
-        sandbox = await self._ensure(browser_id)
-        return browser_id, sandbox
+                    spare_id = candidate
+                    break
+                logger.info(f"Discarding stale spare {candidate} (state unavailable)")
+
+        if spare_id is None:
+            logger.info(f"Pool empty; cold-creating incognito browser {browser_id}")
+            return browser_id
+
+        # Drop the spare label so normal teardown applies; best-effort (claim already succeeded).
+        try:
+            spare = await self._get(_sandbox_name(spare_id))
+            if spare is not None:
+                await spare.set_labels({LABEL_FLEET: "1"})
+        except Exception as e:
+            logger.warning(f"Failed to clear pool label on {spare_id}: {e}")
+
+        self._id_map[browser_id] = spare_id
+        logger.info(f"Claimed pooled spare {spare_id} for incognito browser {browser_id}")
+        asyncio.create_task(self._reconcile_pool())
+        return spare_id
 
     async def _reconcile_pool(self) -> None:
         """Sync the in-memory spare set with Daytona, then backfill to POOL_SIZE.
@@ -299,7 +314,7 @@ class DaytonaBackend:
         return browser_id
 
     async def get_cdp_base_url(self, browser_id: str) -> str:
-        sandbox = await self._get(_sandbox_name(browser_id))
+        sandbox = await self._get(_sandbox_name(self._effective_id(browser_id)))
         if sandbox is None:
             raise BrowserNotFound(browser_id)
         signed = await sandbox.create_signed_preview_url(
@@ -316,7 +331,7 @@ class DaytonaBackend:
         return None  # no raw VNC port; live view uses get_live_view_url (noVNC on VNC_PORT)
 
     async def get_live_view_url(self, browser_id: str) -> str | None:
-        sandbox = await self._get(_sandbox_name(browser_id))
+        sandbox = await self._get(_sandbox_name(self._effective_id(browser_id)))
         if sandbox is None:
             raise BrowserNotFound(browser_id)
         if sandbox.state != "started":

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -131,14 +131,21 @@ async def _get_sandbox_public_ip(
 
 async def _apply_and_verify_proxy(sandbox: AsyncSandbox, proxy_url: str) -> None:
     """Point tinyproxy at the upstream and verify the egress IP actually changed."""
+    _t0 = time.monotonic()  # [TIMING] temporary
     ip_before = await _get_sandbox_public_ip(sandbox)
+    _t_before = time.monotonic()  # [TIMING] temporary
     logger.debug(f"Sandbox {sandbox.name} IP before proxy: {ip_before}")
 
     ok = await _configure_sandbox_proxy(sandbox, proxy_url)
+    _t_cfg = time.monotonic()  # [TIMING] temporary
     if not ok:
         return
 
     ip_after = await _get_sandbox_public_ip(sandbox)
+    logger.info(  # [TIMING] temporary
+        f"[TIMING] proxy {sandbox.name}: ip_before={_t_before - _t0:.1f}s "
+        f"configure={_t_cfg - _t_before:.1f}s ip_after={time.monotonic() - _t_cfg:.1f}s"
+    )
     if ip_before and ip_after and ip_before != ip_after:
         logger.info(f"Sandbox {sandbox.name} IP changed: {ip_before} -> {ip_after}")
     elif ip_before == ip_after:
@@ -229,8 +236,15 @@ class DaytonaBackend:
             and labels.get(LABEL_PROXY_TYPE) == desired_type
             and labels.get(LABEL_PROXY_CC) == desired_cc
         ):
+            logger.info(  # [TIMING] temporary
+                f"[TIMING] proxy SKIP {sandbox.name}: pre-applied {desired_type}/{desired_cc} reused"
+            )
             return  # pre-applied proxy already matches this request
 
+        logger.info(  # [TIMING] temporary
+            f"[TIMING] proxy RECONFIGURE {sandbox.name}: want {desired_type}/{desired_cc}, "
+            f"had {labels.get(LABEL_PROXY_TYPE)}/{labels.get(LABEL_PROXY_CC)}"
+        )
         try:
             await _apply_and_verify_proxy(sandbox, proxy_config.get_proxy_url(browser_id))
         except ProxyVerificationError as e:
@@ -275,12 +289,22 @@ class DaytonaBackend:
     async def create_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]:
+        t0 = time.monotonic()  # [TIMING] temporary
         effective_id = await self._claim_spare_for(browser_id)
+        t_claim = time.monotonic()  # [TIMING] temporary
         lock = self._locks.setdefault(effective_id, asyncio.Lock())
         async with lock:
             sandbox = await self._ensure(effective_id)
+            t_ensure = time.monotonic()  # [TIMING] temporary
             await self._ensure_proxy(sandbox, effective_id, origin_ip, target_domain)
-            return await self._get_info(sandbox)
+            t_proxy = time.monotonic()  # [TIMING] temporary
+            info = await self._get_info(sandbox)
+            logger.info(  # [TIMING] temporary
+                f"[TIMING] create_browser {browser_id}: claim={t_claim - t0:.1f}s "
+                f"ensure={t_ensure - t_claim:.1f}s proxy={t_proxy - t_ensure:.1f}s "
+                f"info={time.monotonic() - t_proxy:.1f}s total={time.monotonic() - t0:.1f}s"
+            )
+            return info
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
@@ -332,7 +356,12 @@ class DaytonaBackend:
 
         # Shuffle so concurrent claimers don't all target the same spare first (each collision costs
         # a wasted set_labels + retry). Claims run unserialized; _try_claim confirms exclusive ownership.
+        _t_list0 = time.monotonic()  # [TIMING] temporary
         candidates = [sb async for sb in self._iter_sandboxes(SPARE_LABELS, started_only=True)]
+        logger.info(  # [TIMING] temporary
+            f"[TIMING] _claim_spare_for {browser_id}: list_spares={time.monotonic() - _t_list0:.1f}s "
+            f"({len(candidates)} candidates)"
+        )
         random.shuffle(candidates)
         for sb in candidates:
             if sb.name and await self._try_claim(sb.name, browser_id):
@@ -352,7 +381,9 @@ class DaytonaBackend:
         live, unclaimed spare. After claiming, re-read once more to confirm the label stuck (lost a
         race otherwise). Returns True only when this caller now exclusively owns the sandbox.
         """
+        _t0 = time.monotonic()  # [TIMING] temporary
         fresh = await self._get(name)
+        _t_get = time.monotonic()  # [TIMING] temporary
         if fresh is None or fresh.state != "started":
             return False  # stale list entry — already deleted/stopped
         labels = fresh.labels or {}
@@ -368,7 +399,12 @@ class DaytonaBackend:
         except Exception as e:
             logger.warning(f"Failed to claim spare {name}: {e}")
             return False
+        _t_set = time.monotonic()  # [TIMING] temporary
         confirmed = await self._get(name)
+        logger.info(  # [TIMING] temporary
+            f"[TIMING] _try_claim {name}: get={_t_get - _t0:.1f}s "
+            f"set_labels={_t_set - _t_get:.1f}s confirm={time.monotonic() - _t_set:.1f}s"
+        )
         if confirmed is None or (confirmed.labels or {}).get(LABEL_CLAIMED) != browser_id:
             logger.warning(f"Lost claim race for spare {name}; skipping")
             return False
@@ -455,25 +491,43 @@ class DaytonaBackend:
 
     async def _ensure(self, browser_id: str) -> AsyncSandbox:
         name = _sandbox_name(browser_id)
+        _t0 = time.monotonic()  # [TIMING] temporary
         sandbox = await self._get(name)
+        _t_get = time.monotonic()  # [TIMING] temporary
+        created = False  # [TIMING] temporary
         if sandbox is None:
             sandbox = await self._create(name)
+            created = True  # [TIMING] temporary
+        _t_create = time.monotonic()  # [TIMING] temporary
 
+        started = False  # [TIMING] temporary
         if sandbox.state != "started":
             logger.info(f"Starting Daytona sandbox {name} (state={sandbox.state})")
             await sandbox.start()
-
+            started = True  # [TIMING] temporary
+        logger.info(  # [TIMING] temporary
+            f"[TIMING] _ensure {name}: get={_t_get - _t0:.1f}s "
+            f"create={_t_create - _t_get:.1f}s(did={created}) "
+            f"start={time.monotonic() - _t_create:.1f}s(did={started})"
+        )
         return sandbox
 
     async def _get_info(self, sandbox: AsyncSandbox) -> dict[str, Any]:
+        _t0 = time.monotonic()  # [TIMING] temporary
         signed = await sandbox.create_signed_preview_url(
             CDP_PORT, expires_in_seconds=SIGNED_URL_TTL_SECONDS
+        )
+        _t_signed = time.monotonic()  # [TIMING] temporary
+        last_activity = await self._get_last_activity(sandbox)
+        logger.info(  # [TIMING] temporary
+            f"[TIMING] _get_info {sandbox.name}: signed_url={_t_signed - _t0:.1f}s "
+            f"last_activity={time.monotonic() - _t_signed:.1f}s"
         )
         return {
             "hostname": sandbox.name,
             "cdp_url": signed.url,  # public, internet-reachable; bearer secret (see SIGNED_URL_TTL_SECONDS)
             "app_state": sandbox.state,
-            "last_activity_timestamp": await self._get_last_activity(sandbox),
+            "last_activity_timestamp": last_activity,
         }
 
     async def _get_last_activity(self, sandbox: AsyncSandbox) -> float | None:

--- a/getgather/browsers/fleet_browsers.py
+++ b/getgather/browsers/fleet_browsers.py
@@ -31,7 +31,6 @@ async def call_chromefleet_api(
     method: HTTP_METHOD,
     browser_id: str | None = None,
     *,
-    path: str | None = None,
     target_domain: str | None = None,
     timeout: float = 120.0,
     retries: int = 3,
@@ -39,8 +38,7 @@ async def call_chromefleet_api(
     headers: dict[str, str] | None = None,
 ) -> httpx.Response | None:
     base_url = settings.effective_chromefleet_url.rstrip("/")
-    if path is None:
-        path = f"/api/v1/browsers/{browser_id}" if browser_id else "/api/v1/browsers"
+    path = f"/api/v1/browsers/{browser_id}" if browser_id else "/api/v1/browsers"
     url = f"{base_url}{path}"
 
     if headers is None:
@@ -102,17 +100,6 @@ class FleetBackend:
     ) -> dict[str, Any]:
         headers = {"x-origin-ip": origin_ip} if origin_ip else {}
         response = _require(await call_chromefleet_api("POST", browser_id, headers=headers))
-        return response.json()
-
-    async def acquire_incognito_browser(
-        self, origin_ip: str | None, target_domain: str | None
-    ) -> dict[str, Any]:
-        headers = {"x-origin-ip": origin_ip} if origin_ip else {}
-        if target_domain:
-            headers["x-target-domains"] = target_domain
-        response = _require(
-            await call_chromefleet_api("POST", path="/api/v1/browsers-incognito", headers=headers)
-        )
         return response.json()
 
     async def shutdown(self) -> None:

--- a/getgather/browsers/fleet_browsers.py
+++ b/getgather/browsers/fleet_browsers.py
@@ -31,6 +31,7 @@ async def call_chromefleet_api(
     method: HTTP_METHOD,
     browser_id: str | None = None,
     *,
+    path: str | None = None,
     target_domain: str | None = None,
     timeout: float = 120.0,
     retries: int = 3,
@@ -38,7 +39,8 @@ async def call_chromefleet_api(
     headers: dict[str, str] | None = None,
 ) -> httpx.Response | None:
     base_url = settings.effective_chromefleet_url.rstrip("/")
-    path = f"/api/v1/browsers/{browser_id}" if browser_id else "/api/v1/browsers"
+    if path is None:
+        path = f"/api/v1/browsers/{browser_id}" if browser_id else "/api/v1/browsers"
     url = f"{base_url}{path}"
 
     if headers is None:
@@ -92,7 +94,7 @@ class FleetBackend:
     relay does not patch again. VNC is not proxied here either (`get_vnc_endpoint` returns None).
     """
 
-    async def shutdown(self) -> None:
+    async def startup(self) -> None:
         return None
 
     async def create_browser(
@@ -101,6 +103,20 @@ class FleetBackend:
         headers = {"x-origin-ip": origin_ip} if origin_ip else {}
         response = _require(await call_chromefleet_api("POST", browser_id, headers=headers))
         return response.json()
+
+    async def acquire_incognito_browser(
+        self, origin_ip: str | None, target_domain: str | None
+    ) -> dict[str, Any]:
+        headers = {"x-origin-ip": origin_ip} if origin_ip else {}
+        if target_domain:
+            headers["x-target-domains"] = target_domain
+        response = _require(
+            await call_chromefleet_api("POST", path="/api/v1/browsers-incognito", headers=headers)
+        )
+        return response.json()
+
+    async def shutdown(self) -> None:
+        return None
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None

--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -8,11 +8,7 @@ from typing import Any
 
 from loguru import logger
 
-from getgather.browsers.backend import (
-    BROWSER_NAME_PREFIX,
-    BrowserNotFound,
-    mint_incognito_browser_id,
-)
+from getgather.browsers.backend import BROWSER_NAME_PREFIX, BrowserNotFound
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
 
@@ -305,15 +301,6 @@ class PodmanBackend:
         await launch_container(settings.CONTAINER_IMAGE, container_name)
         ip = await configure_remote_browser(browser_id, container_name, origin_ip, target_domain)
         return {"container_name": container_name, "status": "created", "ip": ip}
-
-    async def acquire_incognito_browser(
-        self, origin_ip: str | None, target_domain: str | None
-    ) -> dict[str, Any]:
-        # No pool locally: mint an ephemeral id and cold-create, matching the prior dpage behavior.
-        browser_id = mint_incognito_browser_id()
-        info = await self.create_browser(browser_id, origin_ip, target_domain)
-        info["browser_id"] = browser_id
-        return info
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None

--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -8,7 +8,11 @@ from typing import Any
 
 from loguru import logger
 
-from getgather.browsers.backend import BROWSER_NAME_PREFIX, BrowserNotFound
+from getgather.browsers.backend import (
+    BROWSER_NAME_PREFIX,
+    BrowserNotFound,
+    mint_incognito_browser_id,
+)
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
 
@@ -288,6 +292,9 @@ async def get_cdp_url(browser_id: str) -> str:
 
 
 class PodmanBackend:
+    async def startup(self) -> None:
+        return None
+
     async def shutdown(self) -> None:
         return None
 
@@ -298,6 +305,15 @@ class PodmanBackend:
         await launch_container(settings.CONTAINER_IMAGE, container_name)
         ip = await configure_remote_browser(browser_id, container_name, origin_ip, target_domain)
         return {"container_name": container_name, "status": "created", "ip": ip}
+
+    async def acquire_incognito_browser(
+        self, origin_ip: str | None, target_domain: str | None
+    ) -> dict[str, Any]:
+        # No pool locally: mint an ephemeral id and cold-create, matching the prior dpage behavior.
+        browser_id = mint_incognito_browser_id()
+        info = await self.create_browser(browser_id, origin_ip, target_domain)
+        info["browser_id"] = browser_id
+        return info
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None

--- a/getgather/browsers/residential_proxy.py
+++ b/getgather/browsers/residential_proxy.py
@@ -124,6 +124,33 @@ class MassiveProxyConfig:
         )
 
 
+DEFAULT_PROXY_COUNTRY = "us"
+
+
+def default_proxy_config(
+    settings: "BrowserSettings",
+) -> "OxylabsProxyConfig | MassiveProxyConfig | None":
+    """Proxy for a request whose target/origin isn't known yet (e.g. pre-warming a pool spare).
+
+    Uses DEFAULT_PROXY_TYPE + a default country, with no MaxMind lookup. A claim that resolves to the
+    same (provider, country) can reuse it as-is; anything else reconfigures.
+    """
+    location = GeoLocation(country=DEFAULT_PROXY_COUNTRY)
+    if settings.DEFAULT_PROXY_TYPE == "oxylabs" and settings.OXYLABS_PROXY_ENABLED:
+        return OxylabsProxyConfig(location, settings.OXYLABS_USERNAME, settings.OXYLABS_PASSWORD)
+    if settings.DEFAULT_PROXY_TYPE == "massive" and settings.MASSIVE_PROXY_ENABLED:
+        return MassiveProxyConfig(
+            location, settings.MASSIVE_PROXY_USERNAME, settings.MASSIVE_PROXY_PASSWORD
+        )
+    if settings.OXYLABS_PROXY_ENABLED:
+        return OxylabsProxyConfig(location, settings.OXYLABS_USERNAME, settings.OXYLABS_PASSWORD)
+    if settings.MASSIVE_PROXY_ENABLED:
+        return MassiveProxyConfig(
+            location, settings.MASSIVE_PROXY_USERNAME, settings.MASSIVE_PROXY_PASSWORD
+        )
+    return None
+
+
 def get_proxy_type_for_target_domain(
     target_domain: str | None,
 ) -> Literal["oxylabs", "massive"] | None:

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -211,6 +211,20 @@ async def websocket_proxy(
             await client_ws.close(code=4500, reason="Internal proxy error")
 
 
+@router.post("/api/v1/browsers-incognito")
+async def acquire_incognito_browser(request: Request) -> dict[str, Any]:
+    origin_ip = request.headers.get("x-origin-ip")
+    target_domain = request.headers.get("x-target-domains")
+    try:
+        result = await backend.acquire_incognito_browser(origin_ip, target_domain)
+        logger.info(f"Acquired incognito browser {result.get('browser_id')}")
+        return result
+    except Exception as e:
+        detail = "Unable to acquire incognito browser!"
+        logger.error(f"{detail} Exception={e}")
+        raise HTTPException(status_code=500, detail=detail)
+
+
 @router.post("/api/v1/browsers/{browser_id}")
 async def create_browser(browser_id: str, request: Request) -> dict[str, Any]:
     logger.info(f"Starting browser {browser_id}...")

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -405,10 +405,15 @@ async def navigate_page(
 async def cdp_browser_websocket_proxy(client_ws: WebSocket, browser_id: str) -> None:
     logger.debug(f"[CDP] Entered cdp_browser_websocket_proxy for browser_id={browser_id}")
 
+    import time as _t  # [TIMING] temporary
+
+    t0 = _t.monotonic()  # [TIMING] temporary
     await client_ws.accept()
     logger.debug("[CDP] WebSocket accepted")
 
-    if not await backend.browser_exists(browser_id):
+    exists = await backend.browser_exists(browser_id)
+    t_exists = _t.monotonic()  # [TIMING] temporary
+    if not exists:
         logger.info(f"[CDP] Browser {browser_id} not found — launching")
         try:
             origin_ip = client_ws.headers.get("x-origin-ip")
@@ -419,6 +424,11 @@ async def cdp_browser_websocket_proxy(client_ws: WebSocket, browser_id: str) -> 
             logger.error(f"[CDP] Failed to auto-start browser {browser_id}: {e}")
             await client_ws.close(code=1008)
             return
+    t_create = _t.monotonic()  # [TIMING] temporary
+    logger.info(
+        f"[TIMING] /cdp/{browser_id}: exists_check={t_exists - t0:.1f}s "
+        f"create={t_create - t_exists:.1f}s (existed={exists})"
+    )
 
     cdp_base = backend.cdp_websocket_base()
     if cdp_base is not None:
@@ -434,6 +444,10 @@ async def cdp_browser_websocket_proxy(client_ws: WebSocket, browser_id: str) -> 
     for attempt in range(10):
         try:
             remote_url = await get_cdp_websocket_url(browser_id)
+            logger.info(
+                f"[TIMING] /cdp/{browser_id}: got_remote_url={_t.monotonic() - t_create:.1f}s "
+                f"after create (attempt {attempt + 1})"
+            )
             logger.info(f"[CDP] Got remote URL: {remote_url}")
             break
         except Exception as e:
@@ -497,7 +511,13 @@ async def cdp_devtools_websocket_proxy(client_ws: WebSocket, path: str) -> None:
             await client_ws.close(code=4000, reason="Page not found in any browser")
             return
 
+    import time as _t  # [TIMING] temporary
+
+    _t0 = _t.monotonic()  # [TIMING] temporary
     remote_url = await get_page_websocket_url(browser_id, page_id)
+    logger.info(  # [TIMING] temporary
+        f"[TIMING] /devtools page {page_id}: get_page_ws_url={_t.monotonic() - _t0:.1f}s"
+    )
     if not remote_url:
         logger.error(f"[CDP] Could not get websocket URL for page {page_id}")
         await client_ws.close(code=4502, reason="Failed to get page websocket URL")

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -211,20 +211,6 @@ async def websocket_proxy(
             await client_ws.close(code=4500, reason="Internal proxy error")
 
 
-@router.post("/api/v1/browsers-incognito")
-async def acquire_incognito_browser(request: Request) -> dict[str, Any]:
-    origin_ip = request.headers.get("x-origin-ip")
-    target_domain = request.headers.get("x-target-domains")
-    try:
-        result = await backend.acquire_incognito_browser(origin_ip, target_domain)
-        logger.info(f"Acquired incognito browser {result.get('browser_id')}")
-        return result
-    except Exception as e:
-        detail = "Unable to acquire incognito browser!"
-        logger.error(f"{detail} Exception={e}")
-        raise HTTPException(status_code=500, detail=detail)
-
-
 @router.post("/api/v1/browsers/{browser_id}")
 async def create_browser(browser_id: str, request: Request) -> dict[str, Any]:
     logger.info(f"Starting browser {browser_id}...")

--- a/getgather/browsers/settings.py
+++ b/getgather/browsers/settings.py
@@ -46,6 +46,9 @@ class BrowserSettings(BaseSettings):
         ""  # point at a self-hosted Daytona; empty uses the managed cloud default
     )
     DAYTONA_SNAPSHOT: str = ""
+    # Warm pool of pre-booted incognito sandboxes. 0 disables (cold-create per request, the prior
+    # behavior). Spares run without a proxy; the residential proxy is applied at claim time.
+    DAYTONA_INCOGNITO_POOL_SIZE: int = 2
 
     @property
     def effective_chromefleet_url(self) -> str:

--- a/getgather/main.py
+++ b/getgather/main.py
@@ -54,6 +54,8 @@ async def lifespan(app: FastAPI):
 
     background_task = asyncio.create_task(timer_loop())
 
+    await backend.startup()
+
     try:
         async with AsyncExitStack() as stack:
             for mcp_app in mcp_apps:

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from fastmcp.server.dependencies import get_http_headers
 from loguru import logger
+from nanoid import generate
 
 from getgather.auth.auth import get_auth_user
 from getgather.browser import (
@@ -26,7 +27,6 @@ from getgather.browser import (
     wait_for_ready_state,
     zen_navigate_with_retry,
 )
-from getgather.browsers.backend import mint_incognito_browser_id
 from getgather.config import settings
 from getgather.mcp.html_renderer import DEFAULT_TITLE, render_form
 from getgather.zen_distill import (
@@ -49,6 +49,8 @@ router = APIRouter(prefix="/dpage", tags=["dpage"])
 
 # Max seconds for the distillation polling loop in zen_post_dpage (per HTTP request).
 DEFAULT_DPAGE_POST_POLL_TIMEOUT = 60
+
+FRIENDLY_CHARS: str = "23456789abcdefghijkmnpqrstuvwxyz"
 
 SIGN_IN_ID_DELIMITER = "--"
 
@@ -636,7 +638,8 @@ async def remote_zen_dpage_mcp_tool(
             browser_id, str(page.target_id), incoming.mcp_session_id or mcp_session_id
         )
     elif incognito:
-        browser_id = mint_incognito_browser_id()
+        prefix = "E"  # for Ephemeral
+        browser_id = prefix + generate(FRIENDLY_CHARS, 7)
         browser = await create_remote_browser(
             browser_id, target_domain=_target_domain_from_initial_url(initial_url)
         )
@@ -728,7 +731,8 @@ async def remote_zen_dpage_with_action(
             logger.info(f"Continue with remote browser {browser_id} and page {incoming.target_id}")
             signin_id = SignInId(browser_id, incoming.target_id, session_id)
     elif incognito:
-        browser_id = mint_incognito_browser_id()
+        prefix = "E"
+        browser_id = prefix + generate(FRIENDLY_CHARS, 7)
         browser = await create_remote_browser(
             browser_id, target_domain=_target_domain_from_initial_url(initial_url)
         )

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -15,7 +15,6 @@ from loguru import logger
 from getgather.auth.auth import get_auth_user
 from getgather.browser import (
     ElementConfig,
-    acquire_incognito_remote_browser,
     create_remote_browser,
     find_browser_tab,
     get_new_page,
@@ -27,6 +26,7 @@ from getgather.browser import (
     wait_for_ready_state,
     zen_navigate_with_retry,
 )
+from getgather.browsers.backend import mint_incognito_browser_id
 from getgather.config import settings
 from getgather.mcp.html_renderer import DEFAULT_TITLE, render_form
 from getgather.zen_distill import (
@@ -636,9 +636,9 @@ async def remote_zen_dpage_mcp_tool(
             browser_id, str(page.target_id), incoming.mcp_session_id or mcp_session_id
         )
     elif incognito:
-        # Fleet mints the id (a warm-pool spare when available); see acquire_incognito_remote_browser.
-        browser_id, browser = await acquire_incognito_remote_browser(
-            target_domain=_target_domain_from_initial_url(initial_url)
+        browser_id = mint_incognito_browser_id()
+        browser = await create_remote_browser(
+            browser_id, target_domain=_target_domain_from_initial_url(initial_url)
         )
         page = await get_new_page(browser)
         signin_id = SignInId(browser_id, str(page.target_id), mcp_session_id)
@@ -728,9 +728,9 @@ async def remote_zen_dpage_with_action(
             logger.info(f"Continue with remote browser {browser_id} and page {incoming.target_id}")
             signin_id = SignInId(browser_id, incoming.target_id, session_id)
     elif incognito:
-        # Fleet mints the id (a warm-pool spare when available); see acquire_incognito_remote_browser.
-        browser_id, browser = await acquire_incognito_remote_browser(
-            target_domain=_target_domain_from_initial_url(initial_url)
+        browser_id = mint_incognito_browser_id()
+        browser = await create_remote_browser(
+            browser_id, target_domain=_target_domain_from_initial_url(initial_url)
         )
         page = await get_new_page(browser)
         signin_id = SignInId(browser_id, str(page.target_id), mcp_session_id)

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -11,11 +11,11 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from fastmcp.server.dependencies import get_http_headers
 from loguru import logger
-from nanoid import generate
 
 from getgather.auth.auth import get_auth_user
 from getgather.browser import (
     ElementConfig,
+    acquire_incognito_remote_browser,
     create_remote_browser,
     find_browser_tab,
     get_new_page,
@@ -49,8 +49,6 @@ router = APIRouter(prefix="/dpage", tags=["dpage"])
 
 # Max seconds for the distillation polling loop in zen_post_dpage (per HTTP request).
 DEFAULT_DPAGE_POST_POLL_TIMEOUT = 60
-
-FRIENDLY_CHARS: str = "23456789abcdefghijkmnpqrstuvwxyz"
 
 SIGN_IN_ID_DELIMITER = "--"
 
@@ -638,10 +636,9 @@ async def remote_zen_dpage_mcp_tool(
             browser_id, str(page.target_id), incoming.mcp_session_id or mcp_session_id
         )
     elif incognito:
-        prefix = "E"  # for Ephemeral
-        browser_id = prefix + generate(FRIENDLY_CHARS, 7)
-        browser = await create_remote_browser(
-            browser_id, target_domain=_target_domain_from_initial_url(initial_url)
+        # Fleet mints the id (a warm-pool spare when available); see acquire_incognito_remote_browser.
+        browser_id, browser = await acquire_incognito_remote_browser(
+            target_domain=_target_domain_from_initial_url(initial_url)
         )
         page = await get_new_page(browser)
         signin_id = SignInId(browser_id, str(page.target_id), mcp_session_id)
@@ -731,10 +728,9 @@ async def remote_zen_dpage_with_action(
             logger.info(f"Continue with remote browser {browser_id} and page {incoming.target_id}")
             signin_id = SignInId(browser_id, incoming.target_id, session_id)
     elif incognito:
-        prefix = "E"
-        browser_id = prefix + generate(FRIENDLY_CHARS, 7)
-        browser = await create_remote_browser(
-            browser_id, target_domain=_target_domain_from_initial_url(initial_url)
+        # Fleet mints the id (a warm-pool spare when available); see acquire_incognito_remote_browser.
+        browser_id, browser = await acquire_incognito_remote_browser(
+            target_domain=_target_domain_from_initial_url(initial_url)
         )
         page = await get_new_page(browser)
         signin_id = SignInId(browser_id, str(page.target_id), mcp_session_id)

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -692,6 +692,9 @@ async def remote_zen_dpage_with_action(
     config: ElementConfig | None = None,
 ) -> dict[str, Any]:
     """Execute an action after signin completion with remote Zendriver."""
+    import time as _t  # [TIMING] temporary
+
+    t_start = _t.monotonic()  # [TIMING] temporary
     path = os.path.join(os.path.dirname(__file__), "patterns", "**/*.html")
     patterns = load_distillation_patterns(path)
 
@@ -751,7 +754,9 @@ async def remote_zen_dpage_with_action(
         signin_id = SignInId(browser_id, str(page.target_id), mcp_session_id)
         logger.info(f"For user {user_id}: using remote browser {browser_id}")
 
+    t_browser = _t.monotonic()  # [TIMING] temporary
     await zen_navigate_with_retry(page, initial_url)
+    t_nav = _t.monotonic()  # [TIMING] temporary
 
     error_reporter = make_error_reporter(browser, initial_url) if not incognito else None
     terminated, _, _ = await run_distillation_loop(
@@ -761,6 +766,11 @@ async def remote_zen_dpage_with_action(
         timeout=timeout,
         page=page,
         error_reporter=error_reporter,
+    )
+    logger.info(  # [TIMING] temporary
+        f"[TIMING] dpage {browser_id}: browser+page={t_browser - t_start:.1f}s "
+        f"navigate={t_nav - t_browser:.1f}s distill={_t.monotonic() - t_nav:.1f}s "
+        f"total={_t.monotonic() - t_start:.1f}s"
     )
     if terminated:
         result = await action(page, browser)


### PR DESCRIPTION
# feat(daytona): warm pool for incognito browsers

## Problem

Every incognito browser request cold-creates a Daytona sandbox from snapshot. Live-fleet logs showed ~23s from request to usable browser, dominated by a ~9s sandbox create + boot.

## Change

Add a **warm pool** of pre-booted ephemeral sandboxes in `DaytonaBackend`. Incognito requests claim a ready spare instead of cold-creating one. State lives entirely in Daytona labels — the backend keeps no in-memory map, so it survives restarts.

- **`create_browser` keeps its signature.** For an incognito (`E`-prefixed) id with a non-empty pool, it claims a spare and records the binding as a `claimed_as=<requested-id>` label on the spare sandbox. Every later lookup (`get_browser`, `delete_browser`, `browser_exists`, `get_cdp_base_url`, `get_live_view_url`) resolves through that label. Per-user ids and an empty pool cold-create unchanged.
- **Stateless.** The spare keeps its own immutable `chromium-spare-<rand>` name; the claim replaces its labels (`set_labels` is a full replace) — atomically dropping `pool=spare` and recording the binding. No `_id_map`, no `_spares` set. Resolution survives a process restart and reads consistently across instances.
- **Proxy applied at claim**, not baked into spares — each incognito keeps a fresh residential IP.
- **Auto-refill.** Each claim kicks a background `_reconcile_pool` (own lock, so slow spawns never block a claim) to backfill to `POOL_SIZE`. The 5-min `cleanup_idle` sweep also reconciles, so the pool self-heals (e.g. spares Daytona auto-stopped after idle).
- **`POOL_SIZE` via `DAYTONA_INCOGNITO_POOL_SIZE`** (default 2). `0` disables → exact prior cold-create behavior.
- `dpage` is unchanged from main; the pool is fully contained in the backend.

## Result (measured against live fleet)

Request → usable browser: **~23s → ~13s**. The 9s cold-boot is replaced by a ~1s claim.

```
18:57:29  /cdp/Evy9dgnq  "Browser not found — launching"
18:57:30  Claimed pooled spare spare-… for incognito browser Evy9dgnq   ← ~1s
18:57:42  Start with an ephemeral browser Evy9dgnq
```

## Cost

`POOL_SIZE` spares run 24/7 = net-new compute (~$36–73/mo each; 2 ≈ $72–146/mo). Claimed sandboxes keep the existing 15m auto-stop / 60m auto-delete, so no extra cost vs today. `POOL_SIZE=0` is the kill switch.

## Tradeoffs / follow-ups

- **Per-lookup cost:** an incognito `get/delete/exists/cdp` now does one Daytona label query (~100–300ms). Per-user ids and disabled-pool skip it entirely.
- **Cross-instance claim races** are possible (last-writer-wins on the label) and self-heal; the in-process `_pool_lock` covers the single-process deployment. A future deployment needing hard multi-instance safety would add a CAS store.
- **Burst > `POOL_SIZE`** falls back to cold-create until background refill catches up.
- **`"E"` prefix is shared by convention** between dpage (mints it) and the backend (claims on it); a comment flags the contract.
- **Known, not fixed here:** `get_browser` re-applies the proxy on query, duplicating the claim-time config (~4s + a misleading "IP unchanged" warning). Pre-existing; the pool just made it visible. Worth a follow-up.

## Files

- `daytona_browsers.py` — pool: `_claim_spare_for`, `_resolve`, `_reconcile_pool`, `_spawn_spare`, `_iter_sandboxes`, label-based binding.
- `backend.py` — `startup()` added to the protocol.
- `fleet_browsers.py`, `podman_browsers.py` — no-op `startup()`.
- `settings.py` — `DAYTONA_INCOGNITO_POOL_SIZE`.
- `main.py` — `await backend.startup()` in lifespan.

## Test

- ruff format/lint, pyright (clean on changed files), 64 unit tests pass.
- Verified against live Chrome Fleet: pool claim + label resolution + auto-refill confirmed in logs.