### PR TITLE
Remove short-lived MCP tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,9 +52,7 @@ Adding a new brand requires: (1) add a YAML entry in `mcp-tools.yaml` with `id`,
 
 All brands are declared in YAML at `getgather/mcp/mcp-tools.yaml`. `declarative_mcp.create_declarative_mcp_tools()` runs at module level and creates `MCPTool` instances from YAML for every brand. Two registration modes:
 
-- **Declarative** (no `custom: true`): tools are auto-generated from YAML config. Two tool kinds:
-  - default: `remote_zen_dpage_mcp_tool(url, result_key, timeout)` — full sign-in flow via dpage
-  - `short_lived: true`: `short_lived_mcp_tool(location, pattern_wildcard, result_key, hostname)` — one-off scrape for public pages (CNN, ESPN, Ground News, NPR, NYTimes)
+- **Declarative** (no `custom: true`): tools are auto-generated from YAML config. The default kind is `remote_zen_dpage_mcp_tool(url, result_key, timeout)` — full sign-in flow via dpage.
 
 - **Custom** (`custom: true`, `module: <name>`): declarative_mcp creates the MCPTool, then dynamically imports the brand module. The module looks up `MCPTool.registry["<brand_id>"]` and uses `@brand_mcp.tool` to register tools with custom logic (post-signin actions, JSON response interception, multi-page flows) via `remote_zen_dpage_with_action(initial_url, action)` where `action` is an `async (page, browser) -> dict`.
 

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -14,6 +14,7 @@ import sentry_sdk
 import websockets
 import zendriver as zd
 from loguru import logger
+from nanoid import generate
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from zendriver.core import util
 from zendriver.core._contradict import ContraDict
@@ -21,7 +22,7 @@ from zendriver.core.config import Config
 from zendriver.core.connection import Connection, ProtocolException
 
 from getgather.browsers.fleet_browsers import build_chromefleet_headers, call_chromefleet_api
