### PR TITLE
Make the entire podman process natively async

### DIFF
--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -15,20 +15,26 @@ from getgather.config import settings
 DOCKER_INTERNAL_HOST = "172.17.0.1"
 
 
-def run_podman(args: list[str]) -> subprocess.CompletedProcess[str]:
+async def run_podman(args: list[str]) -> tuple[str, str]:
     cmd = ["podman"]
     if settings.CONTAINER_HOST:
         cmd.append("--remote")
     cmd.extend(args)
-    return subprocess.run(
-        cmd, capture_output=True, text=True, check=True, encoding="utf-8", errors="replace"
+    proc = await asyncio.create_subprocess_exec(
+        *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
     )
+    stdout_bytes, stderr_bytes = await proc.communicate()
+    stdout = stdout_bytes.decode("utf-8", errors="replace")
+    stderr = stderr_bytes.decode("utf-8", errors="replace")
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.returncode or -1, cmd, stdout, stderr)
+    return stdout, stderr
 
 
 async def get_host_port(container_name: str, container_port: int) -> int | None:
     try:
-        result = await asyncio.to_thread(run_podman, ["port", container_name, str(container_port)])
-        port_mapping = result.stdout.strip()
+        stdout, _ = await run_podman(["port", container_name, str(container_port)])
+        port_mapping = stdout.strip()
         if not port_mapping:
             return None
         host_port = int(port_mapping.split(":")[-1])
@@ -59,9 +65,9 @@ async def launch_container(image_name: str, container_name: str) -> str:
         image_name,
     ])
     try:
