### PR TITLE
Migrate matching attributes to the rb-* prefix

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -78,20 +78,20 @@ def _first_str(value: Any) -> str | None:
 
 
 def get_match_attr(el: Tag) -> str | None:
-    """Return the gg-match selector value, coerced to a single string."""
-    return _first_str(el.get("gg-match"))
+    """Return the rb-match (or gg-match) selector value, coerced to a single string."""
+    return _first_str(el.get("rb-match")) or _first_str(el.get("gg-match"))
 
 
 def get_match_html_attr(el: Tag) -> str | None:
-    """Return the gg-match-html selector value, coerced to a single string."""
-    return _first_str(el.get("gg-match-html"))
+    """Return the rb-match-html (or gg-match-html) selector value, coerced to a single string."""
+    return _first_str(el.get("rb-match-html")) or _first_str(el.get("gg-match-html"))
 
 
 def find_match_elements(pattern: BeautifulSoup) -> list[Tag]:
-    """Return elements carrying gg-match or gg-match-html, deduped in document order."""
+    """Return elements carrying rb-match/rb-match-html (or gg-match/gg-match-html), deduped in document order."""
     seen: set[int] = set()
     out: list[Tag] = []
-    for name in ("gg-match", "gg-match-html"):
+    for name in ("rb-match", "rb-match-html", "gg-match", "gg-match-html"):
         for el in pattern.find_all(attrs={name: True}):
             if isinstance(el, Tag) and id(el) not in seen:
                 seen.add(id(el))

--- a/tests/distillation/patterns/acme_authentication_error.html
+++ b/tests/distillation/patterns/acme_authentication_error.html
@@ -4,7 +4,7 @@
   </head>
 
   <body>
-    <p gg-stop gg-match="p:has-text('Error Code: ACME_AUTH_ERROR_001')">
+    <p gg-stop rb-match="p:has-text('Error Code: ACME_AUTH_ERROR_001')">
       Error Code: ACME_AUTH_ERROR_001
     </p>
   </body>

--- a/tests/distillation/patterns/acme_email_and_password.html
+++ b/tests/distillation/patterns/acme_email_and_password.html
@@ -4,9 +4,9 @@
   </head>
 
   <body>
-    <h1 gg-match="h1">Login</h1>
-    <input name="email" type="email" placeholder="Email" gg-match="input[type=email]" />
-    <input name="password" type="password" placeholder="Password" gg-match="input[type=password]" />
-    <button gg-autoclick gg-match="button[type=submit]"></button>
+    <h1 rb-match="h1">Login</h1>
+    <input name="email" type="email" placeholder="Email" rb-match="input[type=email]" />
+    <input name="password" type="password" placeholder="Password" rb-match="input[type=password]" />
+    <button gg-autoclick rb-match="button[type=submit]"></button>
   </body>
 </html>

--- a/tests/distillation/patterns/acme_email_and_password_checkbox.html
+++ b/tests/distillation/patterns/acme_email_and_password_checkbox.html
@@ -4,10 +4,10 @@
   </head>
 
   <body>
-    <h1 gg-match="h1">Login</h1>
-    <input name="email" type="email" placeholder="Email" gg-match="input[type=email]" />
-    <input name="password" type="password" placeholder="Password" gg-match="input[type=password]" />
-    <input name="remember_me" type="checkbox" checked gg-match="input[type=checkbox]" />
-    <button gg-autoclick gg-match="button[type=submit]"></button>
+    <h1 rb-match="h1">Login</h1>
+    <input name="email" type="email" placeholder="Email" rb-match="input[type=email]" />
+    <input name="password" type="password" placeholder="Password" rb-match="input[type=password]" />
+    <input name="remember_me" type="checkbox" checked rb-match="input[type=checkbox]" />
+    <button gg-autoclick rb-match="button[type=submit]"></button>
   </body>
 </html>

