### PR TITLE
fix: target signin choose-method autoclick selector to otp

### DIFF
--- a/getgather/mcp/patterns/target-signin-choose-method.html
+++ b/getgather/mcp/patterns/target-signin-choose-method.html
@@ -3,6 +3,6 @@
     <title>Target Sign In - Choose Method</title>
   </head>
   <body>
-    <div gg-autoclick gg-match="div#password[role='button']"></div>
+    <div gg-autoclick gg-match="div#otp[role='button']"></div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- **`target-signin-choose-method.html`** — autoclick selector changed from `div#password[role='button']` to `div#otp[role='button']`

## Context
Password login isn't stable, often errors out. Sometimes even after entering password, still gets prompted for OTP. This change switches the sign-in method priority to OTP directly.