### PR TITLE
feat(captcha): add logging for triggered captcha type

### DIFF
--- a/getgather/captcha_classifier.js
+++ b/getgather/captcha_classifier.js
@@ -1,0 +1,62 @@
+(() => {
+  try {
+    const has = (sel) => {
+      try {
+        return !!document.querySelector(sel);
+      } catch (e) {
+        return false;
+      }
+    };
+    const srcs = [];
+    document.querySelectorAll("script[src], iframe[src], link[href]").forEach((el) => {
+      const v = el.getAttribute("src") || el.getAttribute("href") || "";
+      if (v) srcs.push(v);
+    });
+    let html = "";
+    try {
+      html = document.documentElement.outerHTML;
+    } catch (e) {}
+    const hay = (srcs.join(" ") + " " + html).toLowerCase();
+
+    if (
+      hay.includes("awswaf.com") ||
+      hay.includes("awswafintegration") ||
+      hay.includes("awswafcaptcha")
+    )
+      return "aws_waf";
+    if (
+      hay.includes("arkoselabs.com") ||
+      hay.includes("funcaptcha.com") ||
+      has("iframe[title='verification puzzle']") ||
+      has("#cvf-aamation-challenge-iframe")
+    )
+      return "arkose_funcaptcha";
+    if (hay.includes("hcaptcha.com") || has(".h-captcha") || has('iframe[src*="hcaptcha"]'))
+      return "hcaptcha";
+    if (hay.includes("recaptcha/enterprise")) return "recaptcha_enterprise";
+    if (/recaptcha\/api\.js\?[^\s"']*render=/.test(hay)) return "recaptcha_v3";
+    if (
+      hay.includes("recaptcha/api2") ||
+      has(".g-recaptcha") ||
+      has('iframe[src*="recaptcha"]') ||
+      hay.includes("google.com/recaptcha")
+    )
+      return "recaptcha_v2";
+    if (
+      hay.includes("challenges.cloudflare.com") ||
+      has(".cf-turnstile") ||
+      hay.includes("__cf_chl") ||
+      hay.includes("cf-challenge") ||
+      hay.includes("turnstile")
+    )
+      return "cloudflare";
+    if (hay.includes("geetest") || has('[class^="geetest_"]')) return "geetest";
+    if (hay.includes("mtcaptcha")) return "mtcaptcha";
+    if (has("#captchacharacters") || has('img[src*="captcha"]')) return "image_ocr";
+    if (has("#px-captcha") || has(".px-captcha-header") || has('[id^="px-captcha"]'))
+      return "perimeterx";
+    return "unknown";
+  } catch (e) {
+    return "unknown";
+  }
+})();

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -39,6 +39,7 @@ from getgather.zen_distill import (
     get_selector,
     load_distillation_patterns,
     make_error_reporter,
+    report_captcha,
     run_distillation_loop,
     terminate,
     zen_report_distill_error,
@@ -395,6 +396,11 @@ async def distill_post_loop(
                     f"Distillation reported page error pattern; sign-in still marked complete for polling. Pattern name: {match.name}"
                 )
                 options["error_code"] = error
+                captcha_type = await report_captcha(
+                    page, error_code=error, pattern_name=match.name, hostname=hostname or ""
+                )
+                if captcha_type is not None:
+                    options["captcha_type"] = captcha_type
 
             return HTMLResponse(render(FINISHED_MSG, options))
 

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -396,11 +396,10 @@ async def distill_post_loop(
                     f"Distillation reported page error pattern; sign-in still marked complete for polling. Pattern name: {match.name}"
                 )
                 options["error_code"] = error
-                captcha_type = await report_captcha(
-                    page, error_code=error, pattern_name=match.name, hostname=hostname or ""
-                )
-                if captcha_type is not None:
-                    options["captcha_type"] = captcha_type
+                if error == "captcha":
+                    options["captcha_type"] = await report_captcha(
+                        page, pattern_name=match.name, hostname=hostname or ""
+                    )
 
             return HTMLResponse(render(FINISHED_MSG, options))
 

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -192,36 +192,7 @@ async def get_error(distilled: str) -> str | None:
     return None
 
 
-CAPTCHA_CLASSIFIER_JS = r"""
-(() => {
-  try {
-    const has = (sel) => { try { return !!document.querySelector(sel); } catch (e) { return false; } };
-    const srcs = [];
-    document.querySelectorAll('script[src], iframe[src], link[href]').forEach((el) => {
-      const v = el.getAttribute('src') || el.getAttribute('href') || '';
-      if (v) srcs.push(v);
-    });
-    let html = '';
-    try { html = document.documentElement.outerHTML; } catch (e) {}
-    const hay = (srcs.join(' ') + ' ' + html).toLowerCase();
-
-    if (hay.includes('awswaf.com') || hay.includes('awswafintegration') || hay.includes('awswafcaptcha')) return 'aws_waf';
-    if (hay.includes('arkoselabs.com') || hay.includes('funcaptcha.com') || has("iframe[title='verification puzzle']") || has('#cvf-aamation-challenge-iframe')) return 'arkose_funcaptcha';
-    if (hay.includes('hcaptcha.com') || has('.h-captcha') || has('iframe[src*="hcaptcha"]')) return 'hcaptcha';
-    if (hay.includes('recaptcha/enterprise')) return 'recaptcha_enterprise';
-    if (/recaptcha\/api\.js\?[^\s"']*render=/.test(hay)) return 'recaptcha_v3';
-    if (hay.includes('recaptcha/api2') || has('.g-recaptcha') || has('iframe[src*="recaptcha"]') || hay.includes('google.com/recaptcha')) return 'recaptcha_v2';
-    if (hay.includes('challenges.cloudflare.com') || has('.cf-turnstile') || hay.includes('__cf_chl') || hay.includes('cf-challenge') || hay.includes('turnstile')) return 'cloudflare';
-    if (hay.includes('geetest') || has('[class^="geetest_"]')) return 'geetest';
-    if (hay.includes('mtcaptcha')) return 'mtcaptcha';
-    if (has('#captchacharacters') || has('img[src*="captcha"]')) return 'image_ocr';
-    if (has('#px-captcha') || has('.px-captcha-header') || has('[id^="px-captcha"]')) return 'perimeterx';
-    return 'unknown';
-  } catch (e) {
-    return 'unknown';
-  }
-})()
-"""
+CAPTCHA_CLASSIFIER_JS = (Path(__file__).parent / "captcha_classifier.js").read_text()
 
 
 async def classify_captcha(page: zd.Tab) -> str:

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -9,6 +9,7 @@ from glob import glob
 from pathlib import Path
 from typing import Any, Callable, Coroutine, cast
 
+import logfire
 import sentry_sdk
 import zendriver as zd
 from bs4 import BeautifulSoup
@@ -189,6 +190,76 @@ async def get_error(distilled: str) -> str | None:
         if isinstance(error_value, str):
             return error_value
     return None
+
+
+CAPTCHA_CLASSIFIER_JS = r"""
+(() => {
+  try {
+    const has = (sel) => { try { return !!document.querySelector(sel); } catch (e) { return false; } };
+    const srcs = [];
+    document.querySelectorAll('script[src], iframe[src], link[href]').forEach((el) => {
+      const v = el.getAttribute('src') || el.getAttribute('href') || '';
+      if (v) srcs.push(v);
+    });
+    let html = '';
+    try { html = document.documentElement.outerHTML; } catch (e) {}
+    const hay = (srcs.join(' ') + ' ' + html).toLowerCase();
+
+    if (hay.includes('awswaf.com') || hay.includes('awswafintegration') || hay.includes('awswafcaptcha')) return 'aws_waf';
+    if (hay.includes('arkoselabs.com') || hay.includes('funcaptcha.com') || has("iframe[title='verification puzzle']") || has('#cvf-aamation-challenge-iframe')) return 'arkose_funcaptcha';
+    if (hay.includes('hcaptcha.com') || has('.h-captcha') || has('iframe[src*="hcaptcha"]')) return 'hcaptcha';
+    if (hay.includes('recaptcha/enterprise')) return 'recaptcha_enterprise';
+    if (/recaptcha\/api\.js\?[^\s"']*render=/.test(hay)) return 'recaptcha_v3';
+    if (hay.includes('recaptcha/api2') || has('.g-recaptcha') || has('iframe[src*="recaptcha"]') || hay.includes('google.com/recaptcha')) return 'recaptcha_v2';
+    if (hay.includes('challenges.cloudflare.com') || has('.cf-turnstile') || hay.includes('__cf_chl') || hay.includes('cf-challenge') || hay.includes('turnstile')) return 'cloudflare';
+    if (hay.includes('geetest') || has('[class^="geetest_"]')) return 'geetest';
+    if (hay.includes('mtcaptcha')) return 'mtcaptcha';
+    if (has('#captchacharacters') || has('img[src*="captcha"]')) return 'image_ocr';
+    if (has('#px-captcha') || has('.px-captcha-header') || has('[id^="px-captcha"]')) return 'perimeterx';
+    return 'unknown';
+  } catch (e) {
+    return 'unknown';
+  }
+})()
+"""
+
+
+async def classify_captcha(page: zd.Tab) -> str:
+    """Sniff the live page for a known CAPTCHA vendor fingerprint.
+
+    Returns a type slug (e.g. "aws_waf", "recaptcha_v2", "image_ocr") or
+    "unknown" if no signature matched or the probe failed.
+    """
+    try:
+        result = await page.evaluate(CAPTCHA_CLASSIFIER_JS)
+        if isinstance(result, str) and result:
+            return result
+    except Exception as error:
+        logger.warning(f"Captcha classification failed: {error}")
+    return "unknown"
+
+
+async def report_captcha(
+    page: zd.Tab, *, error_code: str | None, pattern_name: str, hostname: str
+) -> str | None:
+    """Classify and record a CAPTCHA encounter for per-type analytics.
+
+    No-op unless the terminating pattern error is "captcha". Emits a Logfire
+    event (when a token is configured) so encounters can be counted by
+    `captcha_type`. Returns the classified type, or None when not a captcha.
+    """
+    if error_code != "captcha":
+        return None
+    captcha_type = await classify_captcha(page)
+    logger.info(f"Captcha detected: type={captcha_type} hostname={hostname} pattern={pattern_name}")
+    if settings.LOGFIRE_TOKEN:
+        logfire.info(
+            "captcha detected",
+            captcha_type=captcha_type,
+            hostname=hostname,
+            pattern=pattern_name,
+        )
+    return captcha_type
 
 
 def load_distillation_patterns(path: str) -> list[Pattern]:
@@ -583,6 +654,10 @@ async def run_distillation_loop(
                 current = match
 
                 if await terminate(distilled):
+                    error_code = await get_error(distilled)
+                    await report_captcha(
+                        page, error_code=error_code, pattern_name=match.name, hostname=hostname
+                    )
                     converted = await convert(distilled, pattern_path=match.name)
                     return (True, distilled, converted)
 

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -239,17 +239,13 @@ async def classify_captcha(page: zd.Tab) -> str:
     return "unknown"
 
 
-async def report_captcha(
-    page: zd.Tab, *, error_code: str | None, pattern_name: str, hostname: str
-) -> str | None:
+async def report_captcha(page: zd.Tab, *, pattern_name: str, hostname: str) -> str:
     """Classify and record a CAPTCHA encounter for per-type analytics.
 
-    No-op unless the terminating pattern error is "captcha". Emits a Logfire
-    event (when a token is configured) so encounters can be counted by
-    `captcha_type`. Returns the classified type, or None when not a captcha.
+    Emits a Logfire event (when a token is configured) so encounters can be
+    counted by `captcha_type`. Returns the classified type. Callers should only
+    invoke this once they know the terminating pattern error is "captcha".
     """
-    if error_code != "captcha":
-        return None
     captcha_type = await classify_captcha(page)
     logger.info(f"Captcha detected: type={captcha_type} hostname={hostname} pattern={pattern_name}")
     if settings.LOGFIRE_TOKEN:
@@ -655,9 +651,8 @@ async def run_distillation_loop(
 
                 if await terminate(distilled):
                     error_code = await get_error(distilled)
-                    await report_captcha(
-                        page, error_code=error_code, pattern_name=match.name, hostname=hostname
-                    )
+                    if error_code == "captcha":
+                        await report_captcha(page, pattern_name=match.name, hostname=hostname)
                     converted = await convert(distilled, pattern_path=match.name)
                     return (True, distilled, converted)
 


### PR DESCRIPTION
## Why

Determining which captcha hit the most lets us focus solver effort on the captchas that actually block us the most.

## How
When a captcha stop pattern fires, sniff the live DOM for each vendor's fingerprint (script/iframe URLs and known element ids) and emit the type to Logfire (`captcha detected` span with `captcha_type`/`hostname` / `pattern`).

### Counting in Logfire

```sql
select attributes->>'captcha_type' as type, count(*)
from records
where message = 'captcha detected'
group by type order by count(*) desc
```

## Tests

script to test

```
import asyncio, os
os.environ.setdefault("CHROMEFLEET_URL", "http://localhost:1")  # unused; satisfies config import
import zendriver as zd
from getgather.zen_distill import classify_captcha

BROWSER = "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser" 
DEMOS = {
    "recaptcha_v2": "https://www.google.com/recaptcha/api2/demo",
    "hcaptcha": "https://accounts.hcaptcha.com/demo",
    "cloudflare": "https://demo.turnstile.workers.dev/",
    "geetest": "https://www.geetest.com/en/demo",
    "aws_waf": "https://dcz1t9chpw9yt.cloudfront.net/image-captcha",
    "image_captcha": "https://dcz1t9chpw9yt.cloudfront.net/image-captcha"
}

async def main():
    for expected, url in DEMOS.items():
        browser = await zd.start(browser_executable_path=BROWSER, headless=True)
        try:
            page = await browser.get(url)
            await asyncio.sleep(7)  # let the widget inject its iframe
            got = await classify_captcha(page)
        finally:
            await browser.stop()
        print(f"[{'PASS' if got == expected else 'FAIL'}] {expected} -> {got}  {url}")

asyncio.run(main())
```



Ran `classify_captcha` against real challenge pages in a local Chromium (zendriver), one fresh browser per URL. 

| Expected       | Result | Page                                               |
| -------------- | ------ | -------------------------------------------------- |
| `recaptcha_v2` | PASS   | https://www.google.com/recaptcha/api2/demo         |
| `hcaptcha`     | PASS   | https://accounts.hcaptcha.com/demo                 |
| `cloudflare`   | PASS   | https://demo.turnstile.workers.dev/                |
| `geetest`      | PASS   | https://www.geetest.com/en/demo                    |
| `aws_waf`      | PASS   | https://dcz1t9chpw9yt.cloudfront.net/protected     |
| `image_captcha`    | PASS   | https://dcz1t9chpw9yt.cloudfront.net/image-captcha |