### PR TITLE
fix(garmin): use prefix class matching for hashed CSS module selectors

### DIFF
--- a/getgather/mcp/patterns/garmin-activities.html
+++ b/getgather/mcp/patterns/garmin-activities.html
@@ -6,7 +6,7 @@
     <div>
       <div
         rb-convert="garmin-activities.json"
-        rb-match-html="div#scrollableArea.ActivityList_activitiesListItems__lWW3P"
+        rb-match-html='div#scrollableArea[class*="ActivityList_activitiesListItems_"]'
         rb-stop
       ></div>
     </div>

--- a/getgather/mcp/patterns/garmin-activities.json
+++ b/getgather/mcp/patterns/garmin-activities.json
@@ -1,5 +1,5 @@
 {
-  "rows": "div.ActivityListItem_listItem__aoJjV",
+  "rows": "div[class*=\"ActivityListItem_listItem_\"]",
   "columns": [
     {
       "name": "activity_icon",

--- a/getgather/mcp/patterns/garmin-activities.json
+++ b/getgather/mcp/patterns/garmin-activities.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "activity_date",
-      "selector": "span[class*=\"ActivityListItem_activityDate_\"]"
+      "selector": "div[class*=\"ActivityListItem_dateListContainer_\"]"
     },
     {
       "name": "activity_year",

--- a/getgather/mcp/patterns/garmin-activity-stat.json
+++ b/getgather/mcp/patterns/garmin-activity-stat.json
@@ -3,27 +3,27 @@
   "columns": [
     {
       "name": "distance",
-      "selector": "div#distanceStatsPlaceholder .DataBlock_dataField__t4-ai"
+      "selector": "div#distanceStatsPlaceholder [class*=\"DataBlock_dataField_\"]"
     },
     {
       "name": "calories",
-      "selector": "div#caloriesPlaceholder .DataBlock_dataField__t4-ai"
+      "selector": "div#caloriesPlaceholder [class*=\"DataBlock_dataField_\"]"
     },
     {
       "name": "training_effect_primary_benefit",
-      "selector": "div#trainingEffectStatsPlaceholder .DataBlock_dataField__t4-ai:first-child"
+      "selector": "div#trainingEffectStatsPlaceholder [class*=\"DataBlock_dataField_\"]:first-child"
     },
     {
       "name": "training_effect_aerobic",
-      "selector": "div#trainingEffectStatsPlaceholder .DataBlock_small:nth-of-type(1) .DataBlock_dataField__t4-ai"
+      "selector": "div#trainingEffectStatsPlaceholder [class*=\"DataBlock_small_\"]:nth-of-type(1) [class*=\"DataBlock_dataField_\"]"
     },
     {
       "name": "training_effect_anaerobic",
-      "selector": "div#trainingEffectStatsPlaceholder .DataBlock_small:nth-of-type(2) .DataBlock_dataField__t4-ai"
+      "selector": "div#trainingEffectStatsPlaceholder [class*=\"DataBlock_small_\"]:nth-of-type(2) [class*=\"DataBlock_dataField_\"]"
     },
     {
       "name": "exercise_load",
-      "selector": "div#trainingEffectStatsPlaceholder .DataBlock_small:nth-of-type(3) .DataBlock_dataField__t4-ai"
+      "selector": "div#trainingEffectStatsPlaceholder [class*=\"DataBlock_small_\"]:nth-of-type(3) [class*=\"DataBlock_dataField_\"]"
     },
     {
       "name": "avg_heart_rate",
@@ -67,19 +67,19 @@
     },
     {
       "name": "total_ascent",
-      "selector": "div#elevationStatsPlaceholder .DataBlock_small__a7f56:nth-of-type(1) .DataBlock_dataField__t4-ai"
+      "selector": "div#elevationStatsPlaceholder [class*=\"DataBlock_small_\"]:nth-of-type(1) [class*=\"DataBlock_dataField_\"]"
     },
     {
       "name": "total_descent",
-      "selector": "div#elevationStatsPlaceholder .DataBlock_small__a7f56:nth-of-type(2) .DataBlock_dataField__t4-ai"
+      "selector": "div#elevationStatsPlaceholder [class*=\"DataBlock_small_\"]:nth-of-type(2) [class*=\"DataBlock_dataField_\"]"
     },
     {
       "name": "min_elevation",
-      "selector": "div#elevationStatsPlaceholder .DataBlock_small__a7f56:nth-of-type(3) .DataBlock_dataField__t4-ai"
+      "selector": "div#elevationStatsPlaceholder [class*=\"DataBlock_small_\"]:nth-of-type(3) [class*=\"DataBlock_dataField_\"]"
     },
     {
       "name": "max_elevation",
-      "selector": "div#elevationStatsPlaceholder .DataBlock_small__a7f56:nth-of-type(4) .DataBlock_dataField__t4-ai"
+      "selector": "div#elevationStatsPlaceholder [class*=\"DataBlock_small_\"]:nth-of-type(4) [class*=\"DataBlock_dataField_\"]"
     },
     {
       "name": "avg_speed",
@@ -95,11 +95,11 @@
     },
     {
       "name": "avg_bike_cadence",
-      "selector": "div#bikeCadence .DataBlock_small__a7f56:nth-of-type(1) .DataBlock_dataField__t4-ai"
+      "selector": "div#bikeCadence [class*=\"DataBlock_small_\"]:nth-of-type(1) [class*=\"DataBlock_dataField_\"]"
     },
     {
       "name": "max_bike_cadence",
-      "selector": "div#bikeCadence .DataBlock_small__a7f56:nth-of-type(2) .DataBlock_dataField__t4-ai"
+      "selector": "div#bikeCadence [class*=\"DataBlock_small_\"]:nth-of-type(2) [class*=\"DataBlock_dataField_\"]"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Garmin's frontend uses CSS-module class names with hashed suffixes (e.g. `DataBlock_dataField__t4-ai`, `ActivityList_activitiesListItems__lWW3P`). These hashes change on every Garmin build, silently breaking our distillation selectors.

This switches the affected Garmin pattern selectors to attribute-prefix matching (`[class*="DataBlock_dataField_"]`) so extraction survives hash changes.

## Changes
- `garmin-activities.html` — activity list container match
- `garmin-activities.json` — activity list rows selector
- `garmin-activity-stat.json` — distance, calories, training effect, elevation, and bike cadence stat selectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)