### PR TITLE
feat: Best-of-N Daytona sandbox creation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,6 +17,9 @@ MAX_IDLE_MINUTES=15
 DAYTONA_API_KEY=
 DAYTONA_API_URL=
 DAYTONA_SNAPSHOT=
+# Best-of-N cold-create: race this many sandbox candidates and keep the first proxy-verified one
+# (losers deleted in the background). 1 disables the race. Only affects POST /api/v1/browsers.
+DAYTONA_BEST_OF_N=3
 
 # Residential proxy (Massive or Oxylabs) and MaxMind GeoIP. Consumed only by the podman backend,
 # which sets a per-browser upstream proxy and resolves geo from x-origin-ip. The Daytona backend

--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -1,10 +1,17 @@
 from typing import Any, Protocol, runtime_checkable
 
-from getgather.config import settings
+from nanoid import generate
+
+from getgather.config import FRIENDLY_CHARS, settings
 
 # Shared name prefix: a browser with id `abc` is a podman container / Daytona sandbox named
 # `chromium-abc`. Both local backends derive names and parse ids from this single prefix.
 BROWSER_NAME_PREFIX = "chromium-"
+
+
+def new_browser_id() -> str:
+    """A server-assigned browser id. `B`-prefixed so it is distinguishable from client-supplied ids."""
+    return "B" + generate(FRIENDLY_CHARS, 8)
 
 
 class BrowserNotFound(Exception):
@@ -29,6 +36,15 @@ class Backend(Protocol):
     async def create_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]: ...
+
+    async def create_browser_auto(
+        self, origin_ip: str | None, target_domain: str | None
+    ) -> tuple[str, dict[str, Any]]:
+        """Create a browser with a server-assigned id and return `(browser_id, info)`.
+
+        Backends may race several candidates (best-of-N) and return the winner; the returned id is
+        authoritative and every subsequent call must use it."""
+        ...
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -13,14 +13,9 @@ from daytona import (
 )
 from loguru import logger
 
-from getgather.browsers.backend import BROWSER_NAME_PREFIX, BrowserNotFound
+from getgather.browsers.backend import BROWSER_NAME_PREFIX, BrowserNotFound, new_browser_id
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
-
-
-class ProxyVerificationError(Exception):
-    """Raised when egress IP is unchanged after proxy configuration."""
-
 
 CDP_PORT = 9222
 VNC_PORT = 8080
@@ -104,27 +99,30 @@ async def _configure_remote_sandbox(
     browser_id: str,
     origin_ip: str | None,
     target_domain: str | None,
-) -> None:
+) -> bool:
+    """Apply the residential proxy to the sandbox and verify egress IP changed.
+
+    Returns True if the proxy is verified (or none is required), False if the proxy failed to
+    apply or the egress IP was unchanged. Best-of-N uses this to pick a proxy-verified winner."""
     proxy_config = await get_proxy_config(origin_ip, target_domain, settings)
     proxy_url = proxy_config.get_proxy_url(browser_id) if proxy_config else None
 
     if not proxy_url:
-        return
+        return True  # no proxy required; nothing to verify
 
     ip_before = await _get_sandbox_public_ip(sandbox)
     logger.debug(f"Sandbox {sandbox.name} IP before proxy: {ip_before}")
 
     ok = await _configure_sandbox_proxy(sandbox, proxy_url)
     if not ok:
-        return
+        return False
 
     ip_after = await _get_sandbox_public_ip(sandbox)
     if ip_before and ip_after and ip_before != ip_after:
         logger.info(f"Sandbox {sandbox.name} IP changed: {ip_before} -> {ip_after}")
-    elif ip_before == ip_after:
-        raise ProxyVerificationError(
-            f"Sandbox {sandbox.name} IP unchanged after proxy: {ip_before}"
-        )
+        return True
+    logger.warning(f"Sandbox {sandbox.name} IP unchanged after proxy: {ip_before}")
+    return False
 
 
 def _browser_id_from_name(name: str) -> str:
@@ -159,11 +157,18 @@ class DaytonaBackend:
         lock = self._locks.setdefault(browser_id, asyncio.Lock())
         async with lock:
             sandbox = await self._ensure(browser_id)
-            try:
-                await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
-            except ProxyVerificationError as e:
-                logger.warning(str(e))
+            if not await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain):
+                logger.warning(f"Proxy not verified for {browser_id}; returning sandbox anyway")
             return await self._get_info(sandbox)