-        result = await asyncio.to_thread(run_podman, cmd)
-        if result.returncode == 0 and result.stdout:
-            container_id = result.stdout.strip()
+        stdout, _ = await run_podman(cmd)
+        if stdout:
+            container_id = stdout.strip()
             cdp_port = await get_host_port(container_name, 9222)
             vnc_port = await get_host_port(container_name, 5900)
             logger.info(
@@ -75,19 +81,16 @@ async def launch_container(image_name: str, container_name: str) -> str:
 
 async def container_exists(container_name: str) -> bool:
     try:
-        result = await asyncio.to_thread(run_podman, ["container", "exists", container_name])
-        return result.returncode == 0
+        await run_podman(["container", "exists", container_name])
+        return True
     except subprocess.CalledProcessError:
         return False
 
 
 async def container_is_running(container_name: str) -> bool:
     try:
-        result = await asyncio.to_thread(
-            run_podman,
-            ["inspect", "--format", "{{.State.Running}}", container_name],
-        )
-        return result.stdout.strip() == "true"
+        stdout, _ = await run_podman(["inspect", "--format", "{{.State.Running}}", container_name])
+        return stdout.strip() == "true"
     except subprocess.CalledProcessError:
         return False
 
@@ -95,8 +98,8 @@ async def container_is_running(container_name: str) -> bool:
 async def kill_container(container_name: str) -> None:
     logger.info(f"Killing Chromium container {container_name}...")
     try:
-        result = await asyncio.to_thread(run_podman, ["kill", container_name])
-        if result.returncode == 0 and result.stdout:
+        stdout, _ = await run_podman(["kill", container_name])
+        if stdout:
             logger.info(f"Container killed: name={container_name}")
         else:
             raise Exception(f"Unable to kill container {container_name}")
@@ -107,43 +110,34 @@ async def kill_container(container_name: str) -> None:
 async def list_containers() -> list[str]:
     logger.debug("Retrieving the list of all containers...")
     try:
-        result = await asyncio.to_thread(run_podman, ["container", "ls", "--format", "{{.Names}}"])
-        if result.returncode == 0:
-            containers = result.stdout.splitlines() if result.stdout else []
-            logger.debug(f"All containers obtained. Total={len(containers)}")
-            return containers
-        else:
-            raise Exception("Unable to list all containers")
+        stdout, _ = await run_podman(["container", "ls", "--format", "{{.Names}}"])
+        containers = stdout.splitlines() if stdout else []
+        logger.debug(f"All containers obtained. Total={len(containers)}")
+        return containers
     except subprocess.CalledProcessError as e:
         raise Exception(f"Unable to list all containers: {e}")
 
 
 async def get_container_last_activity(container_name: str) -> float | None:
     try:
-        await asyncio.to_thread(
-            run_podman,
-            [
-                "exec",
-                container_name,
-                "sh",
-                "-c",
-                "cp /home/user/chrome-profile/Default/History db",
-            ],
-        )
+        await run_podman([
+            "exec",
+            container_name,
+            "sh",
+            "-c",
+            "cp /home/user/chrome-profile/Default/History db",
+        ])
 
-        result = await asyncio.to_thread(
-            run_podman,
-            [
-                "exec",
-                container_name,
-                "sqlite3",
-                "db",
-                "select MAX(last_visit_time) from urls;",
-            ],
-        )
+        stdout, _ = await run_podman([
+            "exec",
+            container_name,
+            "sqlite3",
+            "db",
+            "select MAX(last_visit_time) from urls;",
+        ])
 
-        if result.returncode == 0 and result.stdout:
-            chromium_time = float(result.stdout.strip())
+        if stdout:
+            chromium_time = float(stdout.strip())
             unix_epoch = (chromium_time / 1_000_000) - 11644473600
             return unix_epoch
         return None
@@ -161,49 +155,37 @@ async def configure_container(container_name: str, proxy_url: str | None) -> Non
             proxy_url = proxy_url.removeprefix("http://")
             logger.debug(f"Configuring proxy with proxy_url: {proxy_url}")
             logger.info(f"Modifying tinyproxy.conf in {container_name}...")
-            await asyncio.to_thread(
-                run_podman,
-                [
-                    "exec",
-                    container_name,
-                    "sed",
-                    "-i",
-                    "/^Upstream http/d",
-                    "/app/tinyproxy.conf",
-                ],
-            )
-            await asyncio.to_thread(
-                run_podman,
-                [
-                    "exec",
-                    container_name,
-                    "sed",
-                    "-i",
-                    f"$ a\\Upstream http {proxy_url}",
-                    "/app/tinyproxy.conf",
-                ],
-            )
+            await run_podman([
+                "exec",
+                container_name,
+                "sed",
+                "-i",
+                "/^Upstream http/d",
+                "/app/tinyproxy.conf",
+            ])
+            await run_podman([
+                "exec",
+                container_name,
+                "sed",
+                "-i",
+                f"$ a\\Upstream http {proxy_url}",
+                "/app/tinyproxy.conf",
+            ])
             logger.info(f"Restarting tinyproxy in {container_name}...")
-            await asyncio.to_thread(
-                run_podman,
-                [
-                    "exec",
-                    container_name,
-                    "sh",
-                    "-c",
-                    "pkill tinyproxy || true",
-                ],
-            )
-            await asyncio.to_thread(
-                run_podman,
-                [
-                    "exec",
-                    container_name,
-                    "sh",
-                    "-c",
-                    "tinyproxy -d -c /app/tinyproxy.conf &",
-                ],
-            )
+            await run_podman([
+                "exec",
+                container_name,
+                "sh",
+                "-c",
+                "pkill tinyproxy || true",
+            ])
+            await run_podman([
+                "exec",
+                container_name,
+                "sh",
+                "-c",
+                "tinyproxy -d -c /app/tinyproxy.conf &",
+            ])
             logger.info(f"Proxy configured successfully in {container_name}.")
         except subprocess.CalledProcessError as e:
             raise Exception(f"Error configuring proxy: {e}")
@@ -220,25 +202,22 @@ async def get_container_public_ip(
 ) -> str | None:
     for attempt in range(1, retries + 1):
         try:
-            result = await asyncio.to_thread(
-                run_podman,
-                [
-                    "exec",
-                    container_name,
-                    "curl",
-                    "-s",
-                    "--max-time",
-                    "10",
-                    "--proxy",
-                    "http://127.0.0.1:8119",
-                    "https://ip.fly.dev",
-                ],
-            )
-            ip = result.stdout.strip() or None
+            stdout, stderr = await run_podman([
+                "exec",
+                container_name,
+                "curl",
+                "-s",
+                "--max-time",
+                "10",
+                "--proxy",
+                "http://127.0.0.1:8119",
+                "https://ip.fly.dev",
+            ])
+            ip = stdout.strip() or None
             if ip:
                 return ip
             logger.debug(
-                f"IP check attempt {attempt}/{retries} in {container_name}: empty response (stderr: {result.stderr.strip()!r})"
+                f"IP check attempt {attempt}/{retries} in {container_name}: empty response (stderr: {stderr.strip()!r})"
             )
         except subprocess.CalledProcessError as e:
             logger.debug(


### PR DESCRIPTION
This is a follow-up to PR #1350

Replace `asyncio.to_thread(subprocess.run)` with the true `asyncio.create_subprocess_exec` to avoid blocking the event loop thread pool and simplify call sites.