### PR TITLE
Refactor: add get_match_attr helper for element match access

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -36,6 +36,7 @@ from getgather.zen_distill import (
     capture_page_artifacts,
     distill,
     get_error,
+    get_match_attr,
     get_selector,
     load_distillation_patterns,
     make_error_reporter,
@@ -435,7 +436,7 @@ async def distill_post_loop(
                     if not isinstance(radio, Tag):
                         logger.warning(f"No radio button found for group {name_str} value {value}")
                         continue
-                    rgm = radio.get("gg-match")
+                    rgm = get_match_attr(radio)
                     if not rgm:
                         continue
                     selector, frame_selector = get_selector(str(rgm))
@@ -457,7 +458,7 @@ async def distill_post_loop(
                     continue
 
                 expected_field_count += 1
-                gg_match = input.get("gg-match")
+                gg_match = get_match_attr(input)
                 selector, frame_selector = get_selector(
                     str(gg_match) if gg_match is not None else ""
                 )
@@ -501,7 +502,7 @@ async def distill_post_loop(
                                 continue
                             logger.info(f"Handling radio button group {name}")
                             logger.info(f"Using form data {name}={value}")
-                            radio_gg_match = str(radio.get("gg-match"))
+                            radio_gg_match = str(get_match_attr(radio))
                             selector, frame_selector = get_selector(radio_gg_match)
                             config = getattr(page, "element_config", None)
                             radio_element = await page_query_selector(
@@ -536,7 +537,7 @@ async def distill_post_loop(
 
         # Queue non-button auto-clicks so they can run in the same batch as field updates.
         for auto_click_target in document.select("[gg-autoclick]:not(button)"):
-            auto_click_selector, _ = get_selector(str(auto_click_target.get("gg-match")))
+            auto_click_selector, _ = get_selector(str(get_match_attr(auto_click_target)))
             if auto_click_selector:
                 pending_actions.append({
                     "key": f"click:auto:{len(pending_actions)}",
@@ -550,7 +551,7 @@ async def distill_post_loop(
             if len(names) > 0 and expected_field_count == len(names):
                 logger.info("Submitting form, all fields are filled...")
                 for submit_button in document.select(SUBMIT_BUTTON):
-                    submit_selector, _ = get_selector(str(submit_button.get("gg-match")))
+                    submit_selector, _ = get_selector(str(get_match_attr(submit_button)))
                     if submit_selector:
                         pending_actions.append({
                             "key": f"click:submit:{len(pending_actions)}",

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -66,6 +66,27 @@ def get_selector(input_selector: str | None) -> tuple[str | None, str | None]:
     return match.group(2), match.group(1)
 
 
+def _first_str(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        items = cast(list[Any], value)
+        for item in items:
+            if isinstance(item, str):
+                return item
+    return None
+
+
+def get_match_attr(el: Tag) -> str | None:
+    """Return the gg-match selector value, coerced to a single string."""
+    return _first_str(el.get("gg-match"))
+
+
+def get_match_html_attr(el: Tag) -> str | None:
+    """Return the gg-match-html selector value, coerced to a single string."""
+    return _first_str(el.get("gg-match-html"))
+
+
 def find_match_elements(pattern: BeautifulSoup) -> list[Tag]:
     """Return elements carrying gg-match or gg-match-html, deduped in document order."""
     seen: set[int] = set()
@@ -369,9 +390,9 @@ async def distill(
         target_specs: list[dict[str, object]] = []
 
         for target in targets:
-            html_attr = target.get("gg-match-html")
+            html_attr = get_match_html_attr(target)
             selector, iframe_selector = get_selector(
-                str(html_attr if html_attr else target.get("gg-match"))
+                str(html_attr if html_attr else get_match_attr(target))
             )
             if not selector:
                 continue
@@ -518,7 +539,7 @@ async def autoclick(page: zd.Tab, distilled: str, expr: str):
     document = BeautifulSoup(distilled, "html.parser")
     elements = document.select(expr)
     for el in elements:
-        selector, iframe_selector = get_selector(str(el.get("gg-match")))
+        selector, iframe_selector = get_selector(str(get_match_attr(el)))
         if selector:
             target = await page_query_selector(page, selector, iframe_selector=iframe_selector)
             if target:


### PR DESCRIPTION
Replace the repeated inline match (and HTML) lookup with a pair of small helpers, `get_match_attr` and `get_match_html_attr`.

Just like in PR #1377, this is to prepare for an upcoming larger refactoring to support for attribute prefixes other than `gg-*`.

To verify, launch Remote Browser and then Headline Hub/Page Turner pointing to it. Everything should still work as expected.