### PR TITLE
Migrate the error attribute to rb-error

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -102,6 +102,11 @@ def get_convert_attr(el: Tag) -> str | None:
     return _first_str(el.get("rb-convert")) or _first_str(el.get("gg-convert"))
 
 
+def get_error_attr(el: Tag) -> str | None:
+    """Return the rb-error (or gg-error) value, coerced to a single string."""
+    return _first_str(el.get("rb-error")) or _first_str(el.get("gg-error"))
+
+
 def get_stop_attr(el: Tag) -> str | None:
     """Return the rb-stop (or gg-stop) value, coerced to a single string.
 
@@ -129,6 +134,18 @@ def find_stop_elements(pattern: BeautifulSoup) -> list[Tag]:
     seen: set[int] = set()
     out: list[Tag] = []
     for name in ("rb-stop", "gg-stop"):
+        for el in pattern.find_all(attrs={name: True}):
+            if isinstance(el, Tag) and id(el) not in seen:
+                seen.add(id(el))
+                out.append(el)
+    return out
+
+
+def find_error_elements(pattern: BeautifulSoup) -> list[Tag]:
+    """Return elements carrying rb-error (or gg-error), deduped in document order."""
+    seen: set[int] = set()
+    out: list[Tag] = []
+    for name in ("rb-error", "gg-error"):
         for el in pattern.find_all(attrs={name: True}):
             if isinstance(el, Tag) and id(el) not in seen:
                 seen.add(id(el))
@@ -263,11 +280,11 @@ async def terminate(distilled: str) -> bool:
 
 async def get_error(distilled: str) -> str | None:
     document = BeautifulSoup(distilled, "html.parser")
-    error_element = document.find(attrs={"gg-error": True})
-    if error_element and isinstance(error_element, Tag):
-        error_value = error_element.get("gg-error")
-        logger.info(f"Found error element: {error_value}")
-        if isinstance(error_value, str):
+    error_elements = find_error_elements(document)
+    for error_element in error_elements:
+        error_value = get_error_attr(error_element)
+        if error_value:
+            logger.info(f"Found error element: {error_value}")
             return error_value
     return None
 

--- a/tests/distillation/patterns/acme_authentication_error.html
+++ b/tests/distillation/patterns/acme_authentication_error.html
@@ -4,7 +4,7 @@
   </head>
 
   <body>
-    <p rb-stop rb-match="p:has-text('Error Code: ACME_AUTH_ERROR_001')">
+    <p rb-stop rb-error="auth_error" rb-match="p:has-text('Error Code: ACME_AUTH_ERROR_001')">
       Error Code: ACME_AUTH_ERROR_001
     </p>
   </body>

--- a/tests/distillation/test_distill.py
+++ b/tests/distillation/test_distill.py
@@ -25,6 +25,7 @@ from getgather.config import FRIENDLY_CHARS, settings
 from getgather.zen_distill import (
     Pattern,
     distill,
+    get_error,
     load_distillation_patterns,
     make_error_reporter,
     run_distillation_loop,
@@ -191,6 +192,32 @@ async def test_page_batch_extract_falls_back_to_none_on_invalid_result():
 
     assert result is None
     assert len(page.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_error_returns_rb_error_value():
+    distilled = '<html><body><div rb-stop rb-error="captcha"></div></body></html>'
+    assert await get_error(distilled) == "captcha"
+
+
+@pytest.mark.asyncio
+async def test_get_error_falls_back_to_gg_error():
+    distilled = '<html><body><div gg-stop gg-error="signin_error"></div></body></html>'
+    assert await get_error(distilled) == "signin_error"
+
+
+@pytest.mark.asyncio
+async def test_get_error_prefers_rb_error_over_gg_error():
+    distilled = (
+        '<html><body><div rb-stop rb-error="new_code" gg-error="old_code"></div></body></html>'
+    )
+    assert await get_error(distilled) == "new_code"
+
+
+@pytest.mark.asyncio
+async def test_get_error_returns_none_without_error_attr():
+    distilled = '<html><body><div rb-stop rb-match="h1"></div></body></html>'
+    assert await get_error(distilled) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The deprecated attribute `gg-error` is still supported.

Only the testing code has been migrated.