### PR TITLE
ci: remove extended-health check from simulated Chrome Fleet readiness probe

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -82,10 +82,6 @@ jobs:
         run: while ! curl -s 'http://localhost:8300/health' | grep 'OK'; do sleep 1; done
         timeout-minutes: 3
 
-      - name: Run the extended health check validation
-        run: while ! curl -s 'http://localhost:8300/extended-health' | grep 'OK'; do sleep 1; done
-        timeout-minutes: 3
-
       - uses: remotebrowser/shared-github-actions/container-health-check@v1
         with:
           image-name: remotebrowser


### PR DESCRIPTION
## Summary

- **`.github/workflows/container.yml`** — removed the `Run the extended health check validation` step from the `external` job (port 8300 readiness probe)

## Why

<img width="791" height="220" alt="image" src="https://github.com/user-attachments/assets/3b1b239c-8909-4e22-bbb3-98537a6260c2" />

PR #1368 removed `short_lived_mcp_tool`, which was the function that made `/extended-health` succeed when the wheel runs without `CHROMEFLEET_URL`. Without it, `extended_health` calls `create_remote_browser()` which connects via CDP to `ws://127.0.0.1:8300/cdp/...` — this path is unreliable under CI's podman backend and always returns `Error: ...`. The `grep 'OK'` loop never exits, causing a 3-minute timeout.

The step was never meaningful in this context anyway: the wheel at port 8300 acts as the **Chrome Fleet backend**, not as a getgather consumer. The real extended-health test already runs in the `container-health-check` step against the getgather container at port 23456 with `CHROMEFLEET_URL=http://localhost:8300` properly configured.
