### PR TITLE
Refactor CDP websocket URL resolution into each backend

### DIFF
--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -1,6 +1,8 @@
 import asyncio
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, cast, runtime_checkable
 
+import httpx
+from fastapi import WebSocket
 from loguru import logger
 from nanoid import generate
 
@@ -9,6 +11,57 @@ from getgather.config import FRIENDLY_CHARS, settings
 # Shared name prefix: a browser with id `abc` is a podman container / Daytona sandbox named
 # `chromium-abc`. Both local backends derive names and parse ids from this single prefix.
 BROWSER_NAME_PREFIX = "chromium-"
+
+
+def rewrite_ws_url(ws_url: str, cdp_base_url: str) -> str:
+    """Rewrite a CDP webSocketDebuggerUrl to use the cdp_base_url's scheme/host/port.
+
+    Chrome reports webSocketDebuggerUrl against the Host it saw (e.g. ws://localhost:9222/...),
+    which is unreachable when CDP is fronted by a reverse proxy (a Daytona signed preview URL).
+    This points the websocket at the same scheme+host+port we reached CDP on (https -> wss),
+    keeping the path/query. For the local podman backend the host already matches, so it is a no-op.
+    """
+    base = httpx.URL(cdp_base_url)
+    scheme = "wss" if base.scheme == "https" else "ws"
+    return str(httpx.URL(ws_url).copy_with(scheme=scheme, host=base.host, port=base.port))
+
+
+async def get_browser_websocket_debugger_url(cdp_base_url: str) -> str:
+    """Discover the browser-level `webSocketDebuggerUrl` from a CDP endpoint's
+    `/json/version`, rewritten to ride over the same scheme/host/port as `cdp_base_url`.
+
+    Used by the local backends (Podman / Daytona) that expose a per-browser HTTP CDP endpoint
+    but no pre-baked wss connect URL: their `get_cdp_websocket_remote_url` resolves the
+    cdp base URL (per browser) and then this helper does the standard /json/version probe.
+    """
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.get(f"{cdp_base_url}/json/version")
+        response.raise_for_status()
+        data: dict[str, Any] = response.json()
+        logger.debug(f"[CDP] CDP json version gives {data}")
+        return rewrite_ws_url(str(data["webSocketDebuggerUrl"]), cdp_base_url)
+
+
+async def get_page_websocket_debugger_url(cdp_base_url: str, page_id: str) -> str | None:
+    """Discover the per-page `webSocketDebuggerUrl` for `page_id` from a CDP endpoint's
+    `/json/list`, rewritten to ride over the same scheme/host/port as `cdp_base_url`.
+
+    Used by the local backends (Podman / Daytona) that expose per-page webSocketDebuggerUrls
+    over HTTP — their `get_devtools_websocket_remote_url` resolves the cdp base URL (per
+    browser) and then this helper does the standard /json/list probe. Returns None when the
+    page id is not present in the listing (page already closed or not yet registered).
+    """
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.get(f"{cdp_base_url}/json/list")
+        response.raise_for_status()
+        raw: Any = response.json()
+        if not isinstance(raw, list):
+            return None
+        for item in cast(list[dict[str, Any]], raw):
+            if item.get("id") == page_id:
+                ws_url = item.get("webSocketDebuggerUrl")
+                return rewrite_ws_url(str(ws_url), cdp_base_url) if ws_url else None
+        return None
 
 
 def new_browser_id() -> str:
@@ -172,6 +225,36 @@ class Backend(Protocol):
     async def get_cdp_base_url(self, browser_id: str) -> str: ...
 
     def cdp_websocket_base(self) -> str | None: ...
