### PR TITLE
Attach screenshot + HTML to Sentry on no-pattern-match 502

### DIFF
--- a/getgather/cdp_client.py
+++ b/getgather/cdp_client.py
@@ -185,14 +185,23 @@ class CDPPage:
             return str(html) if html is not None else ""
         return html
 
-    async def screenshot(self) -> bytes:
-        """Capture a full-page PNG screenshot and return the raw bytes."""
+    async def screenshot(self, *, full_page: bool = True) -> bytes:
+        """Capture a PNG screenshot and return the raw bytes."""
         result = await self._client.send(
             "Page.captureScreenshot",
-            {"format": "png", "captureBeyondViewport": True},
+            {"format": "png", "captureBeyondViewport": full_page},
             session_id=self._session_id,
         )
         data = result.get("data")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
         if not isinstance(data, str):
             raise CDPError("Page.captureScreenshot returned no image data")
         return base64.b64decode(data)
+
+    async def save_screenshot(self, filename: str, full_page: bool = True) -> str:
+        """Capture a screenshot and write it to `filename`. Mirrors the
+        zendriver `Tab.save_screenshot` signature so both page types work with
+        `capture_page_artifacts`."""
+        data = await self.screenshot(full_page=full_page)
+        with open(filename, "wb") as f:
+            f.write(data)
+        return filename

--- a/getgather/cdp_client.py
+++ b/getgather/cdp_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import json
 from typing import Any, cast
 
@@ -176,3 +177,22 @@ class CDPPage:
         if isinstance(remote_result, dict):
             return remote_result.get("value")  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType, reportUnknownVariableType]
         return None
+
+    async def get_content(self) -> str:
+        """Return the full outer HTML of the page."""
+        html = await self.evaluate("document.documentElement.outerHTML")
+        if not isinstance(html, str):
+            return str(html) if html is not None else ""
+        return html
+
+    async def screenshot(self) -> bytes:
+        """Capture a full-page PNG screenshot and return the raw bytes."""
+        result = await self._client.send(
+            "Page.captureScreenshot",
+            {"format": "png", "captureBeyondViewport": True},
+            session_id=self._session_id,
+        )
+        data = result.get("data")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+        if not isinstance(data, str):
+            raise CDPError("Page.captureScreenshot returned no image data")
+        return base64.b64decode(data)

--- a/getgather/pages_api_router.py
+++ b/getgather/pages_api_router.py
@@ -2,17 +2,59 @@ import os
 import urllib.parse
 from typing import Any
 
+import sentry_sdk
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from loguru import logger
 
 from getgather.browser import find_browser_tab, get_remote_browser
 from getgather.browsers.router import strip_browser_id_from_target_id
-from getgather.cdp_client import PageNotFoundError, open_cdp
+from getgather.cdp_client import CDPPage, PageNotFoundError, open_cdp
+from getgather.config import settings
 from getgather.mcp.dpage import distill_post_loop
 from getgather.zen_distill import convert, distill, load_distillation_patterns
 
 router = APIRouter()
+
+
+async def report_no_pattern_match(
+    *,
+    error: Exception,
+    page: CDPPage,
+    browser_id: str,
+    hostname: str,
+    current_url: str,
+) -> None:
+    """Attach a screenshot + HTML of the page to Sentry when no distillation
+    pattern matches, so the missing pattern can be triaged."""
+    if not settings.SENTRY_DSN:
+        return
+
+    screenshot: bytes | None = None
+    html: str | None = None
+    try:
+        screenshot = await page.screenshot()
+    except Exception as exc:
+        logger.warning(f"Failed to capture screenshot for no-pattern-match: {exc}")
+    try:
+        html = await page.get_content()
+    except Exception as exc:
+        logger.warning(f"Failed to capture HTML for no-pattern-match: {exc}")
+
+    with sentry_sdk.isolation_scope() as scope:
+        scope.set_context(
+            "distill",
+            {"browser_id": browser_id, "hostname": hostname, "url": current_url},
+        )
+        if screenshot:
+            scope.add_attachment(filename="page.png", bytes=screenshot, content_type="image/png")
+        if html:
+            scope.add_attachment(
+                filename="page.html",
+                bytes=html.encode("utf-8"),
+                content_type="text/html",
+            )
+        sentry_sdk.capture_exception(error)
 
 
 @router.get("/api/v1/browsers/{browser_id}/pages")