--- a/tests/distillation/patterns/acme_email_only.html
+++ b/tests/distillation/patterns/acme_email_only.html
@@ -4,8 +4,8 @@
   </head>
 
   <body>
-    <h1 gg-match="h1">Login</h1>
-    <input name="email" type="email" placeholder="Email" gg-match="input[type=email]" />
-    <button gg-autoclick gg-match="button[type=submit]"></button>
+    <h1 rb-match="h1">Login</h1>
+    <input name="email" type="email" placeholder="Email" rb-match="input[type=email]" />
+    <button gg-autoclick rb-match="button[type=submit]"></button>
   </body>
 </html>

--- a/tests/distillation/patterns/acme_home_page.html
+++ b/tests/distillation/patterns/acme_home_page.html
@@ -4,8 +4,8 @@
   </head>
 
   <body>
-    <h1 gg-match="h1">ACME Corp</h1>
-    <a gg-match="a[href='/auth/email-and-password']">Email and Password</a>
-    <a gg-match="a[href='/auth/email-then-password']">Email then Password</a>
+    <h1 rb-match="h1">ACME Corp</h1>
+    <a rb-match="a[href='/auth/email-and-password']">Email and Password</a>
+    <a rb-match="a[href='/auth/email-then-password']">Email then Password</a>
   </body>
 </html>

--- a/tests/distillation/patterns/acme_login_success.html
+++ b/tests/distillation/patterns/acme_login_success.html
@@ -4,6 +4,6 @@
   </head>
 
   <body>
-    <h1 gg-stop gg-match-html="h1:has-text('Login successful!')"></h1>
+    <h1 gg-stop rb-match-html="h1:has-text('Login successful!')"></h1>
   </body>
 </html>

--- a/tests/distillation/patterns/acme_otp_only.html
+++ b/tests/distillation/patterns/acme_otp_only.html
@@ -4,8 +4,8 @@
   </head>
 
   <body>
-    <h1 gg-match="h1">Login</h1>
-    <input name="otp" type="text" placeholder="One-time Code" gg-match="input[type=text]" />
-    <button gg-autoclick gg-match="button[type=submit]"></button>
+    <h1 rb-match="h1">Login</h1>
+    <input name="otp" type="text" placeholder="One-time Code" rb-match="input[type=text]" />
+    <button gg-autoclick rb-match="button[type=submit]"></button>
   </body>
 </html>

--- a/tests/distillation/patterns/acme_password_only.html
+++ b/tests/distillation/patterns/acme_password_only.html
@@ -4,8 +4,8 @@
   </head>
 
   <body>
-    <h1 gg-match="h1">Login</h1>
-    <input name="password" type="password" placeholder="Password" gg-match="input[type=password]" />
-    <button gg-autoclick gg-match="button[type=submit]"></button>
+    <h1 rb-match="h1">Login</h1>
+    <input name="password" type="password" placeholder="Password" rb-match="input[type=password]" />
+    <button gg-autoclick rb-match="button[type=submit]"></button>
   </body>
 </html>

--- a/tests/distillation/patterns/acme_universal_error_test.html
+++ b/tests/distillation/patterns/acme_universal_error_test.html
@@ -4,7 +4,7 @@
   </head>
 
   <body>
-    <p gg-match="//p[contains(text(), 'Sign')]">Click 'Sign in' to continue</p>
-    <button gg-autoclick gg-match="button[type=submit]">Sign in</button>
+    <p rb-match="//p[contains(text(), 'Sign')]">Click 'Sign in' to continue</p>
+    <button gg-autoclick rb-match="button[type=submit]">Sign in</button>
   </body>
 </html>