+
+    async def get_cdp_websocket_remote_url(self, browser_id: str) -> str | None:
+        """The single wss URL the router should relay a /cdp/{browser_id} client socket to.
+        Owned end-to-end by each backend, so the router can stay agnostic of how the URL is
+        derived (the external fleet's /cdp relay for Fleet, the per-browser /json/version
+        discovery for Podman/Daytona). Returns None when the URL can't (yet) be resolved."""
+
+    def cdp_targets_need_namespacing(self) -> bool:
+        """Whether `websocket_proxy` should rewrite target ids to namespace them by `browser_id`
+        when relaying to this backend's URL. True for backends that hand back a single browser's
+        raw CDP socket (Podman / Daytona); False for the Fleet relay, whose /cdp proxy already
+        namespaces target ids itself (so the router patching again would double-prefix)."""
+        ...
+
+    async def get_devtools_websocket_remote_url(
+        self, client_ws: WebSocket, browser_id: str, page_id: str
+    ) -> str | None:
+        """Resolve the remote wss URL the router should relay a /devtools/{path} client socket
+        to, or self-relay the socket and return a sentinel "" telling the router to skip its own
+        `websocket_proxy`. Owned end-to-end by each backend.
+
+        Returns:
+          - a non-empty URL string: the router relays via `websocket_proxy(client_ws, url, …)`.
+            Fleet returns the external /devtools relay URL; Podman/Daytona return the per-page
+            `/json/list` webSocketDebuggerUrl.
+          - "": the backend already relayed `client_ws`, the router must skip `websocket_proxy`.
+          - None: the URL can't (yet) be resolved — the router retries up to 10 times before
+            giving up and closing the client with 4502.
+        """
+        ...
 
     async def get_vnc_endpoint(self, browser_id: str) -> tuple[str, int] | None: ...
 

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -11,12 +11,15 @@ from daytona import (
     DaytonaNotFoundError,
     ListSandboxesQuery,
 )
+from fastapi import WebSocket
 from loguru import logger
 
 from getgather.browsers.backend import (
     BROWSER_NAME_PREFIX,
     BrowserNotFound,
     ProxyVerificationError,
+    get_browser_websocket_debugger_url,
+    get_page_websocket_debugger_url,
 )
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
@@ -235,6 +238,30 @@ class DaytonaBackend:
         # CDP is reached per-sandbox over a signed HTTPS preview URL via get_cdp_base_url +
         # /json/version, not a shared websocket proxy, so there is no relay base.
         return None
+
+    async def get_cdp_websocket_remote_url(self, browser_id: str) -> str | None:
+        # Discover the browser-level webSocketDebuggerUrl over the signed preview proxy's
+        # /json/version (get_cdp_base_url → /json/version). May raise BrowserNotFound if the
+        # sandbox was torn down underneath the router, or transiently on a boot race — the router
+        # retries 10x before giving up.
+        cdp_base_url = await self.get_cdp_base_url(browser_id)
+        return await get_browser_websocket_debugger_url(cdp_base_url)
+
+    def cdp_targets_need_namespacing(self) -> bool:
+        # The per-sandbox socket reports raw target ids; the router namespaces them by browser_id
+        # so the devtools route can route /devtools/{browser_id@page_id} back to this sandbox.
+        return True
+
+    async def get_devtools_websocket_remote_url(
+        self, client_ws: WebSocket, browser_id: str, page_id: str
+    ) -> str | None:
+        # Discover the per-page webSocketDebuggerUrl over the signed preview proxy's /json/list
+        # (get_cdp_base_url → /json/list). May return None transiently (page just registered /
+        # already closed) or raise BrowserNotFound if the sandbox was torn down — the router
+        # retries 10x before giving up.
+        del client_ws
+        cdp_base_url = await self.get_cdp_base_url(browser_id)
+        return await get_page_websocket_debugger_url(cdp_base_url, page_id)
 
     async def get_vnc_endpoint(self, browser_id: str) -> tuple[str, int] | None:
         return None  # no raw VNC port; live view uses get_live_view_url (noVNC on VNC_PORT)

--- a/getgather/browsers/fleet_browsers.py
+++ b/getgather/browsers/fleet_browsers.py
@@ -1,6 +1,7 @@
 from typing import Any, Literal, cast
 
 import httpx
