### PR TITLE
Add a POST endpoint to start the distillation loop

### DIFF
--- a/.github/workflows/extraction-test.yml
+++ b/.github/workflows/extraction-test.yml
@@ -77,6 +77,9 @@ jobs:
 
       - name: Run the extraction tests
         run: uv run pytest -v -s tests/test_extractions.py
+        env:
+          ACME_EMAIL: joe@example.com
+          ACME_PASSWORD: trustno1
 
   extraction-tests-wheel:
     needs: setup
@@ -132,6 +135,9 @@ jobs:
 
       - name: Run the extraction tests
         run: uv run pytest -v -s tests/test_extractions.py
+        env:
+          ACME_EMAIL: joe@example.com
+          ACME_PASSWORD: trustno1
 
   extraction-tests-fleet:
     runs-on: ubuntu-24.04
@@ -167,3 +173,6 @@ jobs:
 
       - name: Run the extraction tests
         run: uv run pytest -v -s tests/test_extractions.py
+        env:
+          ACME_EMAIL: joe@example.com
+          ACME_PASSWORD: trustno1

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ _Example_: `curl -X POST 'localhost:23456/api/v1/browsers/test/pages/96FDE4162B8
 
 _Example_: `curl localhost:23456/api/v1/browsers/test/pages/96FDE4162B8EEEBF98E26756D21CF0C5/distilled`
 
+### Submit distilled page form
+
+`POST /api/v1/browsers/{browser_id}/pages/{page_id}/distill` submits form field values for the specified page and continues the distillation loop, returning the next rendered distilled HTML form. The request body is form-encoded (`application/x-www-form-urlencoded` or `multipart/form-data`); each field is mapped by its `name` to the corresponding form input. Returns HTTP 404 if the browser or page is not found.
+
+_Example_: `curl -X POST localhost:23456/api/v1/browsers/test/pages/96FDE4162B8EEEBF98E26756D21CF0C5/distill -d 'email=user@example.com&password=secret'` returns the next distilled HTML page.
+
 ### List all patterns
 
 `GET /api/v1/patterns` returns a JSON array of all pattern filenames (sorted alphabetically), including the extension (`.html` or `.json`).

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -171,10 +171,30 @@ async def _create_browser_from_cdp_websocket(
 
 
 def find_browser_tab(browser: zd.Browser, target_id: str) -> zd.Tab | None:
-    """Find a browser tab by its target ID."""
-    for tab in browser.tabs:
-        if tab.target_id == target_id:
-            return tab
+    """Find a browser tab by its target ID.
+
+    zendriver's ``Browser.update_targets`` populates ``self.targets`` with plain
+    ``Connection`` objects for targets that already existed when the browser was
+    attached (e.g. via ChromeFleet CDP), instead of ``Tab`` objects. Only targets
+    created later through a ``TargetCreated`` event get promoted to ``Tab``.
+    Since ``evaluate`` (and most page-level helpers) live on ``Tab`` and not on
+    ``Connection``, calling ``page.evaluate(...)`` on such a target fails with
+    ``'Connection' object has no attribute 'evaluate'``.
+
+    Here we upgrade any matched ``Connection`` to a ``Tab`` (mirroring what
+    ``_handle_target_update`` does for newly created targets) and replace it in
+    ``browser.targets`` so subsequent lookups return the ``Tab`` as well.
+    """
+    for idx, target in enumerate(browser.targets):
+        if target.target_id != target_id:
+            continue
+        if isinstance(target, zd.Tab):
+            return target
+        if target.target is None:
+            return None
+        tab = zd.Tab(target.websocket_url, target=target.target, browser=browser)
+        browser.targets[idx] = tab
+        return tab
     return None
 
 

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -311,19 +311,23 @@ def is_incognito_request(headers: dict[str, str]) -> bool:
     return headers.get("x-incognito", "0") == "1"
 
 
-async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLResponse:
-    form_data = await request.form()
-    fields: dict[str, str] = {k: str(v) for k, v in form_data.items()}
-
-    path = os.path.join(os.path.dirname(__file__), "patterns", "**/*.html")
-    patterns = load_distillation_patterns(path)
+async def distill_post_loop(
+    page: zd.Tab,
+    id: str,
+    fields: dict[str, str],
+    action: str,
+    patterns: list[Pattern] | None = None,
+    timeout: int = DEFAULT_DPAGE_POST_POLL_TIMEOUT,
+) -> HTMLResponse:
+    if patterns is None:
+        path = os.path.join(os.path.dirname(__file__), "patterns", "**/*.html")
+        patterns = load_distillation_patterns(path)
 
     logger.info(f"Continuing distillation for page {id}...")
     logger.debug(f"Available distillation patterns: {len(patterns)}")
 
     TICK = 1  # seconds
-    TIMEOUT = DEFAULT_DPAGE_POST_POLL_TIMEOUT
-    max = TIMEOUT // TICK
+    max = timeout // TICK
 
     current = Match(name="", priority=-1, distilled="")
 
@@ -358,7 +362,6 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
 
         title_element = BeautifulSoup(distilled, "html.parser").find("title")
         title = title_element.get_text() if title_element is not None else DEFAULT_TITLE
-        action = f"/dpage/{id}"
         options = {"title": title, "action": action}
         inputs = document.find_all("input")
         pending_actions: list[dict[str, str]] = []
@@ -565,10 +568,10 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
             results = action_results if isinstance(action_results, dict) else {}
 
             # Fallback for failed/unexecuted actions to preserve behavior.
-            for i, action in enumerate(pending_actions):
-                key = action.get("key")
-                kind = action.get("kind")
-                selector = action.get("selector")
+            for i, pending_action in enumerate(pending_actions):
+                key = pending_action.get("key")
+                kind = pending_action.get("kind")
+                selector = pending_action.get("selector")
                 if (
                     not isinstance(key, str)
                     or not isinstance(kind, str)
@@ -585,7 +588,7 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
                 if kind == "click":
                     await element.click()
                 elif kind == "set_value":
-                    value = action.get("value")
+                    value = pending_action.get("value")
                     await element.type_text(value if isinstance(value, str) else "")
 
             await asyncio.sleep(0.25)
@@ -595,7 +598,7 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
 
     hostname_attr: str | None = getattr(page, "hostname", None)  # type: ignore[assignment]
     location = getattr(page, "url", "unknown")  # type: ignore[assignment]
-    timeout_error = TimeoutError("Timeout reached in zen_post_dpage")
+    timeout_error = TimeoutError("Timeout reached in distill_post_loop")
 
     await zen_report_distill_error(
         error=timeout_error,
@@ -606,6 +609,12 @@ async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLRespons
         iteration=max,
     )
     raise HTTPException(status_code=503, detail="Timeout reached")
+
+
+async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLResponse:
+    form_data = await request.form()
+    fields: dict[str, str] = {k: str(v) for k, v in form_data.items()}
+    return await distill_post_loop(page, id, fields, f"/dpage/{id}")
 
 
 async def remote_zen_dpage_mcp_tool(

--- a/getgather/pages_api_router.py
+++ b/getgather/pages_api_router.py
@@ -6,8 +6,10 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from loguru import logger
 
+from getgather.browser import find_browser_tab, get_remote_browser
 from getgather.browsers.router import strip_browser_id_from_target_id
 from getgather.cdp_client import PageNotFoundError, open_cdp
+from getgather.mcp.dpage import distill_post_loop
 from getgather.zen_distill import convert, distill, load_distillation_patterns
 
 router = APIRouter()
@@ -105,6 +107,28 @@ async def get_page_distilled(browser_id: str, page_id: str) -> JSONResponse | HT
             raise HTTPException(status_code=502, detail=f"Failed to distill page: {e}")
     finally:
         await client.aclose()
+
+
+@router.post("/api/v1/browsers/{browser_id}/pages/{page_id}/distill")
+async def post_page_distill(
+    browser_id: str,
+    page_id: str,
+    request: Request,
+) -> HTMLResponse:
+    page_id = strip_browser_id_from_target_id(page_id)
+    browser = await get_remote_browser(browser_id)
+    if browser is None:
+        raise HTTPException(status_code=404, detail=f"Browser {browser_id} not found!")
+
+    page = find_browser_tab(browser, page_id)
+    if page is None:
+        raise HTTPException(status_code=404, detail=f"Page {page_id} not found in browser")
+
+    logger.info(f"POST /distill for browser: {browser_id}  page: {page_id}")
+    form_data = await request.form()
+    fields: dict[str, str] = {k: str(v) for k, v in form_data.items()}
+    action = f"/api/v1/browsers/{browser_id}/pages/{page_id}/distill"
+    return await distill_post_loop(page, page_id, fields, action, timeout=15)
 
 
 @router.post("/api/v1/browsers/{browser_id}/pages/{page_id}/navigate")

--- a/tests/test_extractions.py
+++ b/tests/test_extractions.py
@@ -65,6 +65,27 @@ def navigate_page(client: httpx.Client, browser_id: str, page_id: str, url: str)
     return navigate
 
 
+def distill_page(
+    client: httpx.Client,
+    browser_id: str,
+    page_id: str,
+    fields: dict[str, str] | None = None,
+) -> httpx.Response:
+    distilled: httpx.Response | None = None
+    for _ in range(RETRY_TIMEOUT):
+        response = client.post(
+            f"/api/v1/browsers/{browser_id}/pages/{page_id}/distill",
+            data=fields or {},
+        )
+        if response.status_code == 200:
+            distilled = response
+            break
+        time.sleep(1)
+    assert distilled is not None, "Distill POST never returned 200"
+    assert distilled.status_code == 200
+    return distilled
+
+
 def get_distilled_json(client: httpx.Client, browser_id: str, page_id: str) -> list[object]:
     distilled: httpx.Response | None = None
     for _ in range(RETRY_TIMEOUT):
@@ -77,6 +98,19 @@ def get_distilled_json(client: httpx.Client, browser_id: str, page_id: str) -> l
     assert distilled.status_code == 200
     data: list[object] = distilled.json()
     return data
+
+
+def get_distilled_html(client: httpx.Client, browser_id: str, page_id: str) -> str:
+    distilled: httpx.Response | None = None
+    for _ in range(RETRY_TIMEOUT):
+        response = client.get(f"/api/v1/browsers/{browser_id}/pages/{page_id}/distilled")
+        if response.status_code == 200:
+            distilled = response
+            break
+        time.sleep(1)
+    assert distilled is not None, "Distilled endpoint never returned 200"
+    assert distilled.status_code == 200
+    return distilled.text
 
 
 @pytest.mark.distill
@@ -220,3 +254,40 @@ class TestCBC:
         assert "link" in first
         assert isinstance(first["link"], str)
         assert first["link"]
+
+
+@pytest.mark.distill
+def test_acme_login_email_password(client: httpx.Client, browser_ids: list[str]) -> None:
+    acme_login_pattern = """<html gg-domain="acme">
+  <body>
+    <h1 gg-match="h1">Login</h1>
+    <input name="email" type="email" placeholder="Email" gg-match="input[type=email]" />
+    <input name="password" type="password" placeholder="Password" gg-match="input[type=password]" />
+    <button gg-autoclick gg-match="button[type=submit]"></button>
+  </body>
+</html>
+"""
+    acme_success_pattern = """<html gg-domain="acme">
+  <body>
+    <h1 gg-stop gg-match="//h1[contains(text(), 'successful')]">Success</h1>
+  </body>
+</html>
+"""
+    client.post("/api/v1/patterns/acme-login", json={"content": acme_login_pattern})
+    client.post("/api/v1/patterns/acme-success", json={"content": acme_success_pattern})
+    try:
+        email = os.getenv("ACME_EMAIL")
+        password = os.getenv("ACME_PASSWORD")
+        assert email, "ACME_EMAIL environment variable must be set"
+        assert password, "ACME_PASSWORD environment variable must be set"
+
+        browser_id, page_id = prepare_new_browser(client, "acme", browser_ids)
+
+        navigate_page(client, browser_id, page_id, "https://acme.fly.dev/auth/email-and-password")
+        distill_page(client, browser_id, page_id, fields={"email": email, "password": password})
+
+        message = get_distilled_html(client, browser_id, page_id)
+        assert "Login successful!" in message
+    finally:
+        client.delete("/api/v1/patterns/acme-login")
+        client.delete("/api/v1/patterns/acme-success")


### PR DESCRIPTION
Update the README with API documentation for the new endpoint.

As an initial test, cover the ACME sign-in flow with email and password. More tests will follow.

To run the test, first launch Remote Browser and then:
```bash
export REMOTEBROWSER_URL=http://localhost:23456
uv run pytest tests/test_extractions.py::test_acme_login_email_password
```

<img width="1740" height="853" alt="image" src="https://github.com/user-attachments/assets/7c5155cc-dcd5-4fd5-9dfa-cfab169fdcf1" />
