### PR TITLE
Best-of-N has a backend-specific default value

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -9,6 +9,7 @@ BROWSER_BACKEND=podman
 
 # Best-of-N cold-create: race this many browser candidates in parallel and keep the first whose
 # create succeeds (losers are deleted in the background). 1 disables the race.
+# Leave empty to use the backend's default: Podman=5, Daytona=3, Fleet=1.
 # Only affects POST /api/v1/browsers.
 BROWSER_BEST_OF_N=
 

--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -138,6 +138,9 @@ class Backend(Protocol):
 
     async def shutdown(self) -> None: ...
 
+    @property
+    def default_best_of_n(self) -> int: ...
+
     async def create_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]: ...

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -24,6 +24,8 @@ from getgather.config import settings
 CDP_PORT = 9222
 VNC_PORT = 8080
 
+DEFAULT_BEST_OF_N = 3
+
 # Chrome stores last_visit_time as microseconds since 1601-01-01; this offset converts to unix epoch.
 CHROMIUM_EPOCH_OFFSET_SECONDS = 11644473600
 CHROME_HISTORY_PATH = "/home/user/chrome-profile/Default/History"
@@ -159,6 +161,10 @@ class DaytonaBackend:
         self.snapshot = snapshot
         self.client = AsyncDaytona(DaytonaConfig(api_key=api_key, api_url=api_url or None))
         self._locks: dict[str, asyncio.Lock] = {}
+
+    @property
+    def default_best_of_n(self) -> int:
+        return DEFAULT_BEST_OF_N
 
     async def shutdown(self) -> None:
         await self.client.close()

--- a/getgather/browsers/fleet_browsers.py
+++ b/getgather/browsers/fleet_browsers.py
@@ -10,6 +10,8 @@ from getgather.config import settings
 
 HTTP_METHOD = Literal["GET", "POST", "DELETE"]
 
+DEFAULT_BEST_OF_N = 1
+
 
 def build_chromefleet_headers(*, target_domain: str | None = None) -> dict[str, str]:
     mcp_headers = get_http_headers(include_all=True)
@@ -94,6 +96,10 @@ class FleetBackend:
 
     async def shutdown(self) -> None:
         return None
+
+    @property
+    def default_best_of_n(self) -> int:
+        return DEFAULT_BEST_OF_N
 
     async def create_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None

--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -18,6 +18,8 @@ from getgather.config import settings
 
 DOCKER_INTERNAL_HOST = "172.17.0.1"
 
+DEFAULT_BEST_OF_N = 5
+
 
 # uvloop's child process watcher can cause asyncio.create_subprocess_exec to hang
 # indefinitely. When uvloop is the active event loop, fall back to running the
@@ -325,6 +327,10 @@ async def get_cdp_url(browser_id: str) -> str:
 
 
 class PodmanBackend:
+    @property
+    def default_best_of_n(self) -> int:
+        return DEFAULT_BEST_OF_N
+
     async def shutdown(self) -> None:
         return None
 

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -217,13 +217,16 @@ async def websocket_proxy(
 @router.post("/api/v1/browsers")
 async def create_browser_auto_endpoint(request: Request) -> dict[str, Any]:
     # Server-assigned id + best-of-N policy lives here (not per-backend): every backend only owns
-    # per-browser CRUD keyed by a caller-supplied id. When BROWSER_BEST_OF_N > 1 it races that many
-    # candidates via best_of_n and returns the winner; otherwise it creates a single browser directly.
+    # per-browser CRUD keyed by a caller-supplied id. When the effective N > 1 it races that many
+    # candidates via best_of_n and returns the winner; otherwise it creates a single browser
+    # directly. The effective N is BROWSER_BEST_OF_N when explicitly set, else the backend's own
+    # default (see `Backend.default_best_of_n`).
     logger.info("Starting browser (server-assigned id)...")
     try:
         origin_ip = request.headers.get("x-origin-ip")
         target_domain = request.headers.get("x-target-domains")
-        n = max(1, settings.BROWSER_BEST_OF_N)
+        explicit = settings.BROWSER_BEST_OF_N
+        n = max(1, explicit if explicit is not None else backend.default_best_of_n)
         if n == 1:
             browser_id = new_browser_id()
             result = await backend.create_browser(browser_id, origin_ip, target_domain)

--- a/getgather/browsers/settings.py
+++ b/getgather/browsers/settings.py
@@ -56,8 +56,9 @@ class BrowserSettings(BaseSettings):
     # first whose `create_browser` fully succeeds.
     # Losers are deleted in the background. Set to 1 to disable the race and create a single
     # browser. Applies to every backend; only used by the server-assigned-id endpoint
-    # (POST /api/v1/browsers).
-    BROWSER_BEST_OF_N: int = 1
+    # (POST /api/v1/browsers). When unset (None), each backend supplies its own default
+    # (see `Backend.default_best_of_n`): Podman=5, Daytona=3, Fleet=1.
+    BROWSER_BEST_OF_N: int | None = None
 
     @property
     def effective_chromefleet_url(self) -> str:

--- a/tests/test_browser_backend.py
+++ b/tests/test_browser_backend.py
@@ -53,6 +53,7 @@ def test_create_browser_auto_name_starts_with_b(monkeypatch: MonkeyPatch) -> Non
             "ip": "1.2.3.4",
         }
 
