### PR TITLE
feat: add Target OTP sign-in pattern v2

### DIFF
--- a/getgather/mcp/patterns/target-signin-otp-2.html
+++ b/getgather/mcp/patterns/target-signin-otp-2.html
@@ -1,9 +1,9 @@
 <html rb-domain="target" rb-priority="1">
   <head>
-    <title>Target Sign In - OTP v2</title>
+    <title>Target Sign In - OTP</title>
   </head>
   <body>
-    <div rb-match="//*[contains(normalize-space(.), &quot;We’ve sent your code&quot;)]">
+    <div rb-match='//span[contains(normalize-space(.), "We’ve sent your code")]/parent::div'>
       We've sent your code
     </div>
     <input

--- a/getgather/mcp/patterns/target-signin-otp-2.html
+++ b/getgather/mcp/patterns/target-signin-otp-2.html
@@ -1,0 +1,19 @@
+<html rb-domain="target" rb-priority="1">
+  <head>
+    <title>Target Sign In - OTP v2</title>
+  </head>
+  <body>
+    <div rb-match="//*[contains(normalize-space(.), &quot;We’ve sent your code&quot;)]">
+      We've sent your code
+    </div>
+    <input
+      autofocus
+      name="otp"
+      type="tel"
+      placeholder="Enter your code"
+      data-testid="otp"
+      rb-match="input.styles_input__8Dfzg"
+    />
+    <button type="submit" data-testid="submit" rb-match="button#verify">Verify</button>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- **`target-signin-otp-2.html`** — New pattern file for Target's alternate OTP sign-in markup, where the heading is a generic "Sign in" instead of "Verification code sent". Matches on the "We've sent your code" confirmation text instead. Input/button selectors are identical to `target-signin-otp.html`, which is left unchanged.

## Test plan

- [x] `npm run backend:check:format` passes
- [x] `uv run pytest -m "not api and not webui and not mcp and not distill"` passes (69 tests)
- [x] Structural check: pattern parses via BeautifulSoup, `rb-match` selectors and curly-apostrophe text match verified byte-for-byte against source HTML
- [ ] Live `pytest -m distill` against Chrome Fleet (not run — no live instance in this session)

## Demo
<img width="1411" height="828" alt="image" src="https://github.com/user-attachments/assets/80d4c109-b4eb-44a1-bbb2-ba634fb2475c" />