+from fastapi import WebSocket
 from fastmcp.server.dependencies import get_http_headers
 from httpx_retries import Retry, RetryTransport
 
@@ -158,6 +159,29 @@ class FleetBackend:
         # the local routes relay to them verbatim. ws:// for http, wss:// for https.
         base = settings.effective_chromefleet_url.rstrip("/")
         return base.replace("https://", "wss://").replace("http://", "ws://")
+
+    async def get_cdp_websocket_remote_url(self, browser_id: str) -> str | None:
+        # Relay straight to the external fleet's own /cdp proxy, which already namespaces target
+        # ids; the router does not patch again (see cdp_targets_need_namespacing). Deterministic
+        # from CHROMEFLEET_URL + browser_id, so this never returns None — no retry needed.
+        return f"{self.cdp_websocket_base()}/cdp/{browser_id}"
+
+    def cdp_targets_need_namespacing(self) -> bool:
+        # The external fleet's /cdp proxy already namespaces target ids by browser_id; the
+        # router patching here would double-prefix them, so opt out.
+        return False
+
+    async def get_devtools_websocket_remote_url(
+        self, client_ws: WebSocket, browser_id: str, page_id: str
+    ) -> str | None:
+        # Relay verbatim to the external fleet's own /devtools proxy at the Chrome DevTools
+        # `page/` URL form. The router passes the namespaced `<browser_id>@<page_id>` target id
+        # when the path carried it (the form /cdp produces); otherwise `browser_id` is empty and
+        # we relay the un-split fleet target id untouched. Deterministic, so this never returns
+        # None — no retry needed.
+        del client_ws
+        target = f"{browser_id}@{page_id}" if browser_id else page_id
+        return f"{self.cdp_websocket_base()}/devtools/page/{target}"
 
     async def get_vnc_endpoint(self, browser_id: str) -> tuple[str, int] | None:
         return None

--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -6,12 +6,15 @@ import sys
 from datetime import datetime
 from typing import Any
 
+from fastapi import WebSocket
 from loguru import logger
 
 from getgather.browsers.backend import (
     BROWSER_NAME_PREFIX,
     BrowserNotFound,
     ProxyVerificationError,
+    get_browser_websocket_debugger_url,
+    get_page_websocket_debugger_url,
 )
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
@@ -413,6 +416,29 @@ class PodmanBackend:
         # Local containers expose CDP per-browser via /json/version (get_cdp_base_url), not a
         # shared websocket proxy, so the router uses that flow rather than a transparent relay.
         return None
+
+    async def get_cdp_websocket_remote_url(self, browser_id: str) -> str | None:
+        # Local container exposes the browser-level webSocketDebuggerUrl over /json/version
+        # (get_cdp_base_url → /json/version), so this just runs that discovery. May raise on a
+        # missed boot race (chrome not ready yet) — the router retries 10x before giving up.
+        cdp_base_url = await self.get_cdp_base_url(browser_id)
+        return await get_browser_websocket_debugger_url(cdp_base_url)
+
+    def cdp_targets_need_namespacing(self) -> bool:
+        # The per-browser socket reports raw target ids; the router namespaces them by browser_id
+        # so the devtools route can route /devtools/{browser_id@page_id} back to this browser.
+        return True
+
+    async def get_devtools_websocket_remote_url(
+        self, client_ws: WebSocket, browser_id: str, page_id: str
+    ) -> str | None:
+        # Local container exposes the per-page webSocketDebuggerUrl over /json/list
+        # (get_cdp_base_url → /json/list), so this just runs that discovery. May return None
+        # transiently (page just registered / already closed) or raise on a boot race — the
+        # router retries 10x before giving up.
+        del client_ws
+        cdp_base_url = await self.get_cdp_base_url(browser_id)
+        return await get_page_websocket_debugger_url(cdp_base_url, page_id)
 
     async def get_vnc_endpoint(self, browser_id: str) -> tuple[str, int] | None:
         vnc_port = await get_host_port(f"{BROWSER_NAME_PREFIX}{browser_id}", 5900)

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -3,7 +3,6 @@ import html
 import json
 from typing import Any
 
