### PR TITLE
Skip browsing-history rows missing a url instead of crashing

### DIFF
--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -265,7 +265,9 @@ async def get_browsing_history() -> dict[str, Any]:
                     f"Converted batch {start_index}-{end_index}: found {len(converted)} items"
                 )
                 for item in converted:
-                    item["url"] = f"https://www.amazon.com{item['url']}"
+                    url = item.get("url")
+                    if url:
+                        item["url"] = f"https://www.amazon.com{url}"
             else:
                 logger.warning(f"Conversion returned None for batch {start_index}-{end_index}")
             return converted
@@ -434,7 +436,9 @@ async def remote_get_browsing_history() -> dict[str, Any]:
                     f"Converted batch {start_index}-{end_index}: found {len(converted)} items"
                 )
                 for item in converted:
-                    item["url"] = f"https://www.amazon.com{item['url']}"
+                    url = item.get("url")
+                    if url:
+                        item["url"] = f"https://www.amazon.com{url}"
             else:
                 logger.warning(f"Conversion returned None for batch {start_index}-{end_index}")
             return converted

--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -265,9 +265,7 @@ async def get_browsing_history() -> dict[str, Any]:
                     f"Converted batch {start_index}-{end_index}: found {len(converted)} items"
                 )
                 for item in converted:
-                    url = item.get("url")
-                    if url:
-                        item["url"] = f"https://www.amazon.com{url}"
+                    item["url"] = f"https://www.amazon.com{item.get('url', '')}"
             else:
                 logger.warning(f"Conversion returned None for batch {start_index}-{end_index}")
             return converted
@@ -436,9 +434,7 @@ async def remote_get_browsing_history() -> dict[str, Any]:
                     f"Converted batch {start_index}-{end_index}: found {len(converted)} items"
                 )
                 for item in converted:
-                    url = item.get("url")
-                    if url:
-                        item["url"] = f"https://www.amazon.com{url}"
+                    item["url"] = f"https://www.amazon.com{item.get('url', '')}"
             else:
                 logger.warning(f"Conversion returned None for batch {start_index}-{end_index}")
             return converted


### PR DESCRIPTION
## Problem

Amazon `get_browsing_history` extracted data fine (e.g. 283 items across 3 batches in prod trace), then crashed on post-processing:

```python
item["url"] = f"https://www.amazon.com{item['url']}"
```

A row without the `url` selector (ad / alt layout) raises `KeyError: 'url'`. That exception is swallowed by `zen_dpage_with_action`'s broad `except Exception`, which **discards all fetched items** and falls through to the interactive sign-in builder — returning a `dpage` sign-in URL even though the browser was signed in. The client then sees no data → phantom **401**.

## Fix

Guard the lookup so url-less rows keep their other fields instead of taking down the whole batch:

```python
for item in converted:
    url = item.get("url")
    if url:
        item["url"] = f"https://www.amazon.com{url}"
```

Applied to both the local and remote `get_browsing_history` paths.

## Notes

Deeper latent issue remains: the broad `except Exception` in `zen_dpage_with_action` masks *any* post-success error as "not signed in." This PR removes the current trigger; narrowing that except can be a follow-up.

Base: `local-amazon`.