### PR TITLE
Allow creating a browser with an auto-generated id

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Follow the MCP install [guide](https://code.visualstudio.com/docs/copilot/chat/m
 
 ### Start a new browser
 
-`POST /api/v1/browsers/{browser_id}` creates a new browser with the specified `browser_id`. The browser runs in a container.
+`POST /api/v1/browsers/{browser_id}` creates a new browser with the specified `browser_id`. The browser runs in a container. If the `browser_id` is omitted, `POST /api/v1/browsers` creates a new browser with an automatically generated name.
 
 _Example_: `curl -X POST localhost:8300/api/v1/browsers/xyz123` creates a container named `chromium-xyz123` and returns:
 

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -9,9 +9,11 @@ from fastapi import APIRouter, HTTPException, Request, WebSocket, WebSocketDisco
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.websockets import WebSocketState
 from loguru import logger
+from nanoid import generate
 from websockets.exceptions import ConnectionClosed
 
 from getgather.browsers.backend import Backend, BrowserNotFound, create_backend
+from getgather.config import FRIENDLY_CHARS
 
 router = APIRouter()
 
@@ -205,6 +207,22 @@ async def websocket_proxy(
         logger.error(f"[CDP] Unexpected error: {type(e).__name__}: {e}")
         if client_ws.client_state == WebSocketState.CONNECTED:
             await client_ws.close(code=4500, reason="Internal proxy error")
+
+
+@router.post("/api/v1/browsers")
+async def create_browser_auto(request: Request) -> dict[str, Any]:
+    browser_id = "B" + generate(FRIENDLY_CHARS, 8)
+    logger.info(f"Starting browser {browser_id}...")
+    try:
+        origin_ip = request.headers.get("x-origin-ip")
+        target_domain = request.headers.get("x-target-domains")
+        result = await backend.create_browser(browser_id, origin_ip, target_domain)
+        logger.info(f"Browser {browser_id} is started.")
+        return {"browser_id": browser_id, **result}
+    except Exception as e:
+        detail = f"Unable to start browser {browser_id}!"
+        logger.error(f"{detail} Exception={e}")
+        raise HTTPException(status_code=500, detail=detail)
 
 
 @router.post("/api/v1/browsers/{browser_id}")

--- a/tests/test_browser_backend.py
+++ b/tests/test_browser_backend.py
@@ -1,6 +1,7 @@
 from pytest import MonkeyPatch
 
 from getgather.browser import _setup_cdp_url  # pyright: ignore[reportPrivateUsage]
+from getgather.browsers import router as browsers_router
 from getgather.browsers.backend import create_backend
 from getgather.browsers.fleet_browsers import FleetBackend
 from getgather.browsers.podman_browsers import PodmanBackend
@@ -37,3 +38,28 @@ def test_fleet_relay_url_matches_internal_cdp_url(monkeypatch: MonkeyPatch) -> N
 def test_local_backend_opts_out_of_relay() -> None:
     # None signals the router to use the per-browser /json/version flow instead of a relay.
     assert PodmanBackend().cdp_websocket_base() is None
+
+
+def test_create_browser_auto_name_starts_with_b(monkeypatch: MonkeyPatch) -> None:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    async def fake_create_browser(
+        browser_id: str, origin_ip: str | None, target_domain: str | None
+    ):
+        return {
+            "container_name": f"chromium-{browser_id}",
+            "status": "created",
+            "ip": "1.2.3.4",
+        }
+
+    monkeypatch.setattr(browsers_router.backend, "create_browser", fake_create_browser)
+
+    app = FastAPI()
+    app.include_router(browsers_router.router)
+    client = TestClient(app)
+
+    response = client.post("/api/v1/browsers")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["browser_id"].startswith("B")


### PR DESCRIPTION
When the browser id is omitted, the server generates one automatically. This is convenient for certain clients that consume Remote Browser, since they no longer need to pick a unique id themselves.

Example:

```bash
$ curl -X POST http://localhost:23456/api/v1/browsers
{"browser_id":"Bi8rzsq9u","container_name":"chromium-Bi8rzsq9u",
"status":"created","ip":"73.158.108.127"}
```