### PR TITLE
Normalize phone digits in safeway signin input

### DIFF
--- a/getgather/mcp/html_renderer.py
+++ b/getgather/mcp/html_renderer.py
@@ -303,25 +303,9 @@ def render_form(
     <script>
       document.addEventListener("DOMContentLoaded", function () {{
         const form = document.querySelector("div.card");
-        const phoneTextPattern = /^\\+?\\d+(-\\d+)+$/;
 
         if (form) {{
           form.addEventListener("submit", function (e) {{
-            const formElement = form.querySelector("form");
-            if (formElement) {{
-              formElement.querySelectorAll("input").forEach(function (input) {{
-                const value = input.value;
-                if (!value || !value.includes("-")) {{
-                  return;
-                }}
-                const type = input.type.toLowerCase();
-                if (type === "tel" || type === "number") {{
-                  input.value = value.replace(/-/g, "");
-                }} else if (type === "text" && phoneTextPattern.test(value)) {{
-                  input.value = value.replace(/-/g, "");
-                }}
-              }});
-            }}
 
             const overlay = document.createElement("div");
             overlay.className = "form-overlay";

--- a/getgather/mcp/patterns/safeway-signin.html
+++ b/getgather/mcp/patterns/safeway-signin.html
@@ -21,5 +21,19 @@
     >
       Sign in
     </button>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        const input = document.querySelector("input[name='email']");
+        if (!input) return;
+        const form = input.form;
+        if (!form) return;
+        form.addEventListener("submit", function () {
+          const value = input.value || "";
+          if (value.indexOf("@") === -1) {
+            input.value = value.replace(/[^0-9]/g, "");
+          }
+        });
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This also reverts the generic input hypens removal (from PR #1314).

Left: the distilled page, numbers are entered with extra non-numeric characters, e.g `-`.
Right: the normalized version sent to Safeway.

<img width="1616" height="974" alt="image" src="https://github.com/user-attachments/assets/2c1882e0-4823-4670-b7ed-d2354a4e6b48" />