-from getgather.config import settings
+from getgather.config import FRIENDLY_CHARS, settings
 
 _ws_extra_headers_var: ContextVar[dict[str, str] | None] = ContextVar(
     "_ws_extra_headers_var", default=None
@@ -226,13 +227,15 @@ async def get_remote_browser(browser_id: str) -> zd.Browser | None:
 
 
 async def create_remote_browser(
-    browser_id: str,
+    browser_id: str = "",
     target_domain: str | None = None,
 ) -> zd.Browser:
     """
     Connect to a remote Chrome via ChromeFleet CDP.
     ChromeFleet auto-starts the browser on first CDP access if it doesn't exist.
     """
+    if not browser_id:
+        browser_id = generate(FRIENDLY_CHARS, 6)
     logger.info(f"Connecting to ChromeFleet browser: {browser_id}")
     cdp_websocket_url = _setup_cdp_url(browser_id)
     logger.debug(f"Connecting to ChromeFleet CDP at {cdp_websocket_url}")

--- a/getgather/main.py
+++ b/getgather/main.py
@@ -1,5 +1,6 @@
 import ast
 import asyncio
+import os
 from contextlib import AsyncExitStack, asynccontextmanager
 from datetime import datetime
 from typing import Awaitable, Callable
@@ -15,6 +16,7 @@ from fastapi.staticfiles import StaticFiles
 from loguru import logger
 
 from getgather.auth.auth import setup_mcp_auth
+from getgather.browser import create_remote_browser, terminate_remote_browser
 from getgather.browsers.router import backend, router as browsers_router
 from getgather.config import PROJECT_DIR, settings
 from getgather.logs import MCPLoggingContextMiddleware
@@ -23,7 +25,7 @@ from getgather.mcp.main import MCPDoc, create_mcp_apps, mcp_app_docs
 from getgather.pages_api_router import router as pages_router
 from getgather.patterns_api_router import router as patterns_router
 from getgather.tracing import MCPSessionTraceMiddleware, instrument_fastapi
-from getgather.zen_distill import short_lived_mcp_tool
+from getgather.zen_distill import load_distillation_patterns, run_distillation_loop
 
 # Create MCP apps once and reuse for lifespan and mounting
 mcp_apps = create_mcp_apps()
@@ -87,24 +89,30 @@ def health():
 
 @app.get("/extended-health")
 async def extended_health():
+    # A fresh ephemeral browser per probe, terminated when done
+    browser = await create_remote_browser()
     try:
-        # A fresh short-lived browser per probe, terminated when done: the probe never touches
-        # the shared noauth browser (which holds real sessions in noauth deployments) and leaves
-        # no sandbox behind for a later run on the same hostname to inherit.
-        _, result = await short_lived_mcp_tool(
+        patterns = load_distillation_patterns(
+            os.path.join(os.path.dirname(__file__), "mcp", "patterns", "ip-fly.html")
+        )
+        terminated, distilled, converted = await run_distillation_loop(
             location="https://ip.fly.dev/ip",
-            pattern_wildcard="ip-fly.html",
-            result_key="ip_address",
-            url_hostname="ip.fly.dev",
+            patterns=patterns,
+            browser=browser,
             timeout=3,
         )
-        ip_text = str(result.get("ip_address", "Unknown"))[:100]
+        if not terminated:
+            raise ValueError("Distillation did not terminate for ip.fly.dev")
+        payload = converted if converted is not None else distilled
+        ip_text = str(payload)[:100]
         ip_list = ast.literal_eval(ip_text)
         ip_address = ip_list[0]["ip_address"]
         logger.debug(f"IP address: {ip_address}")
         return PlainTextResponse(content=f"OK IP: {ip_address}")
     except Exception as e:
         return PlainTextResponse(content=f"Error: {e}")
+    finally:
+        await terminate_remote_browser(browser)
 
 
 @app.middleware("http")

--- a/getgather/mcp/declarative_mcp.py
+++ b/getgather/mcp/declarative_mcp.py
@@ -10,7 +10,6 @@ from pydantic import BaseModel
 
 from getgather.mcp.dpage import remote_zen_dpage_mcp_tool
 from getgather.mcp.registry import MCPTool
-from getgather.zen_distill import short_lived_mcp_tool
 
 YAML_CONFIG_PATH = Path(__file__).parent / "mcp-tools.yaml"
 
@@ -21,9 +20,6 @@ class ToolConfig(BaseModel):
     result_key: str | None = None
     url: str | None = None
     timeout: int | None = None
-    short_lived: bool = False
-    pattern_wildcard: str | None = None
-    hostname: str | None = None
 
 
 class McpConfig(BaseModel):
@@ -47,8 +43,8 @@ def create_declarative_mcp_tools() -> None:
     """Create and register MCP tools from configuration array.
 
     This function generates MCPTool instances and their tools dynamically
-    from the DECLARATIVE_MCP_CONFIG array. Tools can be either remote zen dpage tools,
-    short-lived tools, or custom-code modules.
+    from the DECLARATIVE_MCP_CONFIG array. Tools can be either remote zen dpage tools
+    or custom-code modules.
 
     For custom-code entries (custom: true), the MCPTool is created and then the
     Python module is imported so its @<id>_mcp.tool decorators register tools.
@@ -73,52 +69,21 @@ def create_declarative_mcp_tools() -> None:
         for tool_config in config.tools:
             function_name: str = tool_config.function_name
             description: str = tool_config.description
-            short_lived: bool = tool_config.short_lived
+            url: str = tool_config.url or ""
+            result_key: str = tool_config.result_key or ""
+            timeout: int = tool_config.timeout if tool_config.timeout is not None else 2
 
-            if short_lived:
-                url: str = tool_config.url or ""
-                pattern_wildcard: str = tool_config.pattern_wildcard or ""
-                result_key: str = tool_config.result_key or ""
-                hostname: str = tool_config.hostname or ""
+            def make_remote_tool_fn(
+                url: str = url,
+                result_key: str = result_key,
+                timeout: int = timeout,
+            ):
+                async def tool_func() -> dict[str, Any]:
+                    return await remote_zen_dpage_mcp_tool(url, result_key, timeout=timeout)
 
-                def make_short_lived_tool_fn(
-                    url: str = url,
-                    pattern_wildcard: str = pattern_wildcard,
-                    result_key: str = result_key,
-                    hostname: str = hostname,
-                ):
-                    async def tool_func() -> dict[str, Any]:
-                        terminated, result = await short_lived_mcp_tool(
-                            location=url,
-                            pattern_wildcard=pattern_wildcard,
-                            result_key=result_key,
-                            url_hostname=hostname,
-                        )
-                        if not terminated:
-                            raise ValueError(f"Failed to retrieve {result_key}")
-                        return result
+                return tool_func
 
-                    return tool_func
-
-                tool_func = make_short_lived_tool_fn()
-
-            else:
-                url: str = tool_config.url or ""
-                result_key: str = tool_config.result_key or ""
-                timeout: int = tool_config.timeout if tool_config.timeout is not None else 2
-
-                def make_remote_tool_fn(
-                    url: str = url,
-                    result_key: str = result_key,
-                    timeout: int = timeout,
-                ):
-                    async def tool_func() -> dict[str, Any]:
-                        return await remote_zen_dpage_mcp_tool(url, result_key, timeout=timeout)
-
-                    return tool_func
-
-                tool_func = make_remote_tool_fn()
-
+            tool_func = make_remote_tool_fn()
             tool_func.__name__ = function_name
             tool_func.__doc__ = description
             gather_mcp.tool(tool_func)

--- a/getgather/mcp/main.py
+++ b/getgather/mcp/main.py
@@ -53,7 +53,7 @@ class LocationProxyMiddleware(Middleware):
 
 
 MCP_BUNDLES: dict[str, list[str]] = {
-    "media": ["bbc", "cnn", "espn", "groundnews", "npr", "nytimes"],
+    "media": ["bbc"],
     "books": ["goodreads"],
     "shopping": ["amazon", "amazonca", "shopee", "wayfair", "kroger", "target"],
     "sports": ["garmin"],

--- a/getgather/mcp/mcp-tools.yaml
+++ b/getgather/mcp/mcp-tools.yaml
@@ -193,17 +193,6 @@
       url: https://www.chewy.com/app/account/orderhistory
       result_key: chewy_orders
 
-- id: cnn
-  name: CNN MCP
-  tools:
-    - function_name: get_latest_stories
-      description: Get the latest stories from CNN.
-      url: https://lite.cnn.com
-      pattern_wildcard: "**/cnn-*.html"
-      result_key: stories
-      hostname: cnn.com
-      short_lived: true
-
 - id: containerstore
   name: Container Store MCP
   tools:
@@ -237,17 +226,6 @@
       description: Get the list of items in the cart from Ebay
       url: https://cart.ebay.com/
       result_key: ebay_cart
-
-- id: espn
-  name: ESPN MCP
-  tools:
-    - function_name: get_schedule
-      description: Get the week's college football schedule from ESPN.
-      url: https://www.espn.com/college-football/schedule
-      pattern_wildcard: "**/espn-*.html"
-      result_key: college_football_schedule
-      hostname: espn.com
-      short_lived: true
 
 - id: expedia
   name: Expedia MCP
@@ -297,17 +275,6 @@
       description: Get the list of activity from Google
       url: https://myactivity.google.com/myactivity
       result_key: google_activity
-
-- id: groundnews
-  name: Ground News MCP
-  tools:
-    - function_name: get_stories
-      description: Get the latest news stories from Ground News.
-      url: https://ground.news
-      pattern_wildcard: "**/groundnews-*.html"
-      result_key: stories
-      hostname: ground.news
-      short_lived: true
 
 - id: hardcover
   name: Hardcover MCP
@@ -455,28 +422,6 @@
   tools:
     - function_name: get_order_history
       description: Get the details of an order from Nordstrom.
-
-- id: npr
-  name: NPR MCP
-  tools:
-    - function_name: get_headlines
-      description: Get the current news headlines from NPR.
-      url: https://text.npr.org
-      pattern_wildcard: "**/npr-*.html"
-      result_key: headlines
-      hostname: npr.org
-      short_lived: true
-
-- id: nytimes
-  name: NYTimes MCP
-  tools:
-    - function_name: get_bestsellers_list
-      description: Get the bestsellers list from NY Times.
-      url: https://www.nytimes.com/books/best-sellers/
-      pattern_wildcard: "**/nytimes-*.html"
-      result_key: best_sellers
-      hostname: nytimes.com
-      short_lived: true
 
 - id: petsmart
   name: Petsmart MCP

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import os
 import re
 import urllib.parse
 from copy import deepcopy
@@ -9,7 +8,6 @@ from datetime import datetime
 from glob import glob
 from pathlib import Path
 from typing import Any, Callable, Coroutine, cast
-from urllib.parse import urlunparse
 
 import sentry_sdk
 import zendriver as zd
@@ -19,15 +17,13 @@ from loguru import logger
 from nanoid import generate
 
 from getgather.browser import (
-    create_remote_browser,
     get_new_page,
     page_batch_extract,
     page_query_selector,
-    terminate_remote_browser,
     wait_for_ready_state,
     zen_navigate_with_retry,
 )
-from getgather.config import FRIENDLY_CHARS, settings
+from getgather.config import settings
 
 
 @dataclass
@@ -606,42 +602,3 @@ async def run_distillation_loop(
             iteration=max,
         )
     return (False, current.distilled, None)
-
-
-async def short_lived_mcp_tool(
-    location: str,
-    pattern_wildcard: str,
-    result_key: str,
-    url_hostname: str,
-    timeout: int = 15,
-) -> tuple[bool, dict[str, Any]]:
-    browser = await create_remote_browser(browser_id=generate(FRIENDLY_CHARS, 6))
-
-    path = os.path.join(os.path.dirname(__file__), "mcp", "patterns", pattern_wildcard)
-    patterns = load_distillation_patterns(path)
-    try:
-        terminated, distilled, converted = await run_distillation_loop(
-            location=location, patterns=patterns, browser=browser, timeout=timeout
-        )
-    finally:
-        await terminate_remote_browser(browser)
-
-    result: dict[str, Any] = {result_key: converted if converted else distilled}
-    if result_key in result:
-        items_value = result[result_key]
-        if isinstance(items_value, list):
-            for item in cast(list[dict[str, Any]], items_value):
-                if "link" in item:
-                    link = cast(str, item["link"])
-                    parsed = urllib.parse.urlparse(link)
-                    netloc: str = parsed.netloc if parsed.netloc else url_hostname
-                    url: str = urlunparse((
-                        "https",
-                        netloc,
-                        parsed.path,
-                        parsed.params,
-                        parsed.query,
-                        parsed.fragment,
-                    ))
-                    item["url"] = url
-    return terminated, result


### PR DESCRIPTION
The tool is no longer needed since the new patterns and (page) distillation REST API can fully replace it. Headline Hub has already migrated to that approach and no longer relies on the MCP tool.

Verified by launching Remote Browser, then pointing Headline Hub at this instance, and confirming Headline Hub continues to work as expected.