@@ -93,7 +135,15 @@ async def get_page_distilled(browser_id: str, page_id: str) -> JSONResponse | HT
 
             match = await distill(hostname, page, patterns)  # type: ignore[arg-type]
             if not match:
-                raise HTTPException(status_code=502, detail="No matching pattern found for page")
+                error = HTTPException(status_code=502, detail="No matching pattern found for page")
+                await report_no_pattern_match(
+                    error=error,
+                    page=page,
+                    browser_id=browser_id,
+                    hostname=hostname,
+                    current_url=current_url,
+                )
+                raise error
 
             converted = await convert(match.distilled, pattern_path=match.name)
             if converted:

--- a/getgather/pages_api_router.py
+++ b/getgather/pages_api_router.py
@@ -2,7 +2,6 @@ import os
 import urllib.parse
 from typing import Any
 
-import sentry_sdk
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from loguru import logger
@@ -10,9 +9,13 @@ from loguru import logger
 from getgather.browser import find_browser_tab, get_remote_browser
 from getgather.browsers.router import strip_browser_id_from_target_id
 from getgather.cdp_client import CDPPage, PageNotFoundError, open_cdp
-from getgather.config import settings
 from getgather.mcp.dpage import distill_post_loop
-from getgather.zen_distill import convert, distill, load_distillation_patterns
+from getgather.zen_distill import (
+    convert,
+    distill,
+    load_distillation_patterns,
+    report_distill_error_to_sentry,
+)
 
 router = APIRouter()
 
@@ -27,34 +30,23 @@ async def report_no_pattern_match(
 ) -> None:
     """Attach a screenshot + HTML of the page to Sentry when no distillation
     pattern matches, so the missing pattern can be triaged."""
-    if not settings.SENTRY_DSN:
-        return
-
     screenshot: bytes | None = None
-    html: str | None = None
+    html: bytes | None = None
     try:
         screenshot = await page.screenshot()
     except Exception as exc:
         logger.warning(f"Failed to capture screenshot for no-pattern-match: {exc}")
     try:
-        html = await page.get_content()
+        html = (await page.get_content()).encode("utf-8")
     except Exception as exc:
         logger.warning(f"Failed to capture HTML for no-pattern-match: {exc}")
 
-    with sentry_sdk.isolation_scope() as scope:
-        scope.set_context(
-            "distill",
-            {"browser_id": browser_id, "hostname": hostname, "url": current_url},
-        )
-        if screenshot:
-            scope.add_attachment(filename="page.png", bytes=screenshot, content_type="image/png")
-        if html:
-            scope.add_attachment(
-                filename="page.html",
-                bytes=html.encode("utf-8"),
-                content_type="text/html",
-            )
-        sentry_sdk.capture_exception(error)
+    report_distill_error_to_sentry(
+        error=error,
+        context={"browser_id": browser_id, "hostname": hostname, "url": current_url},
+        screenshot=screenshot,
+        html=html,
+    )
 
 
 @router.get("/api/v1/browsers/{browser_id}/pages")

