### PR TITLE
Migrate domain matching to rb-domain

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -87,6 +87,11 @@ def get_match_html_attr(el: Tag) -> str | None:
     return _first_str(el.get("rb-match-html")) or _first_str(el.get("gg-match-html"))
 
 
+def get_domain_attr(el: Tag) -> str | None:
+    """Return the rb-domain (or gg-domain) value, coerced to a single string."""
+    return _first_str(el.get("rb-domain")) or _first_str(el.get("gg-domain"))
+
+
 def find_match_elements(pattern: BeautifulSoup) -> list[Tag]:
     """Return elements carrying rb-match/rb-match-html (or gg-match/gg-match-html), deduped in document order."""
     seen: set[int] = set()
@@ -376,11 +381,11 @@ async def distill(
             priority = int(str(gg_priority).lstrip("= "))
         except ValueError:
             priority = -1
-        domain = root.get("gg-domain") if isinstance(root, Tag) else None
+        domain = get_domain_attr(root) if isinstance(root, Tag) else None
 
         if domain and hostname:
             local = "localhost" in hostname or "127.0.0.1" in hostname
-            if isinstance(domain, str) and not local and domain.lower() not in hostname.lower():
+            if not local and domain.lower() not in hostname.lower():
                 logger.trace(f"Skipping {name} due to mismatched domain {domain}")
                 continue
 

--- a/tests/distillation/patterns/acme_authentication_error.html
+++ b/tests/distillation/patterns/acme_authentication_error.html
@@ -1,4 +1,4 @@
-<html gg-domain="acme">
+<html rb-domain="acme">
   <head>
     <title>ACME Universal Error Test</title>
   </head>

--- a/tests/distillation/patterns/acme_email_and_password.html
+++ b/tests/distillation/patterns/acme_email_and_password.html
@@ -1,4 +1,4 @@
-<html gg-domain="acme" gg-priority="1">
+<html rb-domain="acme" gg-priority="1">
   <head>
     <title>ACME Email and Password</title>
   </head>

--- a/tests/distillation/patterns/acme_email_and_password_checkbox.html
+++ b/tests/distillation/patterns/acme_email_and_password_checkbox.html
@@ -1,4 +1,4 @@
-<html gg-domain="acme" gg-priority="0">
+<html rb-domain="acme" gg-priority="0">
   <head>
     <title>ACME Email and Password with Checkbox</title>
   </head>

--- a/tests/distillation/patterns/acme_email_only.html
+++ b/tests/distillation/patterns/acme_email_only.html
@@ -1,4 +1,4 @@
-<html gg-domain="acme" gg-priority="2">
+<html rb-domain="acme" gg-priority="2">
   <head>
     <title>ACME Email</title>
   </head>

--- a/tests/distillation/patterns/acme_home_page.html
+++ b/tests/distillation/patterns/acme_home_page.html
@@ -1,4 +1,4 @@
-<html gg-domain="acme">
+<html rb-domain="acme">
   <head>
     <title>ACME Home Page</title>
   </head>

--- a/tests/distillation/patterns/acme_otp_only.html
+++ b/tests/distillation/patterns/acme_otp_only.html
@@ -1,4 +1,4 @@
-<html gg-domain="acme" gg-priority="1">
+<html rb-domain="acme" gg-priority="1">
   <head>
     <title>ACME OTP</title>
   </head>

--- a/tests/distillation/patterns/acme_password_only.html
+++ b/tests/distillation/patterns/acme_password_only.html
@@ -1,4 +1,4 @@
-<html gg-domain="acme" gg-priority="2">
+<html rb-domain="acme" gg-priority="2">
   <head>
     <title>ACME Password</title>
   </head>

--- a/tests/distillation/patterns/acme_universal_error_test.html
+++ b/tests/distillation/patterns/acme_universal_error_test.html
@@ -1,4 +1,4 @@
-<html gg-domain="acme">
+<html rb-domain="acme">
   <head>
     <title>ACME Universal Error Test</title>
   </head>

--- a/tests/test_extractions.py
+++ b/tests/test_extractions.py
@@ -136,7 +136,7 @@ class TestNPR:
 class TestGroundNews:
     @pytest.fixture(autouse=True)
     def upload_groundnews_patterns(self, client: httpx.Client) -> Generator[None, None, None]:
-        html_content = """<html gg-domain="ground.news">
+        html_content = """<html rb-domain="ground.news">
   <head>
     <title>Ground News</title>
   </head>
@@ -226,7 +226,7 @@ class TestESPN:
 class TestCNN:
     @pytest.fixture(autouse=True)
     def upload_cnn_patterns(self, client: httpx.Client) -> Generator[None, None, None]:
-        html_content = """<html gg-domain="cnn">
+        html_content = """<html rb-domain="cnn">
   <head>
     <title>CNN Latest Stories</title>
   </head>
@@ -275,7 +275,7 @@ class TestCNN:
 class TestCBC:
     @pytest.fixture(autouse=True)
     def upload_cbc_patterns(self, client: httpx.Client) -> Generator[None, None, None]:
-        html_content = """<html gg-domain="cbc">
+        html_content = """<html rb-domain="cbc">
   <head>
     <title>CBC Headlines</title>
   </head>
@@ -321,7 +321,7 @@ class TestCBC:
 
 @pytest.mark.distill
 def test_acme_login_email_password(client: httpx.Client, browser_ids: list[str]) -> None:
-    acme_login_pattern = """<html gg-domain="acme">
+    acme_login_pattern = """<html rb-domain="acme">
   <body>
     <h1 rb-match="h1">Login</h1>
     <input name="email" type="email" placeholder="Email" rb-match="input[type=email]" />
@@ -330,7 +330,7 @@ def test_acme_login_email_password(client: httpx.Client, browser_ids: list[str])
   </body>
 </html>
 """
-    acme_success_pattern = """<html gg-domain="acme">
+    acme_success_pattern = """<html rb-domain="acme">
   <body>
     <h1 gg-stop rb-match="//h1[contains(text(), 'successful')]">Success</h1>
   </body>


### PR DESCRIPTION
The deprecated `gg-domain` remain supported, thought it's considered deprecated

For now, only the testing code has been updated.