### PR TITLE
fix: correct Daytona proxy verification and stop reconfiguring proxy on GET

### DIFF
--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -187,12 +187,12 @@ class DaytonaBackend:
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]:
+        # Proxy is applied + verified once at create time; GET is a cheap read that never
+        # reconfigures (no tinyproxy restart, no egress re-check), so it stays idempotent and
+        # can't 500 on a transient IP-check flake.
         sandbox = await self._get(_sandbox_name(browser_id))
         if sandbox is None:
             raise BrowserNotFound(browser_id)
-        if origin_ip:
-            # Mandatory proxy: propagate ProxyVerificationError instead of returning unproxied.
-            await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
         return await self._get_info(sandbox)
 
     async def delete_browser(self, browser_id: str) -> dict[str, Any]:

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -187,9 +187,6 @@ class DaytonaBackend:
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]:
-        # Proxy is applied + verified once at create time; GET is a cheap read that never
-        # reconfigures (no tinyproxy restart, no egress re-check), so it stays idempotent and
-        # can't 500 on a transient IP-check flake.
         sandbox = await self._get(_sandbox_name(browser_id))
         if sandbox is None:
             raise BrowserNotFound(browser_id)

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -84,7 +84,7 @@ async def _configure_sandbox_proxy(sandbox: AsyncSandbox, proxy_url: str) -> boo
 async def _get_sandbox_public_ip(
     sandbox: AsyncSandbox, *, retries: int = 5, retry_delay: float = 2.0
 ) -> str | None:
-    cmd = "curl -s --max-time 10 --proxy http://127.0.0.1:8119 https://ip.fly.dev"
+    cmd = "curl -s --max-time 20 --retry 2 --proxy http://127.0.0.1:8119 https://ip.fly.dev"
     for attempt in range(1, retries + 1):
         try:
             response = await sandbox.process.exec(cmd)