--- a/getgather/pages_api_router.py
+++ b/getgather/pages_api_router.py
@@ -11,6 +11,7 @@ from getgather.browsers.router import strip_browser_id_from_target_id
 from getgather.cdp_client import CDPPage, PageNotFoundError, open_cdp
 from getgather.mcp.dpage import distill_post_loop
 from getgather.zen_distill import (
+    capture_page_artifacts,
     convert,
     distill,
     load_distillation_patterns,
@@ -30,22 +31,22 @@ async def report_no_pattern_match(
 ) -> None:
     """Attach a screenshot + HTML of the page to Sentry when no distillation
     pattern matches, so the missing pattern can be triaged."""
-    screenshot: bytes | None = None
-    html: bytes | None = None
+    screenshot_path = None
+    html_path = None
     try:
-        screenshot = await page.screenshot()
+        screenshot_path, html_path, _ = await capture_page_artifacts(
+            page,  # type: ignore[arg-type]
+            identifier=browser_id,
+            prefix="no_pattern_match",
+        )
     except Exception as exc:
-        logger.warning(f"Failed to capture screenshot for no-pattern-match: {exc}")
-    try:
-        html = (await page.get_content()).encode("utf-8")
-    except Exception as exc:
-        logger.warning(f"Failed to capture HTML for no-pattern-match: {exc}")
+        logger.warning(f"Failed to capture no-pattern-match artifacts: {exc}")
 
     report_distill_error_to_sentry(
         error=error,
         context={"browser_id": browser_id, "hostname": hostname, "url": current_url},
-        screenshot=screenshot,
-        html=html,
+        screenshot=screenshot_path,
+        html=html_path,
     )
 
 

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -346,6 +346,36 @@ async def capture_page_artifacts(
     return screenshot_path, html_path, html_content
 
 
+def report_distill_error_to_sentry(
+    *,
+    error: Exception,
+    context: dict[str, Any],
+    screenshot: Path | bytes | None = None,
+    html: Path | bytes | None = None,
+) -> None:
+    """Attach a page screenshot + HTML to a Sentry event for distillation
+    triage. Each artifact may be a file `Path` (attached by path) or raw
+    `bytes` (attached inline). No-op when no Sentry DSN is configured."""
+    if not settings.SENTRY_DSN:
+        return
+
+    def _attach(
+        scope: Any, *, filename: str, source: Path | bytes | None, content_type: str
+    ) -> None:
+        if source is None:
+            return
+        if isinstance(source, Path):
+            scope.add_attachment(filename=source.name, path=str(source))
+        else:
+            scope.add_attachment(filename=filename, bytes=source, content_type=content_type)
+
+    with sentry_sdk.isolation_scope() as scope:
+        scope.set_context("distill", context)
+        _attach(scope, filename="page.png", source=screenshot, content_type="image/png")
+        _attach(scope, filename="page.html", source=html, content_type="text/html")
+        sentry_sdk.capture_exception(error)
+
+
 async def zen_report_distill_error(
     *,
     error: Exception,
@@ -384,21 +414,12 @@ async def zen_report_distill_error(
         },
     )
 
-    if settings.SENTRY_DSN:
-        with sentry_sdk.isolation_scope() as scope:
-            scope.set_context("distill", context)
-            if screenshot_path:
-                scope.add_attachment(
-                    filename=screenshot_path.name,
-                    path=str(screenshot_path),
-                )
-            if html_path:
-                scope.add_attachment(
-                    filename=html_path.name,
-                    path=str(html_path),
-                )
-
-            sentry_sdk.capture_exception(error)
+    report_distill_error_to_sentry(
+        error=error,
+        context=context,
+        screenshot=screenshot_path,
+        html=html_path,
+    )
 
 
 def make_error_reporter(browser: zd.Browser, location: str | None = None) -> ErrorReporter:


### PR DESCRIPTION
## What

When `get_page_distilled` finds no matching distillation pattern, it raised a bare `502 No matching pattern found for page` with no page context. Now it captures a **screenshot** and the **page HTML** and attaches both to the Sentry event, so the missing pattern can be triaged directly from Sentry.

Mirrors the existing `zen_report_distill_error` pattern in `zen_distill.py` (isolation scope → `add_attachment` → `capture_exception`).

## Why

Sentry issue [MCP-GETGATHER-6R3](https://heyario.sentry.io/issues/MCP-GETGATHER-6R3) — 678 occurrences, 44 users. Error is actionable only if we can see the page that failed to match (e.g. Goodreads `review/list` layout change). This route bypassed the distill-loop reporter, so events had no artifacts.

## Changes

- `getgather/cdp_client.py` — add `CDPPage.screenshot()` (full-page PNG via `Page.captureScreenshot`) and `CDPPage.get_content()` (outer HTML). This route uses a raw `CDPPage`, not a zendriver `Tab`, so `capture_page_artifacts` couldn't be reused.
- `getgather/pages_api_router.py` — new `report_no_pattern_match()` helper; called before raising the 502. Attaches bytes directly (no disk write). No-op when `SENTRY_DSN` unset.

## Testing

- `pyright` strict: clean
- ruff format/check: clean
- Not exercised against a live Chrome Fleet + Sentry DSN.

Refs MCP-GETGATHER-6R3