+
+    async def create_browser_auto(
+        self, origin_ip: str | None, target_domain: str | None
+    ) -> tuple[str, dict[str, Any]]:
+        n = max(1, settings.DAYTONA_BEST_OF_N)
+        if n == 1:
+            browser_id = new_browser_id()
+            return browser_id, await self.create_browser(browser_id, origin_ip, target_domain)
+        return await self._best_of_n(n, origin_ip, target_domain)
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
@@ -171,11 +176,10 @@ class DaytonaBackend:
         sandbox = await self._get(_sandbox_name(browser_id))
         if sandbox is None:
             raise BrowserNotFound(browser_id)
-        if origin_ip:
-            try:
-                await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
-            except ProxyVerificationError as e:
-                logger.warning(str(e))
+        if origin_ip and not await _configure_remote_sandbox(
+            sandbox, browser_id, origin_ip, target_domain
+        ):
+            logger.warning(f"Proxy not verified for {browser_id}; returning sandbox anyway")
         return await self._get_info(sandbox)
 
     async def delete_browser(self, browser_id: str) -> dict[str, Any]:
@@ -244,6 +248,74 @@ class DaytonaBackend:
             VNC_PORT, expires_in_seconds=SIGNED_URL_TTL_SECONDS
         )
         return signed.url
+
+    async def _best_of_n(
+        self, n: int, origin_ip: str | None, target_domain: str | None
+    ) -> tuple[str, dict[str, Any]]:
+        """Race n cold-create candidates; keep the first proxy-verified one, delete the rest.
+
+        Each candidate is an independent browser with its own server-assigned id (so their sandbox
+        names never collide). The first candidate that starts AND passes proxy verification wins;
+        if none verify their proxy, the fastest that merely started is the fallback. Losers are
+        torn down in the background."""
+        ids = [new_browser_id() for _ in range(n)]
+        logger.info(f"Best-of-{n} sandbox race: {ids}")
+        tasks = [
+            asyncio.create_task(self._create_candidate(b, origin_ip, target_domain)) for b in ids
+        ]
+        winner: tuple[str, dict[str, Any]] | None = None
+        fallback: tuple[str, dict[str, Any]] | None = None
+        for coro in asyncio.as_completed(tasks):
+            try:
+                browser_id, info, proxy_ok = await coro
+            except Exception as e:
+                logger.warning(f"Best-of-N candidate failed: {type(e).__name__}: {e}")
+                continue
+            if proxy_ok:
+                winner = (browser_id, info)
+                break
+            if fallback is None:
+                fallback = (browser_id, info)
+
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+
+        result = winner or fallback
+        if result is None:
+            raise RuntimeError("Best-of-N: all sandbox candidates failed to start")
+        if winner is None:
+            logger.warning(f"Best-of-N: no proxy-verified candidate, falling back to {result[0]}")
+        logger.info(f"Best-of-N winner: {result[0]}")
+        asyncio.create_task(self._cleanup_losers(ids, winner_id=result[0]))
+        return result
+
+    async def _create_candidate(
+        self, browser_id: str, origin_ip: str | None, target_domain: str | None
+    ) -> tuple[str, dict[str, Any], bool]:
+        sandbox = await self._create(_sandbox_name(browser_id))
+        if sandbox.state != "started":
+            await sandbox.start()
+        proxy_ok = await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+        return browser_id, await self._get_info(sandbox), proxy_ok
+
+    async def _cleanup_losers(self, ids: list[str], *, winner_id: str) -> None:
+        for browser_id in ids:
+            if browser_id == winner_id:
+                continue
+            self._locks.pop(browser_id, None)
+            # A cancelled candidate's sandbox may still be materializing server-side; retry the
+            # delete so we don't leak it (Daytona's auto_delete_interval is the final backstop).
+            for _ in range(6):
+                sandbox = await self._get(_sandbox_name(browser_id))
+                if sandbox is not None:
+                    try:
+                        await sandbox.delete()
+                        logger.info(f"Best-of-N: deleted losing candidate {browser_id}")
+                    except Exception as e:
+                        logger.warning(f"Best-of-N: failed to delete loser {browser_id}: {e}")
+                    break
+                await asyncio.sleep(5)
 
     async def _ensure(self, browser_id: str) -> AsyncSandbox:
         name = _sandbox_name(browser_id)

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -17,6 +17,11 @@ from getgather.browsers.backend import BROWSER_NAME_PREFIX, BrowserNotFound, new
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
 