@@ -124,10 +124,18 @@ async def _configure_remote_sandbox(
         raise ProxyVerificationError(f"Proxy failed to apply on {sandbox.name}")
 
     ip_after = await _get_sandbox_public_ip(sandbox)
-    if ip_before and ip_after and ip_before != ip_after:
-        logger.info(f"Sandbox {sandbox.name} IP changed: {ip_before} -> {ip_after}")
-        return
-    raise ProxyVerificationError(f"Sandbox {sandbox.name} IP unchanged after proxy: {ip_before}")
+    if ip_after is None:
+        # Distinct from "unchanged": the egress IP check itself failed (curl/exec timeout),
+        # so we cannot confirm the proxy either way. Fail the candidate with an accurate reason.
+        raise ProxyVerificationError(
+            f"Could not verify egress IP on {sandbox.name} (IP check failed)"
+        )
+    if ip_before is not None and ip_before == ip_after:
+        raise ProxyVerificationError(
+            f"Sandbox {sandbox.name} IP unchanged after proxy: {ip_before}"
+        )
+    logger.info(f"Sandbox {sandbox.name} IP after proxy: {ip_after} (before: {ip_before})")
+    return
 
 
 def _browser_id_from_name(name: str) -> str:

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -84,7 +84,7 @@ async def _configure_sandbox_proxy(sandbox: AsyncSandbox, proxy_url: str) -> boo
 async def _get_sandbox_public_ip(
     sandbox: AsyncSandbox, *, retries: int = 5, retry_delay: float = 2.0
 ) -> str | None:
-    cmd = "curl -s --max-time 20 --retry 2 --proxy http://127.0.0.1:8119 https://ip.fly.dev"
+    cmd = "curl -s --max-time 10 --proxy http://127.0.0.1:8119 https://ip.fly.dev"
     for attempt in range(1, retries + 1):
         try:
             response = await sandbox.process.exec(cmd)

--- a/tests/test_daytona_best_of_n.py
+++ b/tests/test_daytona_best_of_n.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from pytest import MonkeyPatch
@@ -105,6 +105,61 @@ async def test_create_browser_auto_n1_uses_single_path(monkeypatch: MonkeyPatch)
     assert winner_id == "solo"
     assert info == {"id": "solo"}
     assert called["browser_id"] == "solo"
+
+
+def _patch_proxy(monkeypatch: MonkeyPatch, *, ips: list[str | None], proxy_ok: bool = True) -> None:
+    """Force a configured proxy and drive _get_sandbox_public_ip's return sequence."""
+
+    class _Cfg:
+        def get_proxy_url(self, browser_id: str) -> str:
+            return "http://proxy.example:9999"
+
+    async def fake_get_proxy_config(*args: Any, **kwargs: Any):
+        return _Cfg()
+
+    async def fake_configure_sandbox_proxy(*args: Any, **kwargs: Any) -> bool:
+        return proxy_ok
+
+    it = iter(ips)
+
+    async def fake_public_ip(*args: Any, **kwargs: Any):
+        return next(it)
+
+    monkeypatch.setattr(daytona_browsers, "get_proxy_config", fake_get_proxy_config)
+    monkeypatch.setattr(daytona_browsers, "_configure_sandbox_proxy", fake_configure_sandbox_proxy)
+    monkeypatch.setattr(daytona_browsers, "_get_sandbox_public_ip", fake_public_ip)
+
+
+class _Sandbox:
+    name = "chromium-test"
+
+
+def _fake_sandbox() -> "daytona_browsers.AsyncSandbox":
+    return cast("daytona_browsers.AsyncSandbox", _Sandbox())
+
+
+@pytest.mark.asyncio
+async def test_configure_remote_sandbox_ok_when_ip_before_missing(monkeypatch: MonkeyPatch) -> None:
+    # Regression: a failed ip_before measurement (None) must NOT fail a working proxy.
+    _patch_proxy(monkeypatch, ips=[None, "9.9.9.9"])
+    await daytona_browsers._configure_remote_sandbox(_fake_sandbox(), "b0", None, None)  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_configure_remote_sandbox_raises_on_ip_check_failure(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # ip_after is None (curl/exec timeout): distinct, accurate error, not "IP unchanged".
+    _patch_proxy(monkeypatch, ips=["1.1.1.1", None])
+    with pytest.raises(ProxyVerificationError, match="IP check failed"):
+        await daytona_browsers._configure_remote_sandbox(_fake_sandbox(), "b0", None, None)  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_configure_remote_sandbox_raises_when_ip_unchanged(monkeypatch: MonkeyPatch) -> None:
+    _patch_proxy(monkeypatch, ips=["1.1.1.1", "1.1.1.1"])
+    with pytest.raises(ProxyVerificationError, match="IP unchanged"):
+        await daytona_browsers._configure_remote_sandbox(_fake_sandbox(), "b0", None, None)  # pyright: ignore[reportPrivateUsage]
 
 
 @pytest.mark.asyncio

--- a/tests/test_daytona_best_of_n.py
+++ b/tests/test_daytona_best_of_n.py
@@ -163,6 +163,31 @@ async def test_configure_remote_sandbox_raises_when_ip_unchanged(monkeypatch: Mo
 
 
 @pytest.mark.asyncio
+async def test_get_browser_never_reconfigures_proxy(monkeypatch: MonkeyPatch) -> None:
+    # GET is a cheap read: proxy is configured+verified once on create, never on get, even when
+    # x-origin-ip is present. Otherwise every GET restarts tinyproxy and can 500 on an IP-check flake.
+    configured = False
+
+    async def fake_configure(*args: Any, **kwargs: Any) -> None:
+        nonlocal configured
+        configured = True
+
+    async def fake_get(self: Any, name: str):
+        return _Sandbox()
+
+    async def fake_info(self: Any, sandbox: Any):
+        return {"id": "b0"}
+
+    monkeypatch.setattr(daytona_browsers, "_configure_remote_sandbox", fake_configure)
+    monkeypatch.setattr(DaytonaBackend, "_get", fake_get)
+    monkeypatch.setattr(DaytonaBackend, "_get_info", fake_info)
+
+    info = await _backend().get_browser("b0", origin_ip="1.2.3.4", target_domain="amazon.com")
+    assert info == {"id": "b0"}
+    assert configured is False
+
+
+@pytest.mark.asyncio
 async def test_cleanup_losers_deletes_all_but_winner(monkeypatch: MonkeyPatch) -> None:
     deleted: list[str] = []
 


### PR DESCRIPTION
Two related fixes to Daytona proxy handling (follow-up to #1400).

## 1. Proxy verification folded distinct outcomes into one misleading raise

`_configure_remote_sandbox` verified the proxy with:

```python
if ip_before and ip_after and ip_before != ip_after:
    return
raise ProxyVerificationError(f"...IP unchanged after proxy: {ip_before}")
```

`_get_sandbox_public_ip` returns `None` on any curl/exec failure, so a `None` on **either** side short-circuits the `and` to False and raises a misleading **"IP unchanged"** — even when the proxy applied fine and the egress IP actually differed:

- `ip_before=None` — tinyproxy@8119 not yet serving on a freshly-created sandbox
- `ip_after=None` — the IP-check curl timing out (seen in prod as `UND_ERR_HEADERS_TIMEOUT` / "operation aborted")

A transient timeout thus failed **every** best-of-N candidate → `_best_of_n` all-fail → `ProxyVerificationError` to the client.

**Fix:**
- `ip_after is None` → raise a distinct **"IP check failed"** error (can't confirm either way), not "unchanged"
- "IP unchanged" only raises when **both** IPs are present and equal
- a missing `ip_before` no longer fails a working proxy

## 2. GET /api/v1/browsers/{id} no longer reconfigures the proxy

`get_browser` re-ran `_configure_remote_sandbox` on every GET carrying `x-origin-ip` — rewriting tinyproxy.conf, restarting tinyproxy (`s6-svc -r`), and re-running egress IP verification. On an existing browser that's pure waste: it restarts the proxy mid-session and (given fix #1) can 500 a plain read on a transient IP-check flake.

Proxy is now applied + verified **once at create**. GET is a cheap, idempotent read: look up the sandbox and return info.

> Note: browsers are single-purpose, so a persistent browser is not re-matched to a different proxy on later GETs. Re-create (POST) to change proxy.

## Tests
- `ip_before` missing → succeeds (regression)
- `ip_after` None → raises "IP check failed"
- IPs equal → raises "IP unchanged"
- `get_browser` never calls `_configure_remote_sandbox`, even with `origin_ip`

`make check` clean, all daytona tests pass.