### PR TITLE
Refactor: extract find_match_elements helper in zen_distill

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -66,6 +66,18 @@ def get_selector(input_selector: str | None) -> tuple[str | None, str | None]:
     return match.group(2), match.group(1)
 
 
+def find_match_elements(pattern: BeautifulSoup) -> list[Tag]:
+    """Return elements carrying gg-match or gg-match-html, deduped in document order."""
+    seen: set[int] = set()
+    out: list[Tag] = []
+    for name in ("gg-match", "gg-match-html"):
+        for el in pattern.find_all(attrs={name: True}):
+            if isinstance(el, Tag) and id(el) not in seen:
+                seen.add(id(el))
+                out.append(el)
+    return out
+
+
 def extract_value(item: Tag, attribute: str | None = None) -> str:
     """Extract text or attribute value from a BeautifulSoup Tag."""
     if attribute:
@@ -353,9 +365,7 @@ async def distill(
 
         logger.debug(f"Checking {name} with priority {priority}")
 
-        targets = pattern.find_all(attrs={"gg-match": True}) + pattern.find_all(
-            attrs={"gg-match-html": True}
-        )
+        targets = find_match_elements(pattern)
         target_specs: list[dict[str, object]] = []
 
         for target in targets:

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -369,9 +369,6 @@ async def distill(
         target_specs: list[dict[str, object]] = []
 
         for target in targets:
-            if not isinstance(target, Tag):
-                continue
-
             html_attr = target.get("gg-match-html")
             selector, iframe_selector = get_selector(
                 str(html_attr if html_attr else target.get("gg-match"))


### PR DESCRIPTION
This prepares for a future large-scale refactoring that adds support for attribute prefixes other than `gg-*`.