### PR TITLE
fix: stop reporting distillation 'no matched pattern' on the expected sign-in fallthrough

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -597,8 +597,8 @@ async def run_distillation_loop(
 
     # Only report when nothing matched at all. A non-terminating match (e.g. a sign-in
     # page) is the expected sign-in fallthrough, not an error worth reporting.
-    matched_any = current.name != ""
-    if error_reporter is not None and not matched_any:
+    nothing_matched = current.name == ""
+    if error_reporter is not None and nothing_matched:
         await error_reporter(
             error=ValueError("No matched pattern found"),
             page=page,

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -595,7 +595,10 @@ async def run_distillation_loop(
         else:
             logger.debug(f"No matched pattern found")
 
-    if error_reporter is not None:
+    # Only report when nothing matched at all. A non-terminating match (e.g. a sign-in
+    # page) is the expected sign-in fallthrough, not an error worth reporting.
+    matched_any = current.name != ""
+    if error_reporter is not None and not matched_any:
         await error_reporter(
             error=ValueError("No matched pattern found"),
             page=page,


### PR DESCRIPTION
## What

`run_distillation_loop` logged `ValueError("No matched pattern found")` to Sentry **every time** it didn't find a finished data page in time — including the normal "user isn't signed in → return the sign-in screen" path. So a logged-out user calling a data tool (e.g. `get_prime_library`) got the correct sign-in prompt, but a fake error was fired on the way out. That false alarm is the bulk of [MCP-GETGATHER-53](https://heyario.sentry.io/issues/MCP-GETGATHER-53) (13k events / 411 users).

## Fix

Only report when the page is **genuinely unrecognized** (`current.name == ""`). A recognized-but-non-terminating page (like a sign-in screen) is the expected fallthrough and is no longer logged.

## Scope — observability only, not a behavior fix

Sampling 18 events: ~39% benign sign-in (fixed here), ~39% pages that never finished loading (timing bug), ~11% Prime empty-state pattern gap. The two real failures are intentionally **kept reporting** — this just stops them being buried under the sign-in noise. Expect volume down ~39%, not to zero.

## Verification

`pyright` + `ruff` clean; distillation unit tests pass (6).