### PR TITLE
fix(proxy): skip MaxMind for private/non-global IPs

### DIFF
--- a/getgather/browsers/residential_proxy.py
+++ b/getgather/browsers/residential_proxy.py
@@ -20,7 +20,7 @@ _PROXY_DOMAIN_POOLS: list[tuple[Literal["oxylabs", "massive"], set[str]]] = [
 ]
 
 
-def _should_skip_geolocation(ip: str) -> bool:
+def should_skip_geolocation(ip: str) -> bool:
     """True for IPs that MaxMind cannot (and should not) geolocate.
 
     Mirrors Go's net.IP checks: IsPrivate / IsLoopback / IsLinkLocalUnicast /
@@ -77,7 +77,7 @@ class GeoLocation(BaseModel):
 
 @alru_cache
 async def get_location(ip: str, account_id: int, license_key: str) -> "GeoLocation | None":
-    if _should_skip_geolocation(ip):
+    if should_skip_geolocation(ip):
         return None
 
     async with AsyncClient(account_id, license_key) as client:

--- a/getgather/browsers/residential_proxy.py
+++ b/getgather/browsers/residential_proxy.py
@@ -1,3 +1,4 @@
+import ipaddress
 from typing import TYPE_CHECKING, Literal, Protocol, Self
 
 from async_lru import alru_cache
@@ -9,13 +10,35 @@ from pydantic import BaseModel, model_validator
 if TYPE_CHECKING:
     from getgather.browsers.settings import BrowserSettings
 
-_SKIP_IPS = {"127.0.0.1", "::1", "localhost", "unknown"}
+# Non-IP sentinels that still show up as "origin" values.
+_SKIP_IP_LABELS = frozenset({"localhost", "unknown"})
 _MASSIVE_DOMAINS: set[str] = {"google.com", "doordash.com", "youtube.com"}
 _OXYLABS_DOMAINS: set[str] = {"amazon.com"}
 _PROXY_DOMAIN_POOLS: list[tuple[Literal["oxylabs", "massive"], set[str]]] = [
     ("massive", _MASSIVE_DOMAINS),
     ("oxylabs", _OXYLABS_DOMAINS),
 ]
+
+
+def _should_skip_geolocation(ip: str) -> bool:
+    """True for IPs that MaxMind cannot (and should not) geolocate.
+
+    Mirrors Go's net.IP checks: IsPrivate / IsLoopback / IsLinkLocalUnicast /
+    IsMulticast / IsUnspecified. Covers Fly 6PN (fdaa:…) via ULA is_private.
+    """
+    if not ip or ip in _SKIP_IP_LABELS:
+        return True
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return True
+    return (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_multicast
+        or addr.is_unspecified
+    )
 
 
 class GeoLocation(BaseModel):
@@ -54,7 +77,7 @@ class GeoLocation(BaseModel):
 
 @alru_cache
 async def get_location(ip: str, account_id: int, license_key: str) -> "GeoLocation | None":
-    if not ip or ip in _SKIP_IPS:
+    if _should_skip_geolocation(ip):
         return None
 
     async with AsyncClient(account_id, license_key) as client:

--- a/tests/test_residential_proxy.py
+++ b/tests/test_residential_proxy.py
@@ -6,14 +6,13 @@ from getgather.browsers.residential_proxy import (
     GeoLocation,
     MassiveProxyConfig,
     OxylabsProxyConfig,
-    _should_skip_geolocation,
     get_proxy_config,
     get_proxy_type_for_target_domain,
+    should_skip_geolocation,
 )
 from getgather.browsers.settings import BrowserSettings
 
-
-# --- _should_skip_geolocation (Go net.IP equivalent) ---
+# --- should_skip_geolocation (Go net.IP equivalent) ---
 
 
 @pytest.mark.parametrize(
@@ -37,12 +36,12 @@ from getgather.browsers.settings import BrowserSettings
     ],
 )
 def test_should_skip_geolocation_non_global(ip: str) -> None:
-    assert _should_skip_geolocation(ip) is True
+    assert should_skip_geolocation(ip) is True
 
 
 @pytest.mark.parametrize("ip", ["8.8.8.8", "1.1.1.1", "2001:4860:4860::8888"])
 def test_should_skip_geolocation_public(ip: str) -> None:
-    assert _should_skip_geolocation(ip) is False
+    assert should_skip_geolocation(ip) is False
 
 
 def _settings(**kwargs: object) -> BrowserSettings:

--- a/tests/test_residential_proxy.py
+++ b/tests/test_residential_proxy.py
@@ -6,10 +6,43 @@ from getgather.browsers.residential_proxy import (
     GeoLocation,
     MassiveProxyConfig,
     OxylabsProxyConfig,
+    _should_skip_geolocation,
     get_proxy_config,
     get_proxy_type_for_target_domain,
 )
 from getgather.browsers.settings import BrowserSettings
+
+
+# --- _should_skip_geolocation (Go net.IP equivalent) ---
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "",
+        "localhost",
+        "unknown",
+        "not-an-ip",
+        "127.0.0.1",
+        "::1",
+        "10.0.0.1",
+        "192.168.1.1",
+        "169.254.1.1",  # link-local
+        "0.0.0.0",  # unspecified
+        "224.0.0.1",  # multicast
+        "fdaa:40:8a24:a7b:2af:795b:588f:2",  # Fly 6PN / ULA
+        "fe80::1",  # link-local unicast
+        "::",  # unspecified
+        "ff02::1",  # multicast
+    ],
+)
+def test_should_skip_geolocation_non_global(ip: str) -> None:
+    assert _should_skip_geolocation(ip) is True
+
+
+@pytest.mark.parametrize("ip", ["8.8.8.8", "1.1.1.1", "2001:4860:4860::8888"])
+def test_should_skip_geolocation_public(ip: str) -> None:
+    assert _should_skip_geolocation(ip) is False
 
 
 def _settings(**kwargs: object) -> BrowserSettings:


### PR DESCRIPTION
Sentry Issue: https://heyario.sentry.io/issues/7616923093/?project=4511710202363904&query=is%3Aunresolved&referrer=issue-stream

## Summary
- Skip MaxMind geolocation for private, loopback, link-local, multicast, and unspecified IPs (Go `net.IP` equivalent), including Fly 6PN (`fdaa:…`)
- Avoids `AddressNotFoundError` noise when a reserved/origin IP reaches residential proxy selection
- Adds unit coverage for skip vs public addresses

## Test plan
- [x] `uv run pytest tests/test_residential_proxy.py -q`
- [x] Confirm proxy selection still works with a real public `x-origin-ip`
- [x] Confirm private/Fly IPs no longer hit MaxMind (no geo error logs)