--- a/tests/distillation/test_distill.py
+++ b/tests/distillation/test_distill.py
@@ -250,9 +250,9 @@ async def test_distill_uses_page_batch_extract(monkeypatch: MonkeyPatch):
         pattern=BeautifulSoup(
             """
             <html gg-priority="1">
-                <button gg-match="button.login"></button>
-                <div gg-match-html="//section[@data-role='content']"></div>
-                <input gg-match="iframe.auth input[name='email']" />
+                <button rb-match="button.login"></button>
+                <div rb-match-html="//section[@data-role='content']"></div>
+                <input rb-match="iframe.auth input[name='email']" />
             </html>
             """,
             "html.parser",
@@ -295,7 +295,7 @@ async def test_distill_rejects_pattern_when_required_batched_target_missing(
     pattern = Pattern(
         name="required-login.html",
         pattern=BeautifulSoup(
-            '<html gg-priority="1"><button gg-match="button.login"></button></html>',
+            '<html gg-priority="1"><button rb-match="button.login"></button></html>',
             "html.parser",
         ),
     )
@@ -346,8 +346,8 @@ async def test_distill_allows_optional_batched_target_to_be_missing(monkeypatch:
         pattern=BeautifulSoup(
             """
             <html gg-priority="1">
-                <button gg-match="button.login"></button>
-                <span gg-match=".helper" gg-optional></span>
+                <button rb-match="button.login"></button>
+                <span rb-match=".helper" gg-optional></span>
             </html>
             """,
             "html.parser",

--- a/tests/test_extractions.py
+++ b/tests/test_extractions.py
@@ -144,7 +144,7 @@ class TestGroundNews:
     <div
       gg-stop
       gg-convert="groundnews-latest-stories.json"
-      gg-match-html="[data-testid=latest-stories-homepage]"
+      rb-match-html="[data-testid=latest-stories-homepage]"
     ></div>
   </body>
 </html>
@@ -231,8 +231,8 @@ class TestCNN:
     <title>CNN Latest Stories</title>
   </head>
   <body>
-    <div gg-match="//p[@class='title' and contains(text(), 'Latest Stories')]"></div>
-    <div gg-stop gg-convert="cnn-latest-stories.json" gg-match-html="div[data-uri^=cms]"></div>
+    <div rb-match="//p[@class='title' and contains(text(), 'Latest Stories')]"></div>
+    <div gg-stop gg-convert="cnn-latest-stories.json" rb-match-html="div[data-uri^=cms]"></div>
   </body>
 </html>
 """
@@ -280,7 +280,7 @@ class TestCBC:
     <title>CBC Headlines</title>
   </head>
   <body>
-    <ul gg-stop gg-convert="cbc-headlines.json" gg-match-html="main ul"></ul>
+    <ul gg-stop gg-convert="cbc-headlines.json" rb-match-html="main ul"></ul>
   </body>
 </html>
 """
@@ -323,16 +323,16 @@ class TestCBC:
 def test_acme_login_email_password(client: httpx.Client, browser_ids: list[str]) -> None:
     acme_login_pattern = """<html gg-domain="acme">
   <body>
-    <h1 gg-match="h1">Login</h1>
-    <input name="email" type="email" placeholder="Email" gg-match="input[type=email]" />
-    <input name="password" type="password" placeholder="Password" gg-match="input[type=password]" />
-    <button gg-autoclick gg-match="button[type=submit]"></button>
+    <h1 rb-match="h1">Login</h1>
+    <input name="email" type="email" placeholder="Email" rb-match="input[type=email]" />
+    <input name="password" type="password" placeholder="Password" rb-match="input[type=password]" />
+    <button gg-autoclick rb-match="button[type=submit]"></button>
   </body>
 </html>
 """
     acme_success_pattern = """<html gg-domain="acme">
   <body>
-    <h1 gg-stop gg-match="//h1[contains(text(), 'successful')]">Success</h1>
+    <h1 gg-stop rb-match="//h1[contains(text(), 'successful')]">Success</h1>
   </body>
 </html>
 """


### PR DESCRIPTION
The deprecated `gg-match` and `gg-match-html` attributes remain supported during this transition.

For now, only the testing code has been updated to use `rb-match` and `rb-match-html`.