### PR TITLE
feat: per-request browser selection via x-browser-type header

### DIFF
--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -44,12 +44,20 @@ class _BestOfNBackend(_CleanupBackend, Protocol):
     while tests can pass a minimal fake."""
 
     async def create_browser(
-        self, browser_id: str, origin_ip: str | None, target_domain: str | None
+        self,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        browser_type: str | None,
     ) -> dict[str, Any]: ...
 
 
 async def best_of_n(
-    backend: _BestOfNBackend, n: int, origin_ip: str | None, target_domain: str | None
+    backend: _BestOfNBackend,
+    n: int,
+    origin_ip: str | None,
+    target_domain: str | None,
+    browser_type: str | None,
 ) -> tuple[str, dict[str, Any]]:
     """Race `n` cold-create candidates; keep the first that fully succeeds, delete the rest.
 
@@ -64,7 +72,7 @@ async def best_of_n(
     logger.info(f"Best-of-{n} browser race: {ids}")
 
     async def _candidate(bid: str) -> tuple[str, dict[str, Any]]:
-        return bid, await backend.create_browser(bid, origin_ip, target_domain)
+        return bid, await backend.create_browser(bid, origin_ip, target_domain, browser_type)
 
     tasks = [asyncio.create_task(_candidate(b)) for b in ids]
     winner: tuple[str, dict[str, Any]] | None = None
@@ -139,7 +147,11 @@ class Backend(Protocol):
     async def shutdown(self) -> None: ...
 
     async def create_browser(
-        self, browser_id: str, origin_ip: str | None, target_domain: str | None
+        self,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        browser_type: str | None,
     ) -> dict[str, Any]: ...
 
     async def get_browser(

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -169,11 +169,15 @@ class DaytonaBackend:
         await self.client.close()
 
     async def create_browser(
-        self, browser_id: str, origin_ip: str | None, target_domain: str | None
+        self,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        browser_type: str | None,
     ) -> dict[str, Any]:
         lock = self._locks.setdefault(browser_id, asyncio.Lock())
         async with lock:
-            sandbox = await self._ensure(browser_id)
+            sandbox = await self._ensure(browser_id, browser_type)
             # Proxy is mandatory when configured: let ProxyVerificationError propagate (the endpoint
             # maps it to 500) so the client can retry rather than get an unproxied browser.
             await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
@@ -254,11 +258,11 @@ class DaytonaBackend:
         )
         return signed.url
 
-    async def _ensure(self, browser_id: str) -> AsyncSandbox:
+    async def _ensure(self, browser_id: str, browser_type: str | None = None) -> AsyncSandbox:
         name = _sandbox_name(browser_id)
         sandbox = await self._get(name)
         if sandbox is None:
-            sandbox = await self._create(name)
+            sandbox = await self._create(name, browser_type)
 
         # Browser selection is baked into the sandbox at create time via the ACTIVE_BROWSER env var
         # (see _create), so both a fresh create and a resumed start boot the right browser directly —
@@ -317,14 +321,17 @@ class DaytonaBackend:
         except DaytonaNotFoundError:
             return None
 
-    async def _create(self, name: str) -> AsyncSandbox:
+    async def _create(self, name: str, browser_type: str | None = None) -> AsyncSandbox:
         # Select the browser at boot via env; the chromium s6 service reads ACTIVE_BROWSER on first
-        # boot (chrome-live). Defaults to "chrome" so an ACTIVE_BROWSER-unaware snapshot is unaffected.
+        # boot (chrome-live). Per-request `browser_type` (x-browser-type header) wins; otherwise the
+        # DAYTONA_ACTIVE_BROWSER default. Defaults to "chrome" so an ACTIVE_BROWSER-unaware snapshot
+        # is unaffected.
+        active_browser = browser_type or settings.DAYTONA_ACTIVE_BROWSER
         params = CreateSandboxFromSnapshotParams(
             snapshot=self.snapshot,
             name=name,
             labels={LABEL_FLEET: "1"},
-            env_vars={ACTIVE_BROWSER_ENV: settings.DAYTONA_ACTIVE_BROWSER},
+            env_vars={ACTIVE_BROWSER_ENV: active_browser},
             public=False,
             auto_stop_interval=AUTO_STOP_MINUTES,
             # delete after TTL_MINUTES continuously stopped; Daytona owns teardown

--- a/getgather/browsers/fleet_browsers.py
+++ b/getgather/browsers/fleet_browsers.py
@@ -96,9 +96,15 @@ class FleetBackend:
         return None
 
     async def create_browser(
-        self, browser_id: str, origin_ip: str | None, target_domain: str | None
+        self,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        browser_type: str | None,
     ) -> dict[str, Any]:
         headers = {"x-origin-ip": origin_ip} if origin_ip else {}
+        if browser_type:
+            headers["x-browser-type"] = browser_type
         response = _require(await call_chromefleet_api("POST", browser_id, headers=headers))
         return response.json()
 

--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -329,7 +329,11 @@ class PodmanBackend:
         return None
 
     async def create_browser(
-        self, browser_id: str, origin_ip: str | None, target_domain: str | None
+        self,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        browser_type: str | None,  # not supported by the podman backend; always Chrome
     ) -> dict[str, Any]:
         container_name = f"{BROWSER_NAME_PREFIX}{browser_id}"
         await launch_container(settings.CONTAINER_IMAGE, container_name)

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -223,12 +223,15 @@ async def create_browser_auto_endpoint(request: Request) -> dict[str, Any]:
     try:
         origin_ip = request.headers.get("x-origin-ip")
         target_domain = request.headers.get("x-target-domains")
+        browser_type = request.headers.get("x-browser-type")
         n = max(1, settings.BROWSER_BEST_OF_N)
         if n == 1:
             browser_id = new_browser_id()
-            result = await backend.create_browser(browser_id, origin_ip, target_domain)
+            result = await backend.create_browser(
+                browser_id, origin_ip, target_domain, browser_type
+            )
         else:
-            browser_id, result = await best_of_n(backend, n, origin_ip, target_domain)
+            browser_id, result = await best_of_n(backend, n, origin_ip, target_domain, browser_type)
         logger.info(f"Browser {browser_id} is started.")
         return {"browser_id": browser_id, **result}
     except Exception as e:
@@ -243,7 +246,8 @@ async def create_browser(browser_id: str, request: Request) -> dict[str, Any]:
     try:
         origin_ip = request.headers.get("x-origin-ip")
         target_domain = request.headers.get("x-target-domains")
-        result = await backend.create_browser(browser_id, origin_ip, target_domain)
+        browser_type = request.headers.get("x-browser-type")
+        result = await backend.create_browser(browser_id, origin_ip, target_domain, browser_type)
         logger.info(f"Browser {browser_id} is started.")
         return result
     except Exception as e:
@@ -305,7 +309,8 @@ async def cdp_browser_websocket_proxy(client_ws: WebSocket, browser_id: str) -> 
         try:
             origin_ip = client_ws.headers.get("x-origin-ip")
             target_domain = client_ws.headers.get("x-target-domains")
-            await backend.create_browser(browser_id, origin_ip, target_domain)
+            browser_type = client_ws.headers.get("x-browser-type")
+            await backend.create_browser(browser_id, origin_ip, target_domain, browser_type)
             logger.info(f"[CDP] Browser {browser_id} started")
         except Exception as e:
             logger.error(f"[CDP] Failed to auto-start browser {browser_id}: {e}")

--- a/tests/test_best_of_n.py
+++ b/tests/test_best_of_n.py
@@ -25,7 +25,11 @@ class _FakeBackend:
         self.existing: set[str] = set()
 
     async def create_browser(
-        self, browser_id: str, origin_ip: str | None, target_domain: str | None
+        self,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        browser_type: str | None,
     ) -> dict[str, Any]:
         delay = self.delays.get(browser_id, 0.0)
         if delay:
@@ -69,7 +73,7 @@ async def test_best_of_n_picks_first_to_complete(monkeypatch: MonkeyPatch) -> No
     backend.delays = {"b0": 0.02, "b1": 0.01, "b2": 0.05}
     backend.create_outcomes = {"b1": ProxyVerificationError("proxy unchanged")}
 
-    winner_id, info = await best_of_n(backend, 3, None, None)
+    winner_id, info = await best_of_n(backend, 3, None, None, None)
     await asyncio.sleep(0)  # let the fire-and-forget cleanup task schedule
 
     assert winner_id == "b0"
@@ -86,7 +90,7 @@ async def test_best_of_n_raises_when_all_candidates_fail(monkeypatch: MonkeyPatc
     }
 
     with pytest.raises(ProxyVerificationError, match="no browser candidate started"):
-        await best_of_n(backend, 2, None, None)
+        await best_of_n(backend, 2, None, None, None)
 
 
 @pytest.mark.asyncio
@@ -96,7 +100,7 @@ async def test_best_of_n_winner_is_not_deleted(monkeypatch: MonkeyPatch) -> None
     backend = _FakeBackend()
     backend.delays = {"w": 0.01, "l1": 0.05, "l2": 0.05}
 
-    winner_id, _ = await best_of_n(backend, 3, None, None)
+    winner_id, _ = await best_of_n(backend, 3, None, None, None)
     assert winner_id == "w"
     assert "w" not in backend.deleted
 
@@ -150,17 +154,26 @@ async def test_cleanup_losers_waits_for_materialization(monkeypatch: MonkeyPatch
 
 
 @pytest.mark.asyncio
-async def test_best_of_n_passes_origin_ip_and_target_domain(monkeypatch: MonkeyPatch) -> None:
+async def test_best_of_n_passes_origin_ip_target_domain_and_browser_type(
+    monkeypatch: MonkeyPatch,
+) -> None:
     _patch_ids(monkeypatch, ["b0", "b1"])
-    seen: list[tuple[str, str | None, str | None]] = []
+    seen: list[tuple[str, str | None, str | None, str | None]] = []
 
     class _Tracking(_FakeBackend):
         async def create_browser(
-            self, browser_id: str, origin_ip: str | None, target_domain: str | None
+            self,
+            browser_id: str,
+            origin_ip: str | None,
+            target_domain: str | None,
+            browser_type: str | None,
         ) -> dict[str, Any]:
-            seen.append((browser_id, origin_ip, target_domain))
+            seen.append((browser_id, origin_ip, target_domain, browser_type))
             self.existing.add(browser_id)
             return {"id": browser_id}
 
-    await best_of_n(_Tracking(), 2, "1.2.3.4", "amazon.com")
-    assert set(seen) == {("b0", "1.2.3.4", "amazon.com"), ("b1", "1.2.3.4", "amazon.com")}
+    await best_of_n(_Tracking(), 2, "1.2.3.4", "amazon.com", "cloak")
+    assert set(seen) == {
+        ("b0", "1.2.3.4", "amazon.com", "cloak"),
+        ("b1", "1.2.3.4", "amazon.com", "cloak"),
+    }

--- a/tests/test_browser_backend.py
+++ b/tests/test_browser_backend.py
@@ -45,7 +45,10 @@ def test_create_browser_auto_name_starts_with_b(monkeypatch: MonkeyPatch) -> Non
     from fastapi.testclient import TestClient
 
     async def fake_create_browser(
-        browser_id: str, origin_ip: str | None, target_domain: str | None
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        browser_type: str | None,
     ):
         return {
             "container_name": f"chromium-{browser_id}",

--- a/tests/test_daytona_browsers.py
+++ b/tests/test_daytona_browsers.py
@@ -112,9 +112,14 @@ def test_create_browser_n1_short_circuits_best_of_n(monkeypatch: MonkeyPatch) ->
     called: dict[str, Any] = {}
 
     async def fake_create_browser(
-        self: Any, browser_id: str, origin_ip: str | None, target_domain: str | None
+        self: Any,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        browser_type: str | None,
     ) -> dict[str, str]:
         called["browser_id"] = browser_id
+        called["browser_type"] = browser_type
         return {"id": browser_id}
 
     async def fail_best_of_n(*args: Any, **kwargs: Any) -> tuple[str, dict[str, Any]]:
@@ -128,11 +133,12 @@ def test_create_browser_n1_short_circuits_best_of_n(monkeypatch: MonkeyPatch) ->
     app.include_router(router_module.router)
     client = TestClient(app)
 
-    response = client.post("/api/v1/browsers")
+    response = client.post("/api/v1/browsers", headers={"x-browser-type": "cloak"})
     assert response.status_code == 200
     data = response.json()
     assert data == {"browser_id": "solo", "id": "solo"}
     assert called["browser_id"] == "solo"
+    assert called["browser_type"] == "cloak"  # x-browser-type header threaded through
 
 
 def test_create_browser_auto_n_gt1_invokes_best_of_n(monkeypatch: MonkeyPatch) -> None:
@@ -148,11 +154,16 @@ def test_create_browser_auto_n_gt1_invokes_best_of_n(monkeypatch: MonkeyPatch) -
     invoked: dict[str, Any] = {}
 
     async def fake_best_of_n(
-        backend: Any, n: int, origin_ip: str | None, target_domain: str | None
+        backend: Any,
+        n: int,
+        origin_ip: str | None,
+        target_domain: str | None,
+        browser_type: str | None,
     ) -> tuple[str, dict[str, str]]:
         invoked["n"] = n
         invoked["origin_ip"] = origin_ip
         invoked["target_domain"] = target_domain
+        invoked["browser_type"] = browser_type
         return "winner", {"id": "winner"}
 
     monkeypatch.setattr(router_module, "best_of_n", fake_best_of_n)
@@ -162,11 +173,21 @@ def test_create_browser_auto_n_gt1_invokes_best_of_n(monkeypatch: MonkeyPatch) -
     client = TestClient(app)
 
     response = client.post(
-        "/api/v1/browsers", headers={"x-origin-ip": "1.2.3.4", "x-target-domains": "amazon.com"}
+        "/api/v1/browsers",
+        headers={
+            "x-origin-ip": "1.2.3.4",
+            "x-target-domains": "amazon.com",
+            "x-browser-type": "cloak",
+        },
     )
     assert response.status_code == 200
     assert response.json() == {"browser_id": "winner", "id": "winner"}
-    assert invoked == {"n": 3, "origin_ip": "1.2.3.4", "target_domain": "amazon.com"}
+    assert invoked == {
+        "n": 3,
+        "origin_ip": "1.2.3.4",
+        "target_domain": "amazon.com",
+        "browser_type": "cloak",
+    }
 
 
 async def _capture_create_params(monkeypatch: MonkeyPatch, backend: DaytonaBackend) -> list[Any]:
@@ -197,3 +218,24 @@ async def test_create_sets_active_browser_env_chrome_by_default(monkeypatch: Mon
     captured = await _capture_create_params(monkeypatch, backend)
     await backend._create("chromium-test")  # pyright: ignore[reportPrivateUsage]
     assert captured[0].env_vars == {"ACTIVE_BROWSER": "chrome"}
+
+
+@pytest.mark.asyncio
+async def test_create_browser_type_overrides_setting(monkeypatch: MonkeyPatch) -> None:
+    # Per-request browser_type (x-browser-type) wins over the DAYTONA_ACTIVE_BROWSER default.
+    monkeypatch.setattr(daytona_browsers.settings, "DAYTONA_ACTIVE_BROWSER", "chrome")
+    backend = _backend()
+    captured = await _capture_create_params(monkeypatch, backend)
+    await backend._create("chromium-test", "cloak")  # pyright: ignore[reportPrivateUsage]
+    assert captured[0].env_vars == {"ACTIVE_BROWSER": "cloak"}
+
+
+@pytest.mark.asyncio
+async def test_create_falls_back_to_setting_when_browser_type_none(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(daytona_browsers.settings, "DAYTONA_ACTIVE_BROWSER", "cloak")
+    backend = _backend()
+    captured = await _capture_create_params(monkeypatch, backend)
+    await backend._create("chromium-test", None)  # pyright: ignore[reportPrivateUsage]
+    assert captured[0].env_vars == {"ACTIVE_BROWSER": "cloak"}

--- a/tests/test_podman_browsers.py
+++ b/tests/test_podman_browsers.py
@@ -123,7 +123,7 @@ async def test_create_browser_propagates_proxy_verification_error(monkeypatch: M
     monkeypatch.setattr(podman_browsers, "configure_remote_browser", fake_configure)
 
     with pytest.raises(ProxyVerificationError, match="IP unchanged"):
-        await PodmanBackend().create_browser("b0", "1.2.3.4", "amazon.com")
+        await PodmanBackend().create_browser("b0", "1.2.3.4", "amazon.com", None)
 
 
 @pytest.mark.asyncio
@@ -146,7 +146,11 @@ async def test_best_of_n_treats_proxy_failure_as_loser(monkeypatch: MonkeyPatch)
             self.existing: set[str] = set()
 
         async def create_browser(
-            self, browser_id: str, origin_ip: str | None, target_domain: str | None
+            self,
+            browser_id: str,
+            origin_ip: str | None,
+            target_domain: str | None,
+            browser_type: str | None,
         ) -> dict[str, Any]:
             if browser_id == "b0":
                 raise ProxyVerificationError("IP unchanged after proxy")
@@ -163,6 +167,6 @@ async def test_best_of_n_treats_proxy_failure_as_loser(monkeypatch: MonkeyPatch)
     ids = iter(["b0", "b1"])
     monkeypatch.setattr(backend_module, "new_browser_id", lambda: next(ids))
 
-    winner_id, info = await best_of_n(_Backend(), 2, "1.2.3.4", "amazon.com")
+    winner_id, info = await best_of_n(_Backend(), 2, "1.2.3.4", "amazon.com", None)
     assert winner_id == "b1"
     assert info == {"id": "b1"}


### PR DESCRIPTION
Stacked on #1407 (base branch `cloakbrowser-handoff`).

## What

Lets a client choose the browser **per create request** with an `x-browser-type` header (`chrome` | `cloak`), overriding the `DAYTONA_ACTIVE_BROWSER` default. Same client-header → backend pattern as `x-origin-ip`.

## How

- `router.py`: read `x-browser-type` in all three create paths (auto `/api/v1/browsers`, by-id, CDP websocket auto-start); pass through as `browser_type`.
- `backend.py`: `browser_type` param added to the `Backend`/best-of-N `create_browser` protocol and threaded through `best_of_n`.
- `daytona_browsers`: `_create` uses `browser_type or settings.DAYTONA_ACTIVE_BROWSER` as the `ACTIVE_BROWSER` env — per-request wins, setting is the fallback.
- `fleet_browsers`: forwards `x-browser-type` upstream to Chrome Fleet.
- `podman_browsers`: accepts and ignores (always Chrome).

Header absent → falls back to `DAYTONA_ACTIVE_BROWSER` (default `chrome`), so existing behavior is unchanged.

## Usage
```bash
curl -X POST http://host/api/v1/browsers -H "x-browser-type: cloak"
```

## Tests
- Header threads through the N=1 and N>1 (best_of_n) endpoints.
- `_create`: per-request `browser_type` overrides the setting; `None` falls back to it.
- best_of_n / podman fakes updated to the new signature.
- Full suite: 94 passed.