### PR TITLE
fix fly concurrency limit

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -15,8 +15,7 @@ primary_region = 'sjc'
 
   [http_service.concurrency]
     type = "requests"
-    soft_limit = 5
-    hard_limit = 20
+    soft_limit = 20
 
   [http_service.http_options]
     idle_timeout = 180


### PR DESCRIPTION
fly proxy stops routing traffic when hard_limit is reached, this is not what we want
based on the traffic, 1 machine should be able to handle 20 concurrent requests at ease, so update soft_limit to 20