### PR TITLE
fix: assign browser id client-side in FleetBackend.create_browser_auto

### DIFF
--- a/getgather/browsers/fleet_browsers.py
+++ b/getgather/browsers/fleet_browsers.py
@@ -4,7 +4,7 @@ import httpx
 from fastmcp.server.dependencies import get_http_headers
 from httpx_retries import Retry, RetryTransport
 
-from getgather.browsers.backend import BrowserNotFound
+from getgather.browsers.backend import BrowserNotFound, new_browser_id
 from getgather.client_ip import client_ip_var
 from getgather.config import settings
 
@@ -105,12 +105,10 @@ class FleetBackend:
     async def create_browser_auto(
         self, origin_ip: str | None, target_domain: str | None
     ) -> tuple[str, dict[str, Any]]:
-        # The upstream fleet owns id assignment (and any best-of-N race); forward to its
-        # server-assigned-id endpoint and echo back the id it picked.
-        headers = {"x-origin-ip": origin_ip} if origin_ip else {}
-        response = _require(await call_chromefleet_api("POST", headers=headers))
-        data: dict[str, Any] = response.json()
-        return str(data["browser_id"]), data
+        # The upstream fleet has no server-assigned-id endpoint (POST /api/v1/browsers returns
+        # 405); assign the id here and forward to the per-id endpoint.
+        browser_id = new_browser_id()
+        return browser_id, await self.create_browser(browser_id, origin_ip, target_domain)
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None


### PR DESCRIPTION
## Problem

Sentry [MCP-GETGATHER-82X](https://heyario.sentry.io/issues/7611693622/) — `HTTPException: Unable to start browser!` (16 occurrences, 3 users, escalating on `demo`).

Root cause is a nested `HTTPStatusError: 405 Method Not Allowed` for `POST /api/v1/browsers`. `FleetBackend.create_browser_auto` POSTed to the fleet **collection** endpoint expecting a server-assigned id, but the upstream Chrome Fleet only implements `POST /api/v1/browsers/{browser_id}`. Landed on main via #1400.

## Fix

Assign the id client-side via `new_browser_id()` and forward to the per-id endpoint — matching `PodmanBackend` and `DaytonaBackend`, which already do this.

`make check` passes.

Fixes MCP-GETGATHER-82X