+    monkeypatch.setattr(settings, "BROWSER_BEST_OF_N", 1)
     monkeypatch.setattr(browsers_router.backend, "create_browser", fake_create_browser)
 
     app = FastAPI()

--- a/tests/test_daytona_browsers.py
+++ b/tests/test_daytona_browsers.py
@@ -167,3 +167,48 @@ def test_create_browser_auto_n_gt1_invokes_best_of_n(monkeypatch: MonkeyPatch) -
     assert response.status_code == 200
     assert response.json() == {"browser_id": "winner", "id": "winner"}
     assert invoked == {"n": 3, "origin_ip": "1.2.3.4", "target_domain": "amazon.com"}
+
+
+def test_create_browser_auto_uses_backend_default_when_env_unset(monkeypatch: MonkeyPatch) -> None:
+    # When BROWSER_BEST_OF_N is unset (None), the router falls back to the backend's own default
+    # (DaytonaBackend.default_best_of_n == 3) instead of hard-coding 1.
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from getgather.browsers import router as router_module
+
+    monkeypatch.setattr(router_module.settings, "BROWSER_BEST_OF_N", None)
+    monkeypatch.setattr(router_module, "backend", _backend())
+
+    invoked: dict[str, Any] = {}
+
+    async def fake_best_of_n(
+        backend: Any, n: int, origin_ip: str | None, target_domain: str | None
+    ) -> tuple[str, dict[str, str]]:
+        invoked["n"] = n
+        return "winner", {"id": "winner"}
+
+    monkeypatch.setattr(router_module, "best_of_n", fake_best_of_n)
+
+    app = FastAPI()
+    app.include_router(router_module.router)
+    client = TestClient(app)
+
+    response = client.post("/api/v1/browsers")
+    assert response.status_code == 200
+    assert invoked["n"] == 3
+
+
+@pytest.mark.parametrize(
+    ("module_name", "expected"),
+    [
+        ("getgather.browsers.podman_browsers", 5),
+        ("getgather.browsers.daytona_browsers", 3),
+        ("getgather.browsers.fleet_browsers", 1),
+    ],
+)
+def test_backend_default_best_of_n_consts(module_name: str, expected: int) -> None:
+    import importlib
+
+    module = importlib.import_module(module_name)
+    assert module.DEFAULT_BEST_OF_N == expected


### PR DESCRIPTION
This is a follow-up to PR #1405.

`BROWSER_BEST_OF_N` env is optional (None). When unset, each backend supplies its own default via a `DEFAULT_BEST_OF_N` const and a `default_best_of_n` property on the Backend protocol: Podman=5, Daytona=3, Fleet=1.

The `POST /api/v1/browsers` endpoint uses the explicit env value if set, otherwise the backend default.

Here's how it looks with Podman, when accessed by Headline Hub (as the test client).

<img width="1649" height="908" alt="image" src="https://github.com/user-attachments/assets/9d26a81e-ad6d-422d-9ba7-bf46d987ba20" />
