### PR TITLE
fix: raise CDP timeout past Chrome Fleet cold-start

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -135,7 +135,7 @@ async def _create_browser_from_cdp_websocket(
             try:
                 await asyncio.wait_for(
                     instance.connection.send(zd.cdp.target.set_discover_targets(discover=True)),
-                    timeout=30.0,
+                    timeout=settings.CHROMEFLEET_CDP_HANDSHAKE_TIMEOUT_SECONDS,
                 )
             except websockets.ConnectionClosedError as e:
                 raise ConnectionError(
@@ -144,11 +144,16 @@ async def _create_browser_from_cdp_websocket(
                 ) from e
             except asyncio.TimeoutError:
                 raise ConnectionError(
-                    f"CDP WebSocket handshake timed out after 30s: browser_id={browser_id}"
+                    f"CDP WebSocket handshake timed out after "
+                    f"{settings.CHROMEFLEET_CDP_HANDSHAKE_TIMEOUT_SECONDS:g}s: "
+                    f"browser_id={browser_id}"
                 )
 
         try:
-            await asyncio.wait_for(instance.update_targets(), timeout=30.0)
+            await asyncio.wait_for(
+                instance.update_targets(),
+                timeout=settings.CHROMEFLEET_CDP_HANDSHAKE_TIMEOUT_SECONDS,
+            )
         except websockets.ConnectionClosedError as e:
             raise ConnectionError(
                 f"CDP WebSocket closed by remote (code={e.rcvd.code if e.rcvd else 'unknown'},"
@@ -156,7 +161,9 @@ async def _create_browser_from_cdp_websocket(
             ) from e
         except asyncio.TimeoutError:
             raise ConnectionError(
-                f"CDP WebSocket update_targets timed out after 30s: browser_id={browser_id}"
+                f"CDP WebSocket update_targets timed out after "
+                f"{settings.CHROMEFLEET_CDP_HANDSHAKE_TIMEOUT_SECONDS:g}s: "
+                f"browser_id={browser_id}"
             )
     util.get_registered_instances().add(instance)
 

--- a/getgather/browsers/settings.py
+++ b/getgather/browsers/settings.py
@@ -21,7 +21,13 @@ class BrowserSettings(BaseSettings):
     # External Chrome Fleet: when set, the browser API is proxied to this upstream fleet
     # (takes precedence over BROWSER_BACKEND).
     CHROMEFLEET_URL: str = ""
-    CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS: float = 30.0
+    # WebSocket open timeout. Must exceed the Chrome Fleet cold-start (Daytona
+    # sandbox create is ~45s p95), otherwise the connect loses the race against a
+    # browser that is still launching.
+    CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS: float = 60.0
+    # Timeout for the CDP handshake (set_discover_targets / update_targets) after
+    # the WebSocket opens. Also sized past cold-start for the same reason.
+    CHROMEFLEET_CDP_HANDSHAKE_TIMEOUT_SECONDS: float = 60.0
 
     # Local backend selection (ignored when CHROMEFLEET_URL is set)
     BROWSER_BACKEND: BrowserBackendName = "podman"

--- a/getgather/browsers/settings.py
+++ b/getgather/browsers/settings.py
@@ -24,10 +24,10 @@ class BrowserSettings(BaseSettings):
     # WebSocket open timeout. Must exceed the Chrome Fleet cold-start (Daytona
     # sandbox create is ~45s p95), otherwise the connect loses the race against a
     # browser that is still launching.
-    CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS: float = 60.0
+    CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS: float = 120.0
     # Timeout for the CDP handshake (set_discover_targets / update_targets) after
     # the WebSocket opens. Also sized past cold-start for the same reason.
-    CHROMEFLEET_CDP_HANDSHAKE_TIMEOUT_SECONDS: float = 60.0
+    CHROMEFLEET_CDP_HANDSHAKE_TIMEOUT_SECONDS: float = 120.0
 
     # Local backend selection (ignored when CHROMEFLEET_URL is set)
     BROWSER_BACKEND: BrowserBackendName = "podman"


### PR DESCRIPTION
## Problem

A `doordash_get_orders_with_pagination` tool call failed because the CDP handshake timed out after **30s** while the underlying browser sandbox did not exist yet and its Daytona cold-start took **~45s**. The connect aborted before the browser was ready — a lost race, not a transient error. The browser finished launching ~22s *after* the request had already failed.

- Trace: `ec6b5f7b6b4f4f3b906cd6f8167b2b7c` (Logfire, remote-browser-dev)
- Error: `CDP WebSocket handshake timed out after 30s: browser_id=Edtumbwr`

## Root cause

CDP connect is attempted against a sandbox that does not exist. Chrome Fleet triggers a cold launch, but the **30s CDP handshake timeout < ~45s Daytona cold-start**, so the tool call aborts before the browser can accept the connection.

The preferred fix (ensure-sandbox-before-connect) lives in the Chrome Fleet backend, not here. On the getgather side the actionable fix is to size the timeouts past the cold-start p95.

## Change

- Bump `CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS` default 30s → 120s
- Add `CHROMEFLEET_CDP_HANDSHAKE_TIMEOUT_SECONDS` (default 120s) and use it for the `set_discover_targets` and `update_targets` waits, replacing the hardcoded `30.0` values
- Timeout values now flow into the error strings

## Test

`pyright` + `ruff` clean. Acceptance: force a cold sandbox (ensure `chromium-<id>` does not exist), issue a DoorDash tool call — it should launch the browser and succeed rather than fail with a handshake timeout.