### PR TITLE
fix: recover from stale CDP node in dpage field fill

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -588,13 +588,47 @@ class Element:
         logger.error("TODO: Element#check")
         await asyncio.sleep(0.25)
 
+    async def _refresh_node(self) -> bool:
+        """Re-resolve the underlying zendriver node from this element's selector.
+
+        The CDP backendNodeId cached in ``self.element`` becomes stale when the page
+        re-renders the node (common on OTP/verification inputs that auto-advance).
+        Re-selecting swaps in a live node so a retried CDP op can resolve it.
+        """
+        try:
+            if self.xpath_selector:
+                elements = await self.page.xpath(self.xpath_selector, 0)
+                node = elements[0] if elements else None
+            elif self.css_selector:
+                node = await self.page.select(self.css_selector)
+            else:
+                return False
+        except Exception:
+            return False
+        if node is None:
+            return False
+        self.element = node
+        self.tag = node.tag
+        return True
+
+    async def _clear_input(self) -> None:
+        for attempt in range(2):
+            try:
+                await self.element.clear_input_by_deleting()
+                await asyncio.sleep(self.config.typing_clear_delay)
+                await self.element.clear_input()
+                await asyncio.sleep(self.config.typing_clear_delay)
+                return
+            except ProtocolException as e:
+                if attempt == 0 and await self._refresh_node():
+                    logger.warning(f"clear_input hit stale node; refreshed and retrying: {e}")
+                    continue
+                raise
+
     async def type_text(self, text: str) -> None:
         if self.config.action_delay_ms > 0:
             await asyncio.sleep(self.config.action_delay_ms / 1000)
-        await self.element.clear_input_by_deleting()
-        await asyncio.sleep(self.config.typing_clear_delay)
-        await self.element.clear_input()
-        await asyncio.sleep(self.config.typing_clear_delay)
+        await self._clear_input()
         for char in text:
             await self.element.send_keys(char)
             await asyncio.sleep(

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -14,6 +14,7 @@ from fastapi.responses import HTMLResponse
 from fastmcp.server.dependencies import get_http_headers
 from loguru import logger
 from nanoid import generate
+from zendriver.core.connection import ProtocolException
 
 from getgather.browser import (
     ElementConfig,
@@ -595,11 +596,18 @@ async def distill_post_loop(
                 element = await page_query_selector(page, selector, config=config)
                 if not element:
                     continue
-                if kind == "click":
-                    await element.click()
-                elif kind == "set_value":
-                    value = pending_action.get("value")
-                    await element.type_text(value if isinstance(value, str) else "")
+                try:
+                    if kind == "click":
+                        await element.click()
+                    elif kind == "set_value":
+                        value = pending_action.get("value")
+                        await element.type_text(value if isinstance(value, str) else "")
+                except ProtocolException as e:
+                    # Node went stale mid-action (page re-rendered the field). This fallback
+                    # is best-effort; the distillation loop re-distills and retries next
+                    # iteration, so skip this field rather than 500 the whole request.
+                    logger.warning(f"Fallback {kind} on {selector!r} hit stale node, skipping: {e}")
+                    continue
 
             await asyncio.sleep(0.25)
 


### PR DESCRIPTION
## Problem

Sentry [MCP-GETGATHER-7Z1](https://heyario.sentry.io/issues/MCP-GETGATHER-7Z1) — `ProtocolException: Node with given id does not belong to the document` (`command:DOM.resolveNode`). 17 occurrences, 6 users, env `daytona`.

The fallback field-fill path in `distill_post_loop` (runs only when the primary JS `page_batch_actions` reports a failed action) re-queries the element via `page_query_selector` (a CDP node handle → `backendNodeId`), then calls `element.type_text()`. Inside `type_text`, `clear_input()` re-resolves the `backendNodeId`. On re-rendering inputs — e.g. 6-digit OTP/verification fields that auto-advance (crash value was `'134800'`) — the node detaches between query and clear, so `DOM.resolveNode` throws. It was unhandled → bubbled through the TaskGroup → 500/503'd the whole `/dpage` request.

The primary JS batch path is immune (re-runs `document.querySelector` every poll). Only the imperative fallback crashed.

## Fix (two layers)

**`browser.py`** — `type_text` now clears via `_clear_input()`, which on a stale-node `ProtocolException` re-selects the live node (`_refresh_node()`, from the stored css/xpath selector) and retries once.

**`dpage.py`** — guard the best-effort fallback `click`/`type_text` with `try/except ProtocolException`: log and skip the field so the distillation loop re-distills next iteration instead of failing the request.

## Testing

`npm run backend:format` + `pyright` clean. Not exercised live — reproduction needs Chrome Fleet plus a re-rendering OTP page.

Fixes MCP-GETGATHER-7Z1