### PR TITLE
Migrate the optional flag to rb-optional

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -108,6 +108,17 @@ def get_stop_attr(el: Tag) -> str | None:
     return _first_str(el.get("gg-stop"))
 
 
+def get_optional_attr(el: Tag) -> str | None:
+    """Return the rb-optional (or gg-optional) value, coerced to a single string.
+
+    Like stop, optional is a flag (valueless when present), so presence is
+    checked via ``el.attrs`` rather than truthiness.
+    """
+    if "rb-optional" in el.attrs:
+        return _first_str(el.get("rb-optional"))
+    return _first_str(el.get("gg-optional"))
+
+
 def find_stop_elements(pattern: BeautifulSoup) -> list[Tag]:
     """Return elements carrying rb-stop (or gg-stop), deduped in document order."""
     seen: set[int] = set()
@@ -432,7 +443,7 @@ async def distill(
             is_html = html_attr is not None
             query_key = str(next_query_key)
             next_query_key += 1
-            optional = target.get("gg-optional") is not None
+            optional = get_optional_attr(target) is not None
 
             target_specs.append({
                 "target": target,

--- a/tests/distillation/test_distill.py
+++ b/tests/distillation/test_distill.py
@@ -347,7 +347,7 @@ async def test_distill_allows_optional_batched_target_to_be_missing(monkeypatch:
             """
             <html gg-priority="1">
                 <button rb-match="button.login"></button>
-                <span rb-match=".helper" gg-optional></span>
+                <span rb-match=".helper" rb-optional></span>
             </html>
             """,
             "html.parser",


### PR DESCRIPTION
The deprecated attribute `gg-optional` is still supported.

Only the testing code has been migrated.