### PR TITLE
fix: force IPv4 in Daytona proxy IP verification

### DIFF
--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -84,7 +84,11 @@ async def _configure_sandbox_proxy(sandbox: AsyncSandbox, proxy_url: str) -> boo
 async def _get_sandbox_public_ip(
     sandbox: AsyncSandbox, *, retries: int = 5, retry_delay: float = 2.0
 ) -> str | None:
-    cmd = "curl -s --max-time 10 --proxy http://127.0.0.1:8119 https://ip.fly.dev"
+    # Force IPv4 (-4): the residential upstream proxy is IPv4-only. Without this, curl reaches
+    # ip.fly.dev over the sandbox's native IPv6 and tinyproxy connects direct (bypassing the
+    # upstream), so the reported egress IP is the sandbox's own IPv6 both before and after the
+    # proxy is applied -> "IP unchanged" false ProxyVerificationError.
+    cmd = "curl -4 -s --max-time 10 --proxy http://127.0.0.1:8119 https://ip.fly.dev"
     for attempt in range(1, retries + 1):
         try:
             response = await sandbox.process.exec(cmd)


### PR DESCRIPTION
## Why

Trace [`75a8419d…`](https://logfire-us.pydantic.dev/getgather/remote-browser-dev?q=trace_id%3D%2775a8419d4edaf6d068a1915542717bb7%27) failed repeatedly on `GET /api/v1/browsers/{browser_id}` with:

```
getgather.browsers.daytona_browsers.ProxyVerificationError:
Sandbox chromium-Eqsry4ca IP unchanged after proxy: 2601:500:8201:6ba0:6b0:4dd0:c0c3:e1c0
```

Note the reported IP is **IPv6** — the sandbox's own address.

## Root cause

The residential upstream proxy is IPv4-only. `_get_sandbox_public_ip` probed egress with `curl --proxy http://127.0.0.1:8119 https://ip.fly.dev` **without `-4`**. curl reached `ip.fly.dev` over the sandbox's native IPv6, and tinyproxy connected directly (bypassing the upstream). So the probe returned the sandbox's own IPv6 both before and after applying the proxy → `ip_before == ip_after` → false `ProxyVerificationError`.

## Fix

Force `-4` on the probe so it traverses the IPv4 upstream and reports the proxy's egress IP.

## Follow-up (not in this PR)

The `-4` flag fixes the *verification*. If real Chrome traffic also escapes over IPv6, the proxy is genuinely bypassed for browsing. Worth confirming Chrome egress is IPv4-only (or disabling IPv6 in the snapshot).