### PR TITLE
fix(distill): wait for page ready state before polling in run_distillation_loop

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -657,6 +657,14 @@ async def run_distillation_loop(
 
     current = Match(name="", priority=-1, distilled="")
 
+    # Let the page settle (e.g. redirect chains, JS/CSS) before polling, so
+    # matched elements pass isVisible() and short timeouts don't falsely report
+    # "No matched pattern found".
+    try:
+        await wait_for_ready_state(page, timeout=5)
+    except Exception as e:
+        logger.warning(f"Error waiting for page ready state: {e}")
+
     for iteration in range(max):
         logger.debug(f"Iteration {iteration + 1} of {max}")
         await asyncio.sleep(TICK)


### PR DESCRIPTION
## Summary

While investigating Sentry [`MCP-GETGATHER-53`](https://heyario.sentry.io/issues/MCP-GETGATHER-53) ("No matched pattern found"), I found cases where the error fires even though a valid pattern exists for the page.

The failing event was the Amazon Prime Video library flow (`get_prime_library`), which runs distillation with a **2s timeout**. I confirmed the captured page actually matches `amazon-signin-email-only.html` when fully rendered — so the pattern was never the problem.

## Root cause

`run_distillation_loop` started polling immediately after navigation, without waiting for the page to settle. On this flow the browser is still resolving a redirect chain (Prime Video → `amazon.ca` sign-in) and rendering a heavy AUI page. During the only two poll iterations the required elements either don't exist yet or have zero layout size, so they fail the runtime `isVisible()` check — and the loop exhausts its budget and reports "No matched pattern found." By the time the error artifact is captured, the DOM has finished rendering, which is why the saved HTML looks perfectly matchable.

## Fix

`distill_post_loop` already waits for ready-state before polling:

```python
try:
    await wait_for_ready_state(page, timeout=5)
    await page.sleep(1)
    logger.debug("Page ready state is complete")
except Exception as e:
    logger.warning(f"Error waiting for page ready state: {e}")
```

This PR brings the same settle step into `run_distillation_loop` so both distillation loops behave consistently and short-timeout callers don't race the page render.