+
+class ProxyVerificationError(Exception):
+    """Raised when a configured (mandatory) proxy fails to apply or the egress IP is unchanged."""
+
+
 CDP_PORT = 9222
 VNC_PORT = 8080
 
@@ -99,30 +104,30 @@ async def _configure_remote_sandbox(
     browser_id: str,
     origin_ip: str | None,
     target_domain: str | None,
-) -> bool:
+) -> None:
     """Apply the residential proxy to the sandbox and verify egress IP changed.
 
-    Returns True if the proxy is verified (or none is required), False if the proxy failed to
-    apply or the egress IP was unchanged. Best-of-N uses this to pick a proxy-verified winner."""
+    The proxy is mandatory: if one is configured it MUST apply and change the egress IP, otherwise
+    this raises ProxyVerificationError. If no proxy is configured, this is a no-op (proxy is not
+    required). Callers let the error propagate; best-of-N treats a raising candidate as failed."""
     proxy_config = await get_proxy_config(origin_ip, target_domain, settings)
     proxy_url = proxy_config.get_proxy_url(browser_id) if proxy_config else None
 
     if not proxy_url:
-        return True  # no proxy required; nothing to verify
+        return  # no proxy configured; proxy is not required for this browser
 
     ip_before = await _get_sandbox_public_ip(sandbox)
     logger.debug(f"Sandbox {sandbox.name} IP before proxy: {ip_before}")
 
     ok = await _configure_sandbox_proxy(sandbox, proxy_url)
     if not ok:
-        return False
+        raise ProxyVerificationError(f"Proxy failed to apply on {sandbox.name}")
 
     ip_after = await _get_sandbox_public_ip(sandbox)
     if ip_before and ip_after and ip_before != ip_after:
         logger.info(f"Sandbox {sandbox.name} IP changed: {ip_before} -> {ip_after}")
-        return True
-    logger.warning(f"Sandbox {sandbox.name} IP unchanged after proxy: {ip_before}")
-    return False
+        return
+    raise ProxyVerificationError(f"Sandbox {sandbox.name} IP unchanged after proxy: {ip_before}")
 
 
 def _browser_id_from_name(name: str) -> str:
@@ -157,8 +162,9 @@ class DaytonaBackend:
         lock = self._locks.setdefault(browser_id, asyncio.Lock())
         async with lock:
             sandbox = await self._ensure(browser_id)
-            if not await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain):
-                logger.warning(f"Proxy not verified for {browser_id}; returning sandbox anyway")
+            # Proxy is mandatory when configured: let ProxyVerificationError propagate (the endpoint
+            # maps it to 500) so the client can retry rather than get an unproxied browser.
+            await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
             return await self._get_info(sandbox)
 
     async def create_browser_auto(
@@ -176,10 +182,9 @@ class DaytonaBackend:
         sandbox = await self._get(_sandbox_name(browser_id))
         if sandbox is None:
             raise BrowserNotFound(browser_id)
-        if origin_ip and not await _configure_remote_sandbox(
-            sandbox, browser_id, origin_ip, target_domain
-        ):
-            logger.warning(f"Proxy not verified for {browser_id}; returning sandbox anyway")
+        if origin_ip:
+            # Mandatory proxy: propagate ProxyVerificationError instead of returning unproxied.
+            await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
         return await self._get_info(sandbox)
 
     async def delete_browser(self, browser_id: str) -> dict[str, Any]:
@@ -252,52 +257,50 @@ class DaytonaBackend:
     async def _best_of_n(
         self, n: int, origin_ip: str | None, target_domain: str | None
     ) -> tuple[str, dict[str, Any]]:
-        """Race n cold-create candidates; keep the first proxy-verified one, delete the rest.
+        """Race n cold-create candidates; keep the first that fully succeeds, delete the rest.
 
         Each candidate is an independent browser with its own server-assigned id (so their sandbox
-        names never collide). The first candidate that starts AND passes proxy verification wins;
-        if none verify their proxy, the fastest that merely started is the fallback. Losers are
-        torn down in the background."""
+        names never collide). A candidate "succeeds" only after it starts AND (when a proxy is
+        configured) passes mandatory proxy verification, so the first to complete is the winner.
+        If every candidate fails (e.g. no proxy in the pool verifies), this raises rather than
+        returning an unproxied browser, so the client can retry. Losers are torn down in the
+        background."""
         ids = [new_browser_id() for _ in range(n)]
         logger.info(f"Best-of-{n} sandbox race: {ids}")
         tasks = [
             asyncio.create_task(self._create_candidate(b, origin_ip, target_domain)) for b in ids
         ]
         winner: tuple[str, dict[str, Any]] | None = None
-        fallback: tuple[str, dict[str, Any]] | None = None
         for coro in asyncio.as_completed(tasks):
             try:
-                browser_id, info, proxy_ok = await coro
+                browser_id, info = await coro
             except Exception as e:
                 logger.warning(f"Best-of-N candidate failed: {type(e).__name__}: {e}")
                 continue
-            if proxy_ok:
-                winner = (browser_id, info)
-                break
-            if fallback is None:
-                fallback = (browser_id, info)
+            winner = (browser_id, info)
+            break
 
         for task in tasks:
             if not task.done():
                 task.cancel()
 
-        result = winner or fallback
-        if result is None:
-            raise RuntimeError("Best-of-N: all sandbox candidates failed to start")
         if winner is None:
-            logger.warning(f"Best-of-N: no proxy-verified candidate, falling back to {result[0]}")
-        logger.info(f"Best-of-N winner: {result[0]}")
-        asyncio.create_task(self._cleanup_losers(ids, winner_id=result[0]))
-        return result
+            raise ProxyVerificationError(
+                "Best-of-N: no sandbox candidate started with a verified proxy"
+            )
+        logger.info(f"Best-of-N winner: {winner[0]}")
+        asyncio.create_task(self._cleanup_losers(ids, winner_id=winner[0]))
+        return winner
 
     async def _create_candidate(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
-    ) -> tuple[str, dict[str, Any], bool]:
+    ) -> tuple[str, dict[str, Any]]:
         sandbox = await self._create(_sandbox_name(browser_id))
         if sandbox.state != "started":
             await sandbox.start()
-        proxy_ok = await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
-        return browser_id, await self._get_info(sandbox), proxy_ok
+        # Raises ProxyVerificationError if a configured proxy fails; that fails this candidate.
+        await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+        return browser_id, await self._get_info(sandbox)
 
     async def _cleanup_losers(self, ids: list[str], *, winner_id: str) -> None:
         for browser_id in ids:

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -304,18 +304,26 @@ class DaytonaBackend:
             if browser_id == winner_id:
                 continue
             self._locks.pop(browser_id, None)
-            # A cancelled candidate's sandbox may still be materializing server-side; retry the
-            # delete so we don't leak it (Daytona's auto_delete_interval is the final backstop).
-            for _ in range(6):
+            # A cancelled candidate's sandbox may still be materializing server-side: it can be
+            # not-yet-visible, or visible but mid state-change (delete rejected with "state change
+            # in progress"). Retry both cases until it settles, so we don't leak it (Daytona's
+            # auto_delete_interval is the final backstop).
+            deleted = False
+            for _ in range(8):
                 sandbox = await self._get(_sandbox_name(browser_id))
-                if sandbox is not None:
-                    try:
-                        await sandbox.delete()
-                        logger.info(f"Best-of-N: deleted losing candidate {browser_id}")
-                    except Exception as e:
-                        logger.warning(f"Best-of-N: failed to delete loser {browser_id}: {e}")
+                if sandbox is None:
+                    await asyncio.sleep(5)
+                    continue
+                try:
+                    await sandbox.delete()
+                    logger.info(f"Best-of-N: deleted losing candidate {browser_id}")
+                    deleted = True
                     break
-                await asyncio.sleep(5)
+                except Exception as e:
+                    logger.debug(f"Best-of-N: delete retry for loser {browser_id}: {e}")
+                    await asyncio.sleep(5)
+            if not deleted:
+                logger.warning(f"Best-of-N: gave up deleting loser {browser_id} (will auto-delete)")
 
     async def _ensure(self, browser_id: str) -> AsyncSandbox:
         name = _sandbox_name(browser_id)

--- a/getgather/browsers/fleet_browsers.py
+++ b/getgather/browsers/fleet_browsers.py
@@ -102,6 +102,16 @@ class FleetBackend:
         response = _require(await call_chromefleet_api("POST", browser_id, headers=headers))
         return response.json()
 
+    async def create_browser_auto(
+        self, origin_ip: str | None, target_domain: str | None
+    ) -> tuple[str, dict[str, Any]]:
+        # The upstream fleet owns id assignment (and any best-of-N race); forward to its
+        # server-assigned-id endpoint and echo back the id it picked.
+        headers = {"x-origin-ip": origin_ip} if origin_ip else {}
+        response = _require(await call_chromefleet_api("POST", headers=headers))
+        data: dict[str, Any] = response.json()
+        return str(data["browser_id"]), data
+
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]:

--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from loguru import logger
 
-from getgather.browsers.backend import BROWSER_NAME_PREFIX, BrowserNotFound
+from getgather.browsers.backend import BROWSER_NAME_PREFIX, BrowserNotFound, new_browser_id
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
 
@@ -309,6 +309,13 @@ class PodmanBackend:
         await launch_container(settings.CONTAINER_IMAGE, container_name)
         ip = await configure_remote_browser(browser_id, container_name, origin_ip, target_domain)
         return {"container_name": container_name, "status": "created", "ip": ip}
+
+    async def create_browser_auto(
+        self, origin_ip: str | None, target_domain: str | None
+    ) -> tuple[str, dict[str, Any]]:
+        # Local backend: no best-of-N race, just assign an id and create the single container.
+        browser_id = new_browser_id()
+        return browser_id, await self.create_browser(browser_id, origin_ip, target_domain)
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -9,11 +9,9 @@ from fastapi import APIRouter, HTTPException, Request, WebSocket, WebSocketDisco
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.websockets import WebSocketState
 from loguru import logger
-from nanoid import generate
 from websockets.exceptions import ConnectionClosed
 
 from getgather.browsers.backend import Backend, BrowserNotFound, create_backend
-from getgather.config import FRIENDLY_CHARS
 
 router = APIRouter()
 
@@ -211,16 +209,15 @@ async def websocket_proxy(
 
 @router.post("/api/v1/browsers")
 async def create_browser_auto(request: Request) -> dict[str, Any]:
-    browser_id = "B" + generate(FRIENDLY_CHARS, 8)
-    logger.info(f"Starting browser {browser_id}...")
+    logger.info("Starting browser (server-assigned id)...")
     try:
         origin_ip = request.headers.get("x-origin-ip")
         target_domain = request.headers.get("x-target-domains")
-        result = await backend.create_browser(browser_id, origin_ip, target_domain)
+        browser_id, result = await backend.create_browser_auto(origin_ip, target_domain)
         logger.info(f"Browser {browser_id} is started.")
         return {"browser_id": browser_id, **result}
     except Exception as e:
-        detail = f"Unable to start browser {browser_id}!"
+        detail = "Unable to start browser!"
         logger.error(f"{detail} Exception={e}")
         raise HTTPException(status_code=500, detail=detail)
 

--- a/getgather/browsers/settings.py
+++ b/getgather/browsers/settings.py
@@ -52,6 +52,11 @@ class BrowserSettings(BaseSettings):
         ""  # point at a self-hosted Daytona; empty uses the managed cloud default
     )
     DAYTONA_SNAPSHOT: str = ""
+    # Best-of-N cold-create: on a fresh browser, race this many sandbox candidates in parallel and
+    # keep the first that starts AND passes proxy IP verification; losers are deleted in the
+    # background. Set to 1 to disable the race and create a single sandbox. Only used by the
+    # server-assigned-id endpoint (POST /api/v1/browsers).
+    DAYTONA_BEST_OF_N: int = 3
 
     @property
     def effective_chromefleet_url(self) -> str:

--- a/tests/test_daytona_best_of_n.py
+++ b/tests/test_daytona_best_of_n.py
@@ -5,7 +5,7 @@ import pytest
 from pytest import MonkeyPatch
 
 from getgather.browsers import daytona_browsers
-from getgather.browsers.daytona_browsers import DaytonaBackend
+from getgather.browsers.daytona_browsers import DaytonaBackend, ProxyVerificationError
 
 
 def _backend() -> DaytonaBackend:
@@ -20,20 +20,16 @@ def _patch_ids(monkeypatch: MonkeyPatch, ids: list[str]) -> None:
 
 
 @pytest.mark.asyncio
-async def test_best_of_n_picks_first_proxy_verified(monkeypatch: MonkeyPatch) -> None:
+async def test_best_of_n_picks_first_to_complete(monkeypatch: MonkeyPatch) -> None:
     _patch_ids(monkeypatch, ["b0", "b1", "b2"])
 
-    # b1 finishes first but fails proxy; b0 finishes next and passes -> b0 wins.
-    plan = {
-        "b0": (0.02, True),
-        "b1": (0.01, False),
-        "b2": (0.05, True),
-    }
-
+    # b1 finishes first but its proxy fails (raises); b0 completes next -> b0 wins.
     async def fake_candidate(self: Any, browser_id: str, origin_ip: Any, target_domain: Any):
-        delay, ok = plan[browser_id]
-        await asyncio.sleep(delay)
-        return browser_id, {"id": browser_id}, ok
+        delays = {"b0": 0.02, "b1": 0.01, "b2": 0.05}
+        await asyncio.sleep(delays[browser_id])
+        if browser_id == "b1":
+            raise ProxyVerificationError("proxy unchanged")
+        return browser_id, {"id": browser_id}
 
     cleaned: dict[str, Any] = {}
 
@@ -53,17 +49,13 @@ async def test_best_of_n_picks_first_proxy_verified(monkeypatch: MonkeyPatch) ->
 
 
 @pytest.mark.asyncio
-async def test_best_of_n_falls_back_to_fastest_started_when_no_proxy_verified(
-    monkeypatch: MonkeyPatch,
-) -> None:
+async def test_best_of_n_raises_when_no_proxy_verified(monkeypatch: MonkeyPatch) -> None:
+    # Proxy is mandatory: if every candidate fails verification, best-of-N raises instead of
+    # returning an unproxied browser, so the client can retry.
     _patch_ids(monkeypatch, ["b0", "b1"])
 
-    plan = {"b0": (0.03, False), "b1": (0.01, False)}
-
     async def fake_candidate(self: Any, browser_id: str, origin_ip: Any, target_domain: Any):
-        delay, ok = plan[browser_id]
-        await asyncio.sleep(delay)
-        return browser_id, {"id": browser_id}, ok
+        raise ProxyVerificationError("IP unchanged after proxy")
 
     async def fake_cleanup(self: Any, ids: list[str], *, winner_id: str):
         return None
@@ -71,8 +63,8 @@ async def test_best_of_n_falls_back_to_fastest_started_when_no_proxy_verified(
     monkeypatch.setattr(DaytonaBackend, "_create_candidate", fake_candidate)
     monkeypatch.setattr(DaytonaBackend, "_cleanup_losers", fake_cleanup)
 
-    winner_id, _ = await _backend()._best_of_n(2, None, None)  # pyright: ignore[reportPrivateUsage]
-    assert winner_id == "b1"  # fastest to start, since none verified their proxy
+    with pytest.raises(ProxyVerificationError, match="no sandbox candidate started"):
+        await _backend()._best_of_n(2, None, None)  # pyright: ignore[reportPrivateUsage]
 
 
 @pytest.mark.asyncio
@@ -88,7 +80,7 @@ async def test_best_of_n_raises_when_all_candidates_fail(monkeypatch: MonkeyPatc
     monkeypatch.setattr(DaytonaBackend, "_create_candidate", fake_candidate)
     monkeypatch.setattr(DaytonaBackend, "_cleanup_losers", fake_cleanup)
 
-    with pytest.raises(RuntimeError, match="all sandbox candidates failed"):
+    with pytest.raises(ProxyVerificationError, match="no sandbox candidate started"):
         await _backend()._best_of_n(2, None, None)  # pyright: ignore[reportPrivateUsage]
 
 

--- a/tests/test_daytona_best_of_n.py
+++ b/tests/test_daytona_best_of_n.py
@@ -1,0 +1,142 @@
+import asyncio
+from typing import Any
+
+import pytest
+from pytest import MonkeyPatch
+
+from getgather.browsers import daytona_browsers
+from getgather.browsers.daytona_browsers import DaytonaBackend
+
+
+def _backend() -> DaytonaBackend:
+    # The AsyncDaytona client is constructed but never touched: every test patches the methods
+    # that would reach it (_create_candidate, _cleanup_losers, _get).
+    return DaytonaBackend(api_key="test-key", api_url="", snapshot="test-snapshot")
+
+
+def _patch_ids(monkeypatch: MonkeyPatch, ids: list[str]) -> None:
+    it = iter(ids)
+    monkeypatch.setattr(daytona_browsers, "new_browser_id", lambda: next(it))
+
+
+@pytest.mark.asyncio
+async def test_best_of_n_picks_first_proxy_verified(monkeypatch: MonkeyPatch) -> None:
+    _patch_ids(monkeypatch, ["b0", "b1", "b2"])
+
+    # b1 finishes first but fails proxy; b0 finishes next and passes -> b0 wins.
+    plan = {
+        "b0": (0.02, True),
+        "b1": (0.01, False),
+        "b2": (0.05, True),
+    }
+
+    async def fake_candidate(self: Any, browser_id: str, origin_ip: Any, target_domain: Any):
+        delay, ok = plan[browser_id]
+        await asyncio.sleep(delay)
+        return browser_id, {"id": browser_id}, ok
+
+    cleaned: dict[str, Any] = {}
+
+    async def fake_cleanup(self: Any, ids: list[str], *, winner_id: str):
+        cleaned["ids"] = ids
+        cleaned["winner_id"] = winner_id
+
+    monkeypatch.setattr(DaytonaBackend, "_create_candidate", fake_candidate)
+    monkeypatch.setattr(DaytonaBackend, "_cleanup_losers", fake_cleanup)
+
+    winner_id, info = await _backend()._best_of_n(3, None, None)  # pyright: ignore[reportPrivateUsage]
+    await asyncio.sleep(0)  # let the fire-and-forget cleanup task run
+
+    assert winner_id == "b0"
+    assert info == {"id": "b0"}
+    assert cleaned == {"ids": ["b0", "b1", "b2"], "winner_id": "b0"}
+
+
+@pytest.mark.asyncio
+async def test_best_of_n_falls_back_to_fastest_started_when_no_proxy_verified(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _patch_ids(monkeypatch, ["b0", "b1"])
+
+    plan = {"b0": (0.03, False), "b1": (0.01, False)}
+
+    async def fake_candidate(self: Any, browser_id: str, origin_ip: Any, target_domain: Any):
+        delay, ok = plan[browser_id]
+        await asyncio.sleep(delay)
+        return browser_id, {"id": browser_id}, ok
+
+    async def fake_cleanup(self: Any, ids: list[str], *, winner_id: str):
+        return None
+
+    monkeypatch.setattr(DaytonaBackend, "_create_candidate", fake_candidate)
+    monkeypatch.setattr(DaytonaBackend, "_cleanup_losers", fake_cleanup)
+
+    winner_id, _ = await _backend()._best_of_n(2, None, None)  # pyright: ignore[reportPrivateUsage]
+    assert winner_id == "b1"  # fastest to start, since none verified their proxy
+
+
+@pytest.mark.asyncio
+async def test_best_of_n_raises_when_all_candidates_fail(monkeypatch: MonkeyPatch) -> None:
+    _patch_ids(monkeypatch, ["b0", "b1"])
+
+    async def fake_candidate(self: Any, browser_id: str, origin_ip: Any, target_domain: Any):
+        raise RuntimeError("boom")
+
+    async def fake_cleanup(self: Any, ids: list[str], *, winner_id: str):
+        return None
+
+    monkeypatch.setattr(DaytonaBackend, "_create_candidate", fake_candidate)
+    monkeypatch.setattr(DaytonaBackend, "_cleanup_losers", fake_cleanup)
+
+    with pytest.raises(RuntimeError, match="all sandbox candidates failed"):
+        await _backend()._best_of_n(2, None, None)  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_create_browser_auto_n1_uses_single_path(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(daytona_browsers.settings, "DAYTONA_BEST_OF_N", 1)
+    _patch_ids(monkeypatch, ["solo"])
+
+    called: dict[str, Any] = {}
+
+    async def fake_create_browser(self: Any, browser_id: str, origin_ip: Any, target_domain: Any):
+        called["browser_id"] = browser_id
+        return {"id": browser_id}
+
+    async def fail_best_of_n(*args: Any, **kwargs: Any):
+        raise AssertionError("best-of-N should not run when N=1")
+
+    monkeypatch.setattr(DaytonaBackend, "create_browser", fake_create_browser)
+    monkeypatch.setattr(DaytonaBackend, "_best_of_n", fail_best_of_n)
+
+    winner_id, info = await _backend().create_browser_auto(None, None)
+    assert winner_id == "solo"
+    assert info == {"id": "solo"}
+    assert called["browser_id"] == "solo"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_losers_deletes_all_but_winner(monkeypatch: MonkeyPatch) -> None:
+    deleted: list[str] = []
+
+    class FakeSandbox:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        async def delete(self) -> None:
+            deleted.append(self.name)
+
+    async def fake_get(self: Any, name: str):
+        return FakeSandbox(name)
+
+    monkeypatch.setattr(DaytonaBackend, "_get", fake_get)
+
+    backend = _backend()
+    backend._locks["w"] = asyncio.Lock()  # pyright: ignore[reportPrivateUsage]
+    backend._locks["l1"] = asyncio.Lock()  # pyright: ignore[reportPrivateUsage]
+
+    await backend._cleanup_losers(["w", "l1", "l2"], winner_id="w")  # pyright: ignore[reportPrivateUsage]
+
+    assert deleted == ["chromium-l1", "chromium-l2"]
+    assert "w" in backend._locks  # winner's lock preserved  # pyright: ignore[reportPrivateUsage]
+    assert "l1" not in backend._locks  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
On cold-create via `POST /api/v1/browsers`, launch N sandbox candidates in parallel and take the first that fully succeeds (started + proxy verified). Losers are deleted in the background.

`DAYTONA_BEST_OF_N=3` (default). Set to `1` to disable the race.

## Why

Single cold-create is slow and can land a bad proxy. Racing N candidates cuts the p99/tail latency and avoids a bad proxy blocking the user.

## Proxy is mandatory

If a proxy is configured for the browser, it MUST apply and change the egress IP. Otherwise the browser is rejected — we never hand back an unproxied browser:

- **best-of-N**: a candidate only counts as a winner after it starts AND passes proxy verification. If **every** candidate fails verification, best-of-N raises `ProxyVerificationError` (→ 500) instead of falling back to an unverified browser, so the client can retry.
- **single path** (`create_browser` / `get_browser`): the error propagates the same way.
- If **no** proxy is configured for the browser, verification is skipped (proxy is not required).

## Design — no identity change

- Each candidate is a normal browser with its own **server-assigned `browser_id`** and the existing **`chromium-<id>`** sandbox name. Ids are unique, so names never collide during the race.
- No `browser_id` label, no local mapping, no rename. `get`/`delete`/`cdp`/`live_view` lookups are untouched.
- The winner's id is returned to the caller and is authoritative.

Scope: only `POST /api/v1/browsers` (server assigns the id). `POST /api/v1/browsers/{browser_id}` is unchanged — the caller already committed to an id, so there is no winner to swap in; that path does **not** race.

## What changed

- **`backend`** — `new_browser_id()` helper + `create_browser_auto()` on the `Backend` protocol.
- **`router`** — `POST /api/v1/browsers` delegates id assignment to the backend.
- **`daytona`** — `_configure_remote_sandbox` raises `ProxyVerificationError` on a failed mandatory proxy (no-op when none configured). `_best_of_n` races candidates via `as_completed`, takes the first to complete, raises if all fail, and fires `_cleanup_losers`.
- **`_cleanup_losers`** — retries the delete. A cancelled candidate is usually still *starting*, so Daytona rejects the delete with `"Sandbox state change in progress"`; retry until it settles (Daytona's `auto_delete_interval` is the final backstop).
- **`fleet`** — forwards to the upstream auto endpoint (upstream owns the race). **`podman`** — single-create, no race.

## Tests

Unit: first-to-complete winner selection, no-proxy-verified raises, all-fail raises, N=1 single path, cleanup deletes losers only. `make check` + `make test` green.

## Live verification (real Daytona, proxy enabled)

5 requests each to `POST /api/v1/browsers` with `x-origin-ip`:

| stat | N=1 (single) | N=3 (best-of) | Δ |
|------|-------------|---------------|---|
| min | 8.03s | 7.61s | −5% |
| mean | 11.93s | 8.26s | **−31%** |
| median | 9.95s | 8.16s | −18% |
| **max (tail)** | **22.23s** | **9.42s** | **−58%** |

N=1 hit a 22s bad-proxy request; best-of-3 capped max at ~9.4s. The win is killing the tail. Logs confirm each request ran a `Best-of-3 sandbox race` and the winner was frequently **not** the first-listed candidate → selection actually chooses.

**Loser cleanup:** the retry fix was found and validated here — an early pass leaked 3/10 losers (`state change in progress`); after the fix, **10/10 (and 6/6 on re-verify) losers deleted, 0 gave up**. All test sandboxes cleaned up afterward.