### PR TITLE
Migrate autoclick selector to rb-autoclick

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -544,7 +544,8 @@ async def distill_post_loop(
                         logger.info(f"No form data found for {name}")
 
         # Queue non-button auto-clicks so they can run in the same batch as field updates.
-        for auto_click_target in document.select("[gg-autoclick]:not(button)"):
+        AUTOCLICK_NON_BUTTON_SELECTOR = "[rb-autoclick]:not(button), [gg-autoclick]:not(button)"
+        for auto_click_target in document.select(AUTOCLICK_NON_BUTTON_SELECTOR):
             auto_click_selector, _ = get_selector(str(get_match_attr(auto_click_target)))
             if auto_click_selector:
                 pending_actions.append({
@@ -554,7 +555,7 @@ async def distill_post_loop(
                 })
 
         should_submit = False
-        SUBMIT_BUTTON = "button[gg-autoclick], button[type=submit]"
+        SUBMIT_BUTTON = "button[rb-autoclick], button[gg-autoclick], button[type=submit]"
         if document.select(SUBMIT_BUTTON):
             if len(names) > 0 and expected_field_count == len(names):
                 logger.info("Submitting form, all fields are filled...")

--- a/tests/distillation/patterns/acme_email_and_password.html
+++ b/tests/distillation/patterns/acme_email_and_password.html
@@ -7,6 +7,6 @@
     <h1 rb-match="h1">Login</h1>
     <input name="email" type="email" placeholder="Email" rb-match="input[type=email]" />
     <input name="password" type="password" placeholder="Password" rb-match="input[type=password]" />
-    <button gg-autoclick rb-match="button[type=submit]"></button>
+    <button rb-autoclick rb-match="button[type=submit]"></button>
   </body>
 </html>

--- a/tests/distillation/patterns/acme_email_and_password_checkbox.html
+++ b/tests/distillation/patterns/acme_email_and_password_checkbox.html
@@ -8,6 +8,6 @@
     <input name="email" type="email" placeholder="Email" rb-match="input[type=email]" />
     <input name="password" type="password" placeholder="Password" rb-match="input[type=password]" />
     <input name="remember_me" type="checkbox" checked rb-match="input[type=checkbox]" />
-    <button gg-autoclick rb-match="button[type=submit]"></button>
+    <button rb-autoclick rb-match="button[type=submit]"></button>
   </body>
 </html>

--- a/tests/distillation/patterns/acme_email_only.html
+++ b/tests/distillation/patterns/acme_email_only.html
@@ -6,6 +6,6 @@
   <body>
     <h1 rb-match="h1">Login</h1>
     <input name="email" type="email" placeholder="Email" rb-match="input[type=email]" />
-    <button gg-autoclick rb-match="button[type=submit]"></button>
+    <button rb-autoclick rb-match="button[type=submit]"></button>
   </body>
 </html>

--- a/tests/distillation/patterns/acme_otp_only.html
+++ b/tests/distillation/patterns/acme_otp_only.html
@@ -6,6 +6,6 @@
   <body>
     <h1 rb-match="h1">Login</h1>
     <input name="otp" type="text" placeholder="One-time Code" rb-match="input[type=text]" />
-    <button gg-autoclick rb-match="button[type=submit]"></button>
+    <button rb-autoclick rb-match="button[type=submit]"></button>
   </body>
 </html>

--- a/tests/distillation/patterns/acme_password_only.html
+++ b/tests/distillation/patterns/acme_password_only.html
@@ -6,6 +6,6 @@
   <body>
     <h1 rb-match="h1">Login</h1>
     <input name="password" type="password" placeholder="Password" rb-match="input[type=password]" />
-    <button gg-autoclick rb-match="button[type=submit]"></button>
+    <button rb-autoclick rb-match="button[type=submit]"></button>
   </body>
 </html>

--- a/tests/distillation/patterns/acme_universal_error_test.html
+++ b/tests/distillation/patterns/acme_universal_error_test.html
@@ -5,6 +5,6 @@
 
   <body>
     <p rb-match="//p[contains(text(), 'Sign')]">Click 'Sign in' to continue</p>
-    <button gg-autoclick rb-match="button[type=submit]">Sign in</button>
+    <button rb-autoclick rb-match="button[type=submit]">Sign in</button>
   </body>
 </html>

--- a/tests/test_extractions.py
+++ b/tests/test_extractions.py
@@ -326,7 +326,7 @@ def test_acme_login_email_password(client: httpx.Client, browser_ids: list[str])
     <h1 rb-match="h1">Login</h1>
     <input name="email" type="email" placeholder="Email" rb-match="input[type=email]" />
     <input name="password" type="password" placeholder="Password" rb-match="input[type=password]" />
-    <button gg-autoclick rb-match="button[type=submit]"></button>
+    <button rb-autoclick rb-match="button[type=submit]"></button>
   </body>
 </html>
 """


### PR DESCRIPTION
The deprecated attribute `gg-autoclick` is still supported.

Only the testing code has been migrated.