### PR TITLE
Normalize Safeway sign-in email and phone input on submit

### DIFF
--- a/getgather/mcp/patterns/safeway-signin.html
+++ b/getgather/mcp/patterns/safeway-signin.html
@@ -29,8 +29,14 @@
         if (!form) return;
         form.addEventListener("submit", function () {
           const value = input.value || "";
-          if (value.indexOf("@") === -1) {
-            input.value = value.replace(/[^0-9]/g, "");
+          if (value.indexOf("@") !== -1) {
+            input.value = value.trim().replace(/\s+/g, "");
+          } else {
+            let digits = value.replace(/[^0-9]/g, "");
+            while (digits.length > 0 && (digits[0] === "0" || digits[0] === "1")) {
+              digits = digits.slice(1);
+            }
+            input.value = digits;
           }
         });
       });


### PR DESCRIPTION
## Summary
- Trim and remove whitespace from email addresses before Safeway sign-in submit
- Strip non-digit characters from phone numbers and remove leading `0`/`1` digits (e.g. country code or leading zero)

## Test plan
- [ ] Sign in with an email that has accidental spaces (e.g. ` user@example.com `) and confirm it submits cleanly
- [ ] Sign in with a phone number prefixed by `1` or `0` (e.g. `1-555-123-4567`) and confirm leading digits are stripped
- [ ] Sign in with a plain 10-digit phone number and confirm it still works