-import httpx
 import websockets
 from fastapi import APIRouter, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -18,6 +17,7 @@ from getgather.browsers.backend import (
     create_backend,
     new_browser_id,
 )
+from getgather.cdp_client import CDPClient, open_cdp_url
 from getgather.config import settings
 
 router = APIRouter()
@@ -26,60 +26,41 @@ backend: Backend = create_backend()
 logger.info(f"Using browser backend: {backend.__class__.__name__}")
 
 
-def rewrite_ws_url(ws_url: str, cdp_base_url: str) -> str:
-    """Rewrite a CDP webSocketDebuggerUrl to use the cdp_base_url's scheme/host/port.
+async def open_browser_cdp_client(browser_id: str) -> CDPClient | None:
+    """Open a browser-level CDP client for `browser_id`, usable for direct commands like
+    Target.getTargets. Returns None when the backend has no browser-level socket the router
+    can open directly (Fleet relays /cdp and /devtools to an external proxy instead).
 
-    Chrome reports webSocketDebuggerUrl against the Host it saw (e.g. ws://localhost:9222/...),
-    which is unreachable when CDP is fronted by a reverse proxy (a Daytona signed preview URL).
-    This points the websocket at the same scheme+host+port we reached CDP on (https -> wss),
-    keeping the path/query. For the local podman backend the host already matches, so it is a no-op.
+    - Browserbase: open the per-session connectUrl (signing key in the query string).
+    - Podman / Daytona: /json/version discovers the browser webSocketDebuggerUrl, then open it.
+    - Fleet: cdp_websocket_base() is the shared relay; never enumerated here.
     """
-    base = httpx.URL(cdp_base_url)
-    scheme = "wss" if base.scheme == "https" else "ws"
-    return str(httpx.URL(ws_url).copy_with(scheme=scheme, host=base.host, port=base.port))
-
-
-async def get_cdp_websocket_url(browser_id: str) -> str:
-    cdp_base_url = await backend.get_cdp_base_url(browser_id)
-
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        response = await client.get(f"{cdp_base_url}/json/version")
-        response.raise_for_status()
-        data = response.json()
-        logger.debug(f"[CDP] CDP json version gives {data}")
-        return rewrite_ws_url(str(data["webSocketDebuggerUrl"]), cdp_base_url)
-
-
-async def get_page_websocket_url(browser_id: str, page_id: str) -> str | None:
-    try:
-        cdp_base_url = await backend.get_cdp_base_url(browser_id)
-
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.get(f"{cdp_base_url}/json/list")
-            response.raise_for_status()
-            data: list[dict[str, Any]] = response.json()
-            for item in data:
-                if item.get("id") == page_id:
-                    ws_url = item.get("webSocketDebuggerUrl")
-                    return rewrite_ws_url(str(ws_url), cdp_base_url) if ws_url else None
-            return None
-    except Exception as e:
-        logger.error(f"[CDP] Error getting page websocket URL for {browser_id}/{page_id}: {e}")
+    if backend.cdp_websocket_base() is not None:
+        return None  # Fleet: relay-only, no browser-level socket to open directly.
+    ws_url = await backend.get_cdp_websocket_remote_url(browser_id)
+    if ws_url is None:
         return None
+    return await open_cdp_url(ws_url, timeout=10.0)
 
 
 async def get_page_list(browser_id: str) -> list[str]:
-    try:
-        cdp_base_url = await backend.get_cdp_base_url(browser_id)
-
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.get(f"{cdp_base_url}/json/list")
-            response.raise_for_status()
-            data: list[dict[str, Any]] = response.json()
-            return [str(item["id"]) for item in data]
-    except Exception as e:
-        logger.error(f"[CDP] Error getting page list for {browser_id}: {e}")
+    # Page enumeration is done over the browser-level CDP socket by sending Target.getTargets
+    # and filtering for type == "page" — the same call pages_api_router.list_pages uses. This
+    # works uniformly for every backend that exposes a browser-level socket (Browserbase via
+    # connectUrl, Podman/Daytona via /json/version discovery); Fleet relays /devtools to its
+    # own proxy and never reaches this path, so open_browser_cdp_client returns None there.
+    client = await open_browser_cdp_client(browser_id)
+    if client is None:
         return []
+    try:
+        result = await client.send("Target.getTargets")
+    except Exception as e:
+        logger.warning(f"[CDP] Target.getTargets failed for {browser_id}: {type(e).__name__}: {e}")
+        return []
+    finally:
+        await client.aclose()
+    target_infos: list[dict[str, Any]] = result.get("targetInfos", [])  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+    return [str(info["targetId"]) for info in target_infos if info.get("type") == "page"]
 
 
 async def find_browser_id(page_id: str) -> str | None:
@@ -307,6 +288,7 @@ async def cdp_browser_websocket_proxy(client_ws: WebSocket, browser_id: str) -> 
     await client_ws.accept()
     logger.debug("[CDP] WebSocket accepted")
 
+    # (1) Auto-launch the browser if it isn't running yet.
     if not await backend.browser_exists(browser_id):
         logger.info(f"[CDP] Browser {browser_id} not found — launching")
         try:
@@ -320,41 +302,36 @@ async def cdp_browser_websocket_proxy(client_ws: WebSocket, browser_id: str) -> 
             await client_ws.close(code=1008)
             return
 
-    cdp_base = backend.cdp_websocket_base()
-    if cdp_base is not None:
-        # Fleet mode: relay straight to the external fleet's own /cdp proxy, which already
-        # patches target ids — so do not patch again here (would double-prefix browser_id).
-        remote_url = f"{cdp_base}/cdp/{browser_id}"
-        logger.info(f"[CDP] Relaying to external fleet: {remote_url}")
-        await websocket_proxy(client_ws, remote_url, browser_id, patch=False)
-        logger.debug("[CDP] cdp_browser_websocket_proxy exiting")
-        return
-
-    remote_url = None
+    # (2) Resolve the backend-specific remote wss URL — retry up to 10 times. Each backend owns
+    # this lookup end-to-end (`get_cdp_websocket_remote_url`); the router is agnostic of
+    # whether it came from a connectUrl, an external /cdp relay, or a /json/version probe. Both
+    # `None` (not yet resolvable) and exceptions (transient /json/version failure on a boot race)
+    # count as a missed attempt; the first non-None result wins.
+    remote_url: str | None = None
     for attempt in range(10):
         try:
-            remote_url = await get_cdp_websocket_url(browser_id)
-            logger.info(f"[CDP] Got remote URL: {remote_url}")
-            break
+            remote_url = await backend.get_cdp_websocket_remote_url(browser_id)
         except Exception as e:
             logger.warning(
                 f"[CDP] Attempt {attempt + 1}/10 failed to get debugger URL from {browser_id}: {e}"
             )
-            if attempt < 9:
-                logger.debug("[CDP] Retrying in 3 seconds...")
-                await asyncio.sleep(3)
-            else:
-                logger.error("[CDP] All retry attempts exhausted")
-                await client_ws.close(code=4502, reason="Failed to get debugger URL")
-                return
-
-    if not remote_url:
-        logger.error("[CDP] No remote URL obtained")
+        if remote_url is not None:
+            logger.info(f"[CDP] Got remote URL: {remote_url}")
+            break
+        if attempt < 9:
+            logger.debug("[CDP] Retrying in 3 seconds...")
+            await asyncio.sleep(3)
+    else:
+        logger.error("[CDP] All retry attempts exhausted")
         await client_ws.close(code=4502, reason="Failed to get debugger URL")
         return
 
+    # (3) Relay. `cdp_targets_need_namespacing` lets each backend tell the router whether the URL
+    # it returned already namespaces target ids (Fleet's external /cdp proxy) — in which case we
+    # do not patch again (would double-prefix browser_id).
     logger.info(f"[CDP] Client connected, proxying to {remote_url}")
-    await websocket_proxy(client_ws, remote_url, browser_id)
+    patch = backend.cdp_targets_need_namespacing()
+    await websocket_proxy(client_ws, remote_url, browser_id, patch)
     logger.debug("[CDP] cdp_browser_websocket_proxy exiting")
 
 
@@ -364,16 +341,13 @@ async def cdp_devtools_websocket_proxy(client_ws: WebSocket, path: str) -> None:
     await client_ws.accept()
     logger.debug("[CDP] WebSocket accepted")
 
-    cdp_base = backend.cdp_websocket_base()
-    if cdp_base is not None:
-        # Fleet mode: relay the page-level CDP socket to the fleet's own /devtools proxy verbatim.
-        # The fleet resolves the page and patches target ids; browser_id is unused with patch=False.
-        remote_url = f"{cdp_base}/devtools/{path}"
-        logger.info(f"[CDP] Relaying to external fleet: {remote_url}")
-        await websocket_proxy(client_ws, remote_url, browser_id="", patch=False)
-        logger.debug("[CDP] cdp_devtools_websocket_proxy exiting")
-        return
-
+    # Resolve the page id from the path's last segment (Chrome's /devtools/page/<id> URL form,
+    # possibly namespaced by /cdp as `<browser_id>@<page_id>`). When the `@` form is present the
+    # browser_id is carried in the segment; otherwise scan every backend browser's targets via
+    # Target.getTargets to locate the page (Fleet relays /devtools verbatim and never reaches
+    # this branch — it returns a relay URL from `get_devtools_websocket_remote_url` for any
+    # page_id, so the find_browser_id fallback only fires for the local backends that report raw
+    # un-namespaced target ids to clients).
     parts = path.split("/")
     page_id = parts[-1] if parts else None
     if not page_id:
@@ -381,13 +355,10 @@ async def cdp_devtools_websocket_proxy(client_ws: WebSocket, path: str) -> None:
         await client_ws.close(code=4000, reason="No page_id in path")
         return
 
-    browser_id = None
     if "@" in page_id:
-        id_parts = page_id.split("@")
-        browser_id = id_parts[0]
-        page_id = id_parts[1]
+        browser_id, page_id = page_id.split("@", 1)
         logger.debug(f"[CDP] browser_id={browser_id} page_id={page_id}")
-    else:
+    elif backend.cdp_websocket_base() is None:
         logger.debug(f"[CDP] Looking for page_id={page_id}")
         browser_id = await find_browser_id(page_id)
         if browser_id:
@@ -396,15 +367,55 @@ async def cdp_devtools_websocket_proxy(client_ws: WebSocket, path: str) -> None:
             logger.error(f"[CDP] Page {page_id} not found in any browser")
             await client_ws.close(code=4000, reason="Page not found in any browser")
             return
+    else:
+        # Fleet relay: page_id wasn't namespaced by /cdp (the fleet's own /cdp already namespaces
+        # target ids, and we patch=False on that route). Pass the namespaced form through to the
+        # backend by leaving browser_id empty; see `get_devtools_websocket_remote_url`.
+        browser_id = ""
 
-    remote_url = await get_page_websocket_url(browser_id, page_id)
-    if not remote_url:
+    # Resolve the backend-specific remote wss URL — retry up to 10 times. Each backend owns this
+    # end-to-end (`get_devtools_websocket_remote_url`): Fleet returns the external /devtools
+    # relay URL, Podman/Daytona return the per-page /json/list webSocketDebuggerUrl, and
+    # Browserbase self-relays the client socket against its multiplexed connectUrl and returns ""
+    # — the sentinel that tells this router to skip its own websocket_proxy (a plain relay can't
+    # drive a single page off a multiplexed socket). Both `None` (not yet resolvable) and
+    # exceptions (a transient /json/list failure on a boot race) count as a missed attempt; the
+    # first non-None result wins.
+    remote_url: str | None = None
+    for attempt in range(10):
+        try:
+            remote_url = await backend.get_devtools_websocket_remote_url(
+                client_ws, browser_id, page_id
+            )
+        except Exception as e:
+            logger.warning(
+                f"[CDP] Attempt {attempt + 1}/10 failed to get page URL for "
+                f"{browser_id}/{page_id}: {e}"
+            )
+        if remote_url is not None:
+            if remote_url != "":
+                logger.info(f"[CDP] Got page remote URL: {remote_url}")
+            break
+        if attempt < 9:
+            logger.debug("[CDP] Retrying in 3 seconds...")
+            await asyncio.sleep(3)
+    else:
         logger.error(f"[CDP] Could not get websocket URL for page {page_id}")
         await client_ws.close(code=4502, reason="Failed to get page websocket URL")
         return
 
+    # Sentinel: the backend already relayed the client socket itself (Browserbase).
+    if remote_url == "":
+        logger.debug("[CDP] cdp_devtools_websocket_proxy exiting (backend self-relayed)")
+        return
+
+    # Relay. `cdp_targets_need_namespacing` lets each backend tell the router whether the URL it
+    # returned already namespaces target ids (Fleet's external /devtools proxy) — in which case
+    # we do not patch again (would double-prefix browser_id).
     logger.info(f"[CDP] Connecting to {remote_url}")
-    await websocket_proxy(client_ws, remote_url, browser_id)
+    await websocket_proxy(
+        client_ws, remote_url, browser_id, patch=backend.cdp_targets_need_namespacing()
+    )
     logger.debug("[CDP] cdp_devtools_websocket_proxy exiting")
 
 

--- a/getgather/browsers/settings.py
+++ b/getgather/browsers/settings.py
@@ -52,6 +52,7 @@ class BrowserSettings(BaseSettings):
         ""  # point at a self-hosted Daytona; empty uses the managed cloud default
     )
     DAYTONA_SNAPSHOT: str = ""
+
     # Best-of-N cold-create: on a fresh browser, race this many candidates in parallel and keep the
     # first whose `create_browser` fully succeeds.
     # Losers are deleted in the background. Set to 1 to disable the race and create a single

--- a/getgather/cdp_client.py
+++ b/getgather/cdp_client.py
@@ -32,6 +32,18 @@ async def open_cdp(browser_id: str) -> "CDPClient":
     return CDPClient(ws)
 
 
+async def open_cdp_url(ws_url: str, timeout: float | None = None) -> "CDPClient":
+    """Open a CDP client against a direct wss URL Used by router helpers that
+    need to enumerate page targets on backends that have no /json/list HTTP endpoint."""
+    ws = await websockets.connect(
+        ws_url,
+        open_timeout=timeout
+        if timeout is not None
+        else settings.CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS,
+    )
+    return CDPClient(ws)
+
+
 class CDPClient:
     def __init__(self, ws: websockets.asyncio.client.ClientConnection) -> None:  # type: ignore[name-defined]
         self._ws: Any = ws


### PR DESCRIPTION
Lays the groundwork for upcoming work on additional browser backend environments. Most notably, each backend now owns the resolution of both the browser- and page-level CDP websocket URL and tells the router whether CDP target ids need namespacing (i.e., `browser_id@page_id`).

Tested with Headline Hub as well as Page Turner.

<img width="1704" height="1169" alt="image" src="https://github.com/user-attachments/assets/56041263-1d98-4e92-962f-2f55cadff1b9" />
