### PR TITLE
Gradually transition from npm scripts to a Makefile

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -33,7 +33,7 @@ jobs:
         uses: ./.github/actions/prepare-frontend
 
       - name: Check frontend formatting
-        run: npm run frontend:check:format
+        run: make check-frontend-format
 
   backend-types:
     runs-on: ubuntu-22.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,22 +11,21 @@ A FastAPI + FastMCP server (`getgather`) that exposes MCP tools for extracting p
 ## Common Commands
 
 ```bash
-# Dev server (requires CHROMEFLEET_URL)
-npm run dev                      # uvicorn on :23456, --reload
-# or: uv run -m uvicorn getgather.main:app --port 23456
+# Dev server
+make dev                                  # uvicorn on :23456, --reload
 
 # Static analysis (matches CI + pre-push hook)
-npm run check:all                # all of the below
-npm run backend:check:format     # ruff check + ruff format --check
-npm run backend:format           # ruff format + ruff check --fix
-npm run backend:check:type-safety # pyright . (strict mode)
-npm run frontend:check:format    # prettier check on html/js/ts/css/json/md
-npm run yaml:check:format        # yamlfix --check (skips mcp-tools.yaml)
+make check                                # all of the below
+make check-backend-format                 # ruff check + ruff format --check
+make format-backend                       # ruff format + ruff check --fix
+make typecheck                            # pyright . (strict mode)
+make check-frontend-format                # prettier check on html/js/ts/css/json/md
+make check-yaml-format                    # yamlfix --check (skips mcp-tools.yaml)
 
 # Tests (markers: mcp, distill; anything else = unit)
-uv run pytest -m "not api and not webui and not mcp and not distill"  # unit tests (CI)
-uv run pytest -m "mcp" -s -p no:xdist                                  # integration vs live server
-uv run pytest -m "distill" -s -p no:xdist                              # distillation vs Chrome Fleet
+make test                                 # unit tests (CI)
+uv run pytest -m "mcp" -s -p no:xdist     # integration vs live server
+uv run pytest -m "distill" -s -p no:xdist # distillation vs Chrome Fleet
 uv run pytest tests/mcp/test_goodreads.py                              # single test file
 uv run pytest tests/mcp/test_goodreads.py::test_goodreads_login_and_get_book_list
 
@@ -88,6 +87,6 @@ Browser identity: `browser_id` is derived from the auth user (`{sub}-{auth_provi
 - Python 3.11+, pyright **strict** mode — avoid `Any` drift, annotate returns
 - ruff lint selects `I, UP045, UP006, UP007` (isort + modern typing) with `line-length = 100`
 - `mcp-tools.yaml` is intentionally excluded from yamlfix — edit it hand-formatted
-- Pre-push hook runs `npm run check:all`; don't bypass with `--no-verify`
+- Pre-push hook runs `make check`; don't bypass with `--no-verify`.
 - Pattern files live beside patterns at `getgather/mcp/patterns/` — keep them minimal; they're parsed by BeautifulSoup, not rendered
 - Settings via pydantic `BaseSettings` reads `.env`; see `.env.template` for keys

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+.DEFAULT_GOAL := dev
+
+.PHONY: dev
+dev:
+	uv run -m uvicorn getgather.main:app --reload --host 127.0.0.1 --port 23456
+
+.PHONY: format-frontend
+format-frontend:
+	npx --yes prettier --write "**/*.{html,js,jsx,ts,tsx,css,json,md}" "!**/rfb.min.js"
+
+.PHONY: check-frontend-format
+check-frontend-format:
+	npx --yes prettier --check "**/*.{html,js,jsx,ts,tsx,css,json,md}" "!**/rfb.min.js"
+
+.PHONY: format-backend
+format-backend:
+	uv run ruff format
+	uv run ruff check --fix
+
+.PHONY: check-backend-format
+check-backend-format:
+	uv run ruff check
+	uv run ruff format --check
+
+.PHONY: format-yaml
+format-yaml:
+	uv run yamlfix $$(find . -type f \( -name '*.yml' -o -name '*.yaml' \) | grep -v -E '\.venv/|node_modules/|mcp-tools\.yaml')
+
+.PHONY: check-yaml-format
+check-yaml-format:
+	uv run yamlfix --check $$(find . -type f \( -name '*.yml' -o -name '*.yaml' \) | grep -v -E '\.venv/|node_modules/|mcp-tools\.yaml')
+
+.PHONY: format
+format: format-backend format-yaml format-frontend
+
+.PHONY: typecheck
+typecheck:
+	uv run pyright .
+
+.PHONY: test
+test:
+	uv run pytest -m "not api and not webui and not mcp and not distill"
+
+.PHONY: check-patterns
+check-patterns:
+	uv run python scripts/check_pattern_testids.py
+
+.PHONY: check
+check: check-backend-format check-yaml-format check-frontend-format typecheck check-patterns
+
+.PHONY: package
+package:
+	uv run --group dev pyinstaller remotebrowser-mcp.spec

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,7 @@
       "name": "remotebrowser-mcp",
       "version": "0.0.0",
       "devDependencies": {
-        "husky": "^9.1.7",
-        "prettier": "^3.7.3"
+        "husky": "^9.1.7"
       }
     },
     "node_modules/husky": {
@@ -26,22 +25,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.3.tgz",
-      "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,22 +7,22 @@
     "npm": "10.8.2"
   },
   "scripts": {
-    "dev": "npm run dev:backend",
-    "dev:backend": "uv run -m uvicorn getgather.main:app --reload --host 127.0.0.1 --port 23456",
-    "frontend:check:format": "prettier --check \"**/*.{html,js,jsx,ts,tsx,css,json,md}\" \"!**/rfb.min.js\"",
-    "frontend:format": "prettier --write \"**/*.{html,js,jsx,ts,tsx,css,json,md}\" \"!**/rfb.min.js\"",
-    "backend:check:format": "uv run ruff check && uv run ruff format --check",
-    "backend:format": "uv run ruff format && uv run ruff check --fix",
-    "backend:check:type-safety": "uv run pyright .",
-    "yaml:check:format": "uv run yamlfix --check $(find . -type f -name '*.yml' -o -name '*.yaml' | grep -v -E '\\.venv/|node_modules/|mcp-tools\\.yaml')",
-    "yaml:format": "uv run yamlfix $(find . -type f -name '*.yml' -o -name '*.yaml' | grep -v -E '\\.venv/|node_modules/|mcp-tools\\.yaml')",
-    "patterns:check:testids": "uv run python scripts/check_pattern_testids.py",
-    "check:all": "npm run frontend:check:format && npm run backend:check:format && npm run backend:check:type-safety && npm run yaml:check:format && npm run patterns:check:testids",
-    "package": "uv run --group dev pyinstaller remotebrowser-mcp.spec",
+    "dev": "make dev",
+    "dev:backend": "make dev",
+    "frontend:check:format": "make check-frontend-format",
+    "frontend:format": "make format-frontend",
+    "backend:check:format": "make check-backend-format",
+    "backend:format": "make format-backend",
+    "backend:check:type-safety": "make typecheck",
+    "yaml:check:format": "make check-yaml-format",
+    "yaml:format": "make format-yaml",
+    "patterns:check:testids": "make check-patterns",
+    "check:all": "make check",
+    "format": "make format",
+    "package": "make package",
     "prepare": "husky"
   },
   "devDependencies": {
-    "husky": "^9.1.7",
-    "prettier": "^3.7.3"
+    "husky": "^9.1.7"
   }
 }


### PR DESCRIPTION
Since this is purely a Python project, package.json and its npm scripts are not strictly necessary. Use Makefile targets instead for the various operations (running the dev server, formatting code, etc).

During this transition, npm scripts are still supported, though internally they map to the corresponding Makefile targets. For example, `npm run dev` is effectively just `make dev`.

Note that Node.js—specifically its `npx` utility—is still required to run Prettier and to power commit hooks via Husky (these will be migrated later).

To verify, run the various npm scripts and they should still work. All CI workflows should continue to pass as usual.