### PR TITLE
Migrate convert attribute to rb-convert

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -92,6 +92,11 @@ def get_domain_attr(el: Tag) -> str | None:
     return _first_str(el.get("rb-domain")) or _first_str(el.get("gg-domain"))
 
 
+def get_convert_attr(el: Tag) -> str | None:
+    """Return the rb-convert (or gg-convert) value, coerced to a single string."""
+    return _first_str(el.get("rb-convert")) or _first_str(el.get("gg-convert"))
+
+
 def get_stop_attr(el: Tag) -> str | None:
     """Return the rb-stop (or gg-stop) value, coerced to a single string.
 
@@ -158,8 +163,8 @@ async def convert(distilled: str, pattern_path: str | None = None):
     if pattern_path:
         stops = find_stop_elements(document)
         for stop in stops:
-            gg_convert = stop.get("gg-convert")
-            if isinstance(gg_convert, str) and gg_convert.strip():
+            gg_convert = get_convert_attr(stop)
+            if gg_convert and gg_convert.strip():
                 pattern_dir = Path(pattern_path).parent
                 json_path = pattern_dir / gg_convert.strip()
                 logger.info(f"Loading converter from gg-convert: {json_path}")

--- a/tests/test_extractions.py
+++ b/tests/test_extractions.py
@@ -143,7 +143,7 @@ class TestGroundNews:
   <body>
     <div
       rb-stop
-      gg-convert="groundnews-latest-stories.json"
+      rb-convert="groundnews-latest-stories.json"
       rb-match-html="[data-testid=latest-stories-homepage]"
     ></div>
   </body>
@@ -232,7 +232,7 @@ class TestCNN:
   </head>
   <body>
     <div rb-match="//p[@class='title' and contains(text(), 'Latest Stories')]"></div>
-    <div rb-stop gg-convert="cnn-latest-stories.json" rb-match-html="div[data-uri^=cms]"></div>
+    <div rb-stop rb-convert="cnn-latest-stories.json" rb-match-html="div[data-uri^=cms]"></div>
   </body>
 </html>
 """
@@ -280,7 +280,7 @@ class TestCBC:
     <title>CBC Headlines</title>
   </head>
   <body>
-    <ul rb-stop gg-convert="cbc-headlines.json" rb-match-html="main ul"></ul>
+    <ul rb-stop rb-convert="cbc-headlines.json" rb-match-html="main ul"></ul>
   </body>
 </html>
 """


### PR DESCRIPTION
The deprecated attribute `gg-convert` is still supported.

Only the testing code has been migrated.