### PR TITLE
feat: add Browserbase browser backend

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -24,6 +24,9 @@ DAYTONA_API_KEY=
 DAYTONA_API_URL=
 DAYTONA_SNAPSHOT=
 
+# The API key for the Browserbase (required when BROWSER_BACKEND=browserbase).
+BROWSERBASE_API_KEY=
+
 # Residential proxy (Massive or Oxylabs) and MaxMind GeoIP. Consumed only by the podman backend,
 # which sets a per-browser upstream proxy and resolves geo from x-origin-ip. The Daytona backend
 # ignores them; with an external Chrome Fleet the upstream fleet applies its own proxy/geo.

--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -229,8 +229,9 @@ class Backend(Protocol):
     async def get_cdp_websocket_remote_url(self, browser_id: str) -> str | None:
         """The single wss URL the router should relay a /cdp/{browser_id} client socket to.
         Owned end-to-end by each backend, so the router can stay agnostic of how the URL is
-        derived (the external fleet's /cdp relay for Fleet, the per-browser /json/version
-        discovery for Podman/Daytona). Returns None when the URL can't (yet) be resolved."""
+        derived (per-session connectUrl for Browserbase, the external fleet's /cdp relay for
+        Fleet, the per-browser /json/version discovery for Podman/Daytona). Returns None when
+        the URL can't (yet) be resolved."""
 
     def cdp_targets_need_namespacing(self) -> bool:
         """Whether `websocket_proxy` should rewrite target ids to namespace them by `browser_id`
@@ -273,6 +274,11 @@ def create_backend() -> Backend:
         return DaytonaBackend(
             settings.DAYTONA_API_KEY, settings.DAYTONA_API_URL, settings.DAYTONA_SNAPSHOT
         )
+
+    if settings.BROWSER_BACKEND == "browserbase":
+        from getgather.browsers.browserbase_browsers import BrowserbaseBackend
+
+        return BrowserbaseBackend()
 
     from getgather.browsers.podman_browsers import PodmanBackend
 

--- a/getgather/browsers/browserbase_browsers.py
+++ b/getgather/browsers/browserbase_browsers.py
@@ -1,0 +1,397 @@
+import asyncio
+import json
+import os
+from typing import Any
+
+import httpx
+import websockets
+from fastapi import WebSocket, WebSocketDisconnect
+from fastapi.websockets import WebSocketState
+from loguru import logger
+from websockets.exceptions import ConnectionClosed, InvalidStatus
+
+from getgather.browsers.backend import BrowserNotFound
+from getgather.browsers.residential_proxy import get_proxy_config
+from getgather.config import settings
+
+DEFAULT_BEST_OF_N = 1
+
+BROWSERBASE_API_URL = "https://api.browserbase.com/v1/sessions"
+
+
+async def websocket_proxy_attached(
+    client_ws: WebSocket,
+    remote_url: str,
+    target_id: str,
+) -> None:
+    """Bridge a per-page /devtools WebSocket to a multiplexed browser-level CDP socket
+    (a Browserbase connectUrl) by sending Target.attachToTarget with flatten=true, then
+    relaying only that session's frames:
+
+    - Outbound (client -> remote): inject "sessionId" into every CDP command (the client speaks
+      flat per-page mode, the remote speaks multiplexed "flatten" mode).
+    - Inbound  (remote -> client): forward only frames whose "sessionId" matches the one returned
+      by attachToTarget, and strip that field before sending so the client sees plain per-page
+      frames (responses with `id`, events without).
+
+    This is what Puppeteer/Playwright do internally when connecting to a browser endpoint and
+    then driving a single page — here we expose it as an opaque /devtools/<id> socket so clients
+    that follow Chrome's "/devtools/page/<id>" URL convention (zendriver's `Tab.websocket_url`)
+    keep working unchanged against Browserbase's multiplexed connectUrl.
+
+    Single attempt: by the time a /devtools request arrives for a Browserbase session, the chrome
+    inside it has already been confirmed CDP-ready by `BrowserbaseBackend._wait_until_cdp_ready`
+    during `create_browser`. Retrying the wss upgrade here would just paper over a race that no
+    longer exists; if the connect fails now it's a real failure, surfaced to the client as a
+    close (4502).
+    """
+    attach_req = json.dumps({
+        "id": -1,
+        "method": "Target.attachToTarget",
+        "params": {"targetId": target_id, "flatten": True},
+    })
+
+    try:
+        async with websockets.connect(
+            remote_url,
+            ping_interval=60,
+            ping_timeout=30,
+            close_timeout=7200,
+            max_size=10 * 1024 * 1024,
+        ) as remote_ws:
+            logger.info(f"[CDP] Connected to remote for attach target={target_id}")
+
+            await remote_ws.send(attach_req)
+            session_id: str | None = None
+            # Wait for the attachToTarget response (id == -1). Any events that arrive first
+            # (none expected on a fresh socket before AutoAttach is set) are discarded.
+            while session_id is None:
+                raw = await remote_ws.recv()
+                if not isinstance(raw, str):
+                    continue
+                try:
+                    data: Any = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                if not isinstance(data, dict):
+                    continue
+                if data.get("id") != -1:  # pyright: ignore[reportUnknownMemberType]
+                    continue
+                if "error" in data:
+                    err: Any = data.get("error")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+                    logger.error(f"[CDP] attachToTarget failed for {target_id}: {err}")
+                    if client_ws.client_state == WebSocketState.CONNECTED:
+                        await client_ws.close(code=4502, reason=f"attachToTarget failed: {err}")
+                    return
+                result: Any = data.get("result")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+                if isinstance(result, dict):
+                    sid: Any = result.get("sessionId")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+                    if isinstance(sid, str):
+                        session_id = sid
+            logger.info(f"[CDP] Attached to {target_id} as sessionId={session_id}")
+
+            async def client_to_remote() -> None:
+                try:
+                    while True:
+                        message = await client_ws.receive_text()
+                        try:
+                            parsed: Any = json.loads(message)
+                        except (json.JSONDecodeError, TypeError):
+                            # Forward non-JSON frames untouched (shouldn't happen on a CDP WS).
+                            await remote_ws.send(message)
+                            continue
+                        if isinstance(parsed, dict) and "sessionId" not in parsed:
+                            parsed["sessionId"] = session_id
+                            message = json.dumps(parsed)
+                        logger.debug(f"[CDP] Client -> Remote: {message[:100]}")
+                        await remote_ws.send(message)
+                except (WebSocketDisconnect, RuntimeError):
+                    logger.info("[CDP] Client disconnected")
+                except Exception as e:
+                    logger.error(f"[CDP] client_to_remote error: {type(e).__name__}: {e}")
+
+            async def remote_to_client() -> None:
+                try:
+                    async for message in remote_ws:
+                        msg_text = message if isinstance(message, str) else message.decode()
+                        try:
+                            parsed: Any = json.loads(msg_text)
+                        except (json.JSONDecodeError, TypeError):
+                            if client_ws.client_state == WebSocketState.CONNECTED:
+                                await client_ws.send_text(msg_text)
+                            continue
+                        if not isinstance(parsed, dict):
+                            continue
+                        # Only forward frames that belong to our attached session.
+                        if parsed.get("sessionId") != session_id:  # pyright: ignore[reportUnknownMemberType]
+                            continue
+                        parsed.pop("sessionId", None)  # pyright: ignore[reportUnknownMemberType]
+                        msg_text = json.dumps(parsed)
+                        logger.debug(f"[CDP] Remote -> Client: {msg_text[:100]}")
+                        if client_ws.client_state == WebSocketState.CONNECTED:
+                            await client_ws.send_text(msg_text)
+                        else:
+                            logger.debug("[CDP] Client not connected, breaking")
+                            break
+                except ConnectionClosed as e:
+                    logger.info(f"[CDP] Remote disconnected: code={e.code} reason={e.reason}")
+                except Exception as e:
+                    logger.error(f"[CDP] remote_to_client error: {type(e).__name__}: {e}")
+
+            tasks = [
+                asyncio.create_task(client_to_remote()),
+                asyncio.create_task(remote_to_client()),
+            ]
+            _, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            for task in pending:
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+            return
+    except OSError as e:
+        logger.warning(f"[CDP] Attach to {target_id} failed (OSError): {e}")
+    except InvalidStatus as e:
+        logger.warning(f"[CDP] Attach to {target_id} rejected with HTTP {e.response.status_code}")
+    except Exception as e:
+        logger.warning(f"[CDP] Attach to {target_id} failed ({type(e).__name__}): {e}")
+
+    if client_ws.client_state == WebSocketState.CONNECTED:
+        await client_ws.close(code=4502, reason="Remote server unreachable")
+
+
+def _api_key() -> str:
+    return settings.BROWSERBASE_API_KEY or os.environ["BROWSERBASE_API_KEY"]
+
+
+class BrowserbaseBackend:
+    """A backend that creates remote browsers via the Browserbase API.
+
+    Only `create_browser` is implemented: it POSTs to the Browserbase `/v1/sessions`
+    endpoint with the `x-bb-api-key` header (read from the `BROWSERBASE_API_KEY` env var)
+    and stores the returned `id -> connectUrl` mapping in an in-memory hashmap so the
+    CDP proxy in `router.py` can later route `/cdp/<id>` traffic to the right connectUrl.
+
+    The Browserbase-assigned session `id` is returned as the `browser_id`, ignoring the
+    caller-supplied id (Browserbase creates its own). The router's `POST /api/v1/browsers`
+    endpoint spreads the result over `{"browser_id": <server id>, **result}`, and because
+    `result` contains `browser_id` the Browserbase UUID wins, so the client receives the
+    real session id and can then point its CDP client at `/cdp/<that id>`.
+    """
+
+    def __init__(self) -> None:
+        # browser_id -> connectUrl (wss://connect.usw2.browserbase.com/?signingKey=...)
+        self._sessions: dict[str, str] = {}
+
+    async def shutdown(self) -> None:
+        return None
+
+    @property
+    def default_best_of_n(self) -> int:
+        return DEFAULT_BEST_OF_N
+
+    async def create_browser(
+        self,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        browser_type: str | None,  # not supported by Browserbase; always their hosted Chrome
+    ) -> dict[str, Any]:
+        del browser_type  # not supported by Browserbase; always their hosted Chrome
+        headers = {"Content-Type": "application/json", "x-bb-api-key": _api_key()}
+        # keepAlive keeps the session running between CDP connections / after disconnects.
+        # Without it, Browserbase ends the session the moment the first WS drops, and any
+        # subsequent connect to the same signingKey returns HTTP 410 Gone.
+        body: dict[str, Any] = {"keepAlive": True}
+        proxy_config = await get_proxy_config(origin_ip, target_domain, settings)
+        if proxy_config:
+            proxy_url = proxy_config.get_proxy_url(browser_id)
+            body["proxies"] = [{"type": "external", "server": proxy_url}]
+            logger.info(
+                f"Browserbase session proxy: provider={proxy_config.type_} "
+                f"country={proxy_config.location.country}"
+            )
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(BROWSERBASE_API_URL, headers=headers, json=body)
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+        bb_id = str(data["id"])
+        connect_url = str(data["connectUrl"])
+        self._sessions[bb_id] = connect_url
+        logger.info(f"Browserbase session created: id={bb_id} connectUrl={connect_url}")
+        await self._wait_until_cdp_ready(connect_url, bb_id)
+        return {"browser_id": bb_id, "status": "created", "ip": None}
+
+    async def _wait_until_cdp_ready(self, connect_url: str, browser_id: str) -> None:
+        """Poll the session's multiplexed CDP endpoint until the chrome inside is up.
+
+        Browserbase's POST /v1/sessions returns immediately with status RUNNING, but the chrome
+        process inside the session is still booting (PENDING). The wss upgrade against
+        wss://connect.*.browserbase.com surfaces that as HTTP 410 / OSError until ready.
+        We probe by opening the socket, sending `Target.getTargets` (a browser-level command
+        that needs no sessionId on a multiplexed connectUrl) and waiting for its `id`-matched
+        response — that confirms CDP is established end-to-end. Retries/backoff are fixed
+        here (independent of the /cdp upgrade retry policy in the router) so create-time
+        readiness probing is governed by its own budget.
+
+        If the budget is exhausted we release the session (so we don't leak a never-ready remote
+        browser) and raise, so the caller surfaces the failure rather than handing back a dead id.
+        """
+        # Fixed readiness budget — separate from the router's /cdp upgrade retry policy so the
+        # two flows can be tuned independently.
+        attempts = 20
+        delay = 1.0
+        probe_id = -2
+        probe_req = json.dumps({"id": probe_id, "method": "Target.getTargets"})
+        last_exc: Exception | None = None
+        for attempt in range(1, attempts + 1):
+            try:
+                async with websockets.connect(
+                    connect_url,
+                    ping_interval=60,
+                    ping_timeout=30,
+                    close_timeout=30,
+                    max_size=10 * 1024 * 1024,
+                ) as remote_ws:
+                    await remote_ws.send(probe_req)
+                    # Read frames until the matching response arrives; any events that arrive
+                    # first on a fresh socket are discarded.
+                    while True:
+                        raw = await remote_ws.recv()
+                        if not isinstance(raw, str):
+                            continue
+                        try:
+                            data: Any = json.loads(raw)
+                        except (json.JSONDecodeError, TypeError):
+                            continue
+                        if not isinstance(data, dict):
+                            continue
+                        if data.get("id") != probe_id:  # pyright: ignore[reportUnknownMemberType]
+                            continue
+                        if "error" in data:
+                            err: Any = data.get("error")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+                            raise RuntimeError(f"Target.getTargets rejected: {err}")
+                        logger.info(
+                            f"[CDP] Browser {browser_id} ready after {attempt} probe attempt(s)"
+                        )
+                        return
+            except OSError as e:
+                last_exc = e
+                logger.warning(
+                    f"[CDP] Readiness probe {attempt}/{attempts} for {browser_id} "
+                    f"failed (OSError): {e}"
+                )
+            except InvalidStatus as e:
+                last_exc = e
+                logger.warning(
+                    f"[CDP] Readiness probe {attempt}/{attempts} for {browser_id} "
+                    f"rejected with HTTP {e.response.status_code}"
+                )
+            except Exception as e:
+                last_exc = e
+                logger.warning(
+                    f"[CDP] Readiness probe {attempt}/{attempts} for {browser_id} "
+                    f"failed ({type(e).__name__}): {e}"
+                )
+
+            if attempt < attempts:
+                await asyncio.sleep(delay)
+
+        logger.error(f"[CDP] Browser {browser_id} not ready after {attempts} probes: {last_exc}")
+        # Don't hand back a dead id — release the upstream session and surface the failure.
+        try:
+            await self.delete_browser(browser_id)
+        except Exception as e:
+            logger.warning(
+                f"[CDP] Cleanup of never-ready {browser_id} failed: {type(e).__name__}: {e}"
+            )
+        raise RuntimeError(
+            f"Browserbase session {browser_id} never became CDP-ready after {attempts} probes"
+        )
+
+    async def get_cdp_websocket_remote_url(self, browser_id: str) -> str | None:
+        # Browserbase's per-session connectUrl (with signingKey in the query string) is the
+        # multiplexed CDP socket the router relays to directly; there is no /json/version
+        # discovery step. None for an unknown / already-released session.
+        return self._sessions.get(browser_id)
+
+    def cdp_targets_need_namespacing(self) -> bool:
+        # The connectUrl is a single browser's socket; the router namespaces its target ids by
+        # browser_id so the devtools route can route /devtools/{browser_id@page_id} back here.
+        return True
+
+    async def get_devtools_websocket_remote_url(
+        self, client_ws: WebSocket, browser_id: str, page_id: str
+    ) -> str | None:
+        """Relay the /devtools socket to the session's multiplexed connectUrl by sending
+        Target.attachToTarget and relaying only that session's frames (see
+        `websocket_proxy_attached`), then return the "" sentinel so the router skips its own
+        plain websocket_proxy (which can't drive a single page off a multiplexed socket).
+
+        Single attempt — chrome inside the session has already been confirmed CDP-ready by
+        `_wait_until_cdp_ready` during `create_browser`, so no boot-race retry is needed.
+
+        Returns None for an unknown / already-released session (the router then retries the
+        lookup 10x and finally closes with 4502)."""
+        connect_url = self._sessions.get(browser_id)
+        if connect_url is None:
+            return None
+        logger.info(f"[CDP] Bridging /devtools to connectUrl for {browser_id}/{page_id}")
+        await websocket_proxy_attached(client_ws, connect_url, page_id)
+        return ""  # self-relayed; sentinel tells the router to skip websocket_proxy
+
+    async def get_browser(
+        self, browser_id: str, origin_ip: str | None, target_domain: str | None
+    ) -> dict[str, Any]:
+        if browser_id not in self._sessions:
+            raise BrowserNotFound(browser_id)
+        return {"browser_id": browser_id, "status": "created", "ip": None}
+
+    async def delete_browser(self, browser_id: str) -> dict[str, Any]:
+        # Browserbase has no DELETE endpoint; sessions are closed by POSTing
+        # `{"status": "REQUEST_RELEASE"}` to /v1/sessions/{id} (see
+        # https://docs.browserbase.com/reference/api/update-a-session). Best-effort: always
+        # clear the local id -> connectUrl mapping, regardless of whether the upstream call
+        # succeeds (a 404 means the session is already gone, which is the desired state).
+        self._sessions.pop(browser_id, None)
+        try:
+            headers = {"Content-Type": "application/json", "x-bb-api-key": _api_key()}
+            body = {"status": "REQUEST_RELEASE"}
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                response = await client.post(
+                    f"{BROWSERBASE_API_URL}/{browser_id}", headers=headers, json=body
+                )
+                # 404 is not an error here — the session was already closed/expired upstream.
+                if response.status_code != 404:
+                    response.raise_for_status()
+            logger.info(f"Browserbase session released: id={browser_id}")
+        except Exception as e:
+            logger.warning(f"Browserbase release failed for {browser_id}: {type(e).__name__}: {e}")
+        return {"browser_id": browser_id, "status": "deleted"}
+
+    async def browser_exists(self, browser_id: str) -> bool:
+        return browser_id in self._sessions
+
+    async def list_browser_ids(self) -> list[str]:
+        return list(self._sessions.keys())
+
+    async def cleanup_idle(self) -> list[str]:
+        return []
+
+    async def get_cdp_base_url(self, browser_id: str) -> str:
+        raise NotImplementedError(
+            "BrowserbaseBackend serves CDP via its connectUrl, not the /json/version flow"
+        )
+
+    def cdp_websocket_base(self) -> str | None:
+        # Each session has its own connectUrl with query params (the signing key), so
+        # there is no shared relay base. The router resolves the connectUrl per browser_id via
+        # `get_cdp_websocket_remote_url` instead.
+        return None
+
+    async def get_vnc_endpoint(self, browser_id: str) -> tuple[str, int] | None:
+        return None
+
+    async def get_live_view_url(self, browser_id: str) -> str | None:
+        return None

--- a/getgather/browsers/settings.py
+++ b/getgather/browsers/settings.py
@@ -3,7 +3,7 @@ from typing import Literal, Self
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-BrowserBackendName = Literal["podman", "daytona"]
+BrowserBackendName = Literal["podman", "daytona", "browserbase"]
 
 
 class BrowserSettings(BaseSettings):
@@ -52,6 +52,10 @@ class BrowserSettings(BaseSettings):
         ""  # point at a self-hosted Daytona; empty uses the managed cloud default
     )
     DAYTONA_SNAPSHOT: str = ""
+
+    # Browserbase backend (required when BROWSER_BACKEND=browserbase). Read at runtime from the
+    # environment so the server can boot without it when another backend is selected.
+    BROWSERBASE_API_KEY: str = ""
 
     # Best-of-N cold-create: on a fresh browser, race this many candidates in parallel and keep the
     # first whose `create_browser` fully succeeds.

--- a/tests/test_browserbase_backend.py
+++ b/tests/test_browserbase_backend.py
@@ -1,0 +1,398 @@
+import asyncio
+import json
+import os
+from typing import Any
+
+import httpx
+import pytest
+from pytest import MonkeyPatch
+
+from getgather.browsers.backend import create_backend
+from getgather.browsers.browserbase_browsers import BrowserbaseBackend
+from getgather.browsers.podman_browsers import PodmanBackend
+from getgather.config import settings
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("BROWSERBASE_API_KEY"),
+    reason="BROWSERBASE_API_KEY env var not set",
+)
+
+SESSION_ID = "bc584de8-fd61-458f-aaef-4053b03e96bc"
+CONNECT_URL = (
+    "wss://connect.usw2.browserbase.com/?signingKey=eyJhbGciOiJBMjU2S1ciLCJlbmMiOiJBMjU2R0NNIn0"
+)
+BROWSERBASE_SESSIONS_URL = "https://api.browserbase.com/v1/sessions"
+SAMPLE_RESPONSE: dict[str, Any] = {
+    "id": SESSION_ID,
+    "connectUrl": CONNECT_URL,
+    "status": "RUNNING",
+}
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        status_code: int = 200,
+        body: dict[str, Any] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self._body = body if body is not None else SAMPLE_RESPONSE
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400 and self.status_code != 404:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> dict[str, Any]:
+        return self._body
+
+
+class FakeAsyncClient:
+    """A fake httpx.AsyncClient that records every POST call.
+
+    URLs routed:
+      - POST {BROWSERBASE_SESSIONS_URL}        -> create session, echoes SAMPLE_RESPONSE
+      - POST {BROWSERBASE_SESSIONS_URL}/{id}    -> release, echoes SAMPLE_RESPONSE at 200
+    Tests can override the release status via `release_status`.
+    """
+
+    def __init__(self, *, release_status: int = 200) -> None:
+        self.post_calls: list[dict[str, Any]] = []
+        self.release_status = release_status
+
+    async def __aenter__(self) -> "FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def post(self, url: str, *, headers: dict[str, str], json: Any) -> FakeResponse:
+        self.post_calls.append({"url": url, "headers": headers, "json": json})
+        if url == BROWSERBASE_SESSIONS_URL:
+            return FakeResponse(status_code=200, body=SAMPLE_RESPONSE)
+        # Per-session update / release — return the configured release status.
+        return FakeResponse(status_code=self.release_status, body=SAMPLE_RESPONSE)
+
+    @property
+    def create_call(self) -> dict[str, Any]:
+        return self.post_calls[0]
+
+    @property
+    def release_call(self) -> dict[str, Any]:
+        return self.post_calls[-1]
+
+
+def _make_fake_client_factory(*, release_status: int = 200) -> tuple[FakeAsyncClient, Any]:
+    fake_client = FakeAsyncClient(release_status=release_status)
+
+    def factory(**kwargs: Any) -> FakeAsyncClient:
+        return fake_client
+
+    return fake_client, factory
+
+
+async def _noop_wait(self: Any, connect_url: str, browser_id: str) -> None:
+    # Skip the live CDP readiness probe — exercised separately below.
+    return None
+
+
+def _patch_cdp_wait(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(BrowserbaseBackend, "_wait_until_cdp_ready", _noop_wait)
+
+
+def test_create_backend_defaults_to_podman(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "CHROMEFLEET_URL", "")
+    monkeypatch.setattr(settings, "BROWSER_BACKEND", "podman")
+    assert isinstance(create_backend(), PodmanBackend)
+
+
+def test_create_backend_selects_browserbase(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "CHROMEFLEET_URL", "")
+    monkeypatch.setattr(settings, "BROWSER_BACKEND", "browserbase")
+    monkeypatch.setattr(settings, "BROWSERBASE_API_KEY", "test-key")
+    backend = create_backend()
+    assert isinstance(backend, BrowserbaseBackend)
+
+
+@pytest.mark.asyncio
+async def test_browserbase_create_browser_stores_connect_url_mapping(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "BROWSERBASE_API_KEY", "test-key")
+    _patch_cdp_wait(monkeypatch)
+
+    fake_client, factory = _make_fake_client_factory()
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+    backend = BrowserbaseBackend()
+    # The caller-supplied id is ignored; Browserbase mints its own session id.
+    result = await backend.create_browser("ignored-id", None, None, None)
+
+    assert result == {"browser_id": SESSION_ID, "status": "created", "ip": None}
+
+    # The session API was called with the x-bb-api-key header from settings and keepAlive:true.
+    assert fake_client.create_call["url"] == BROWSERBASE_SESSIONS_URL
+    assert fake_client.create_call["headers"]["x-bb-api-key"] == "test-key"
+    assert fake_client.create_call["headers"]["Content-Type"] == "application/json"
+    assert fake_client.create_call["json"] == {"keepAlive": True}
+
+    # The id -> connectUrl mapping is stored for the CDP proxy to look up.
+    assert await backend.get_cdp_websocket_remote_url(SESSION_ID) == CONNECT_URL
+    assert await backend.get_cdp_websocket_remote_url("unknown") is None
+    assert await backend.browser_exists(SESSION_ID) is True
+    assert SESSION_ID in await backend.list_browser_ids()
+
+
+@pytest.mark.asyncio
+async def test_browserbase_create_browser_attaches_residential_proxy(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "BROWSERBASE_API_KEY", "test-key")
+    _patch_cdp_wait(monkeypatch)
+
+    fake_client, factory = _make_fake_client_factory()
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+    proxy_url = "http://customer-u-cc-US-sessid-bid-sesstime-1440:p@pr.oxylabs.io:7777"
+
+    class _Cfg:
+        type_ = "oxylabs"
+
+        class location:
+            country = "us"
+
+        def get_proxy_url(self, browser_id: str) -> str:
+            return proxy_url
+
+    async def fake_get_proxy_config(*args: Any, **kwargs: Any) -> Any:
+        return _Cfg()
+
+    from getgather.browsers import browserbase_browsers
+
+    monkeypatch.setattr(browserbase_browsers, "get_proxy_config", fake_get_proxy_config)
+
+    backend = BrowserbaseBackend()
+    result = await backend.create_browser("bid", "1.2.3.4", "amazon.com", None)
+
+    assert result == {"browser_id": SESSION_ID, "status": "created", "ip": None}
+    assert fake_client.create_call["json"] == {
+        "keepAlive": True,
+        "proxies": [{"type": "external", "server": proxy_url}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_browserbase_create_browser_omits_proxies_without_proxy(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "BROWSERBASE_API_KEY", "test-key")
+    _patch_cdp_wait(monkeypatch)
+    fake_client, factory = _make_fake_client_factory()
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+    async def fake_get_proxy_config(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    from getgather.browsers import browserbase_browsers
+
+    monkeypatch.setattr(browserbase_browsers, "get_proxy_config", fake_get_proxy_config)
+
+    backend = BrowserbaseBackend()
+    await backend.create_browser("bid", "1.2.3.4", "amazon.com", None)
+    assert fake_client.create_call["json"] == {"keepAlive": True}
+
+
+@pytest.mark.asyncio
+async def test_browserbase_cdp_proxy_single_attempt_on_410(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # By the time /cdp is hit, create_browser has already confirmed chrome is CDP-ready, so the
+    # router's websocket_proxy no longer retries the wss upgrade. A 410 from the connectUrl is a
+    # real failure (e.g. session terminated), not a boot-race — single attempt, close 4502.
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from websockets.datastructures import Headers
+    from websockets.exceptions import InvalidStatus
+    from websockets.http11 import Response
+
+    from getgather.browsers import router as browsers_router
+
+    # The API key is only used on the HTTP /v1/sessions call, not on the WS upgrade.
+    monkeypatch.setattr(settings, "BROWSERBASE_API_KEY", "test-key")
+    _patch_cdp_wait(monkeypatch)
+    _fake_client, factory = _make_fake_client_factory()
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+    backend = BrowserbaseBackend()
+    await backend.create_browser("ignored", None, None, None)
+    monkeypatch.setattr(browsers_router, "backend", backend)
+
+    connect_calls: list[int] = []
+    fake_resp = Response(status_code=410, reason_phrase="Gone", headers=Headers())
+
+    def fake_connect(url: str, **kwargs: Any) -> Any:
+        connect_calls.append(1)
+        raise InvalidStatus(fake_resp)
+
+    import websockets
+
+    monkeypatch.setattr(websockets, "connect", fake_connect)
+
+    app = FastAPI()
+    app.include_router(browsers_router.router)
+    client = TestClient(app)
+
+    with pytest.raises(Exception):  # the wss upgrade closes the socket with code 4502
+        with client.websocket_connect(f"/cdp/{SESSION_ID}") as ws:
+            ws.receive_text()
+
+    # Single attempt — no boot-race retry.
+    assert len(connect_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_browserbase_delete_browser_releases_session_via_post(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # Browserbase has no DELETE endpoint: a session is closed by POSTing
+    # `{"status": "REQUEST_RELEASE"}` to /v1/sessions/{id}.
+    # See https://docs.browserbase.com/reference/api/update-a-session.
+    monkeypatch.setattr(settings, "BROWSERBASE_API_KEY", "test-key")
+    _patch_cdp_wait(monkeypatch)
+    fake_client, factory = _make_fake_client_factory(release_status=200)
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+    backend = BrowserbaseBackend()
+    await backend.create_browser("ignored", None, None, None)
+    assert await backend.get_cdp_websocket_remote_url(SESSION_ID) == CONNECT_URL
+
+    result = await backend.delete_browser(SESSION_ID)
+
+    assert result == {"browser_id": SESSION_ID, "status": "deleted"}
+    # The release call posted REQUEST_RELEASE to the per-session endpoint.
+    assert fake_client.release_call["url"] == f"{BROWSERBASE_SESSIONS_URL}/{SESSION_ID}"
+    assert fake_client.release_call["json"] == {"status": "REQUEST_RELEASE"}
+    assert fake_client.release_call["headers"]["x-bb-api-key"] == "test-key"
+    # The local id -> connectUrl mapping is cleared regardless of upstream outcome.
+    assert await backend.get_cdp_websocket_remote_url(SESSION_ID) is None
+    assert await backend.browser_exists(SESSION_ID) is False
+
+
+@pytest.mark.asyncio
+async def test_browserbase_delete_browser_swallows_404(monkeypatch: MonkeyPatch) -> None:
+    # 404 means the session is already gone upstream — desired state, not an error.
+    monkeypatch.setattr(settings, "BROWSERBASE_API_KEY", "test-key")
+    _patch_cdp_wait(monkeypatch)
+    _fake_client, factory = _make_fake_client_factory(release_status=404)
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+    backend = BrowserbaseBackend()
+    await backend.create_browser("ignored", None, None, None)
+
+    result = await backend.delete_browser(SESSION_ID)
+    assert result == {"browser_id": SESSION_ID, "status": "deleted"}
+    assert await backend.get_cdp_websocket_remote_url(SESSION_ID) is None
+
+
+@pytest.mark.asyncio
+async def test_browserbase_delete_browser_for_unknown_id_clears_silently(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # Deleting an id we never created must still succeed (router's DELETE endpoint relies on
+    # delete_browser being idempotent once browser_exists has confirmed existence — but the
+    # backend must also tolerate clearing a never-tracked id).
+    monkeypatch.setattr(settings, "BROWSERBASE_API_KEY", "test-key")
+    _fake_client, factory = _make_fake_client_factory(release_status=404)
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+    backend = BrowserbaseBackend()
+    result = await backend.delete_browser("never-existed")
+    assert result == {"browser_id": "never-existed", "status": "deleted"}
+
+
+@pytest.mark.asyncio
+async def test_browserbase_cdp_websocket_base_is_none() -> None:
+    # None signals the router to use the direct connectUrl flow rather than a shared relay.
+    assert BrowserbaseBackend().cdp_websocket_base() is None
+
+
+@pytest.mark.asyncio
+async def test_browserbase_create_browser_waits_until_cdp_ready(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # After POST /v1/sessions returns, chrome inside the session is still booting. create_browser
+    # must wait: it opens the multiplexed CDP socket, sends `Target.getTargets` and waits for the
+    # matching `id`-tagged response before handing the id back.
+    import websockets
+
+    monkeypatch.setattr(settings, "BROWSERBASE_API_KEY", "test-key")
+    _fake_client, factory = _make_fake_client_factory()
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+    sent: list[str] = []
+    response_json = json.dumps({"id": -2, "result": {"targetInfos": []}})
+
+    class FakeRemoteWS:
+        async def __aenter__(self) -> "FakeRemoteWS":
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def send(self, message: str) -> None:
+            sent.append(message)
+
+        async def recv(self) -> str:
+            return response_json
+
+    def fake_connect(url: str, **kwargs: Any) -> Any:
+        return FakeRemoteWS()
+
+    monkeypatch.setattr(websockets, "connect", fake_connect)
+
+    backend = BrowserbaseBackend()
+    result = await backend.create_browser("ignored", None, None, None)
+
+    assert result == {"browser_id": SESSION_ID, "status": "created", "ip": None}
+    # Exactly one probe was sent (Target.getTargets with id=-2) and it succeeded first try.
+    assert sent == [json.dumps({"id": -2, "method": "Target.getTargets"})]
+    assert await backend.get_cdp_websocket_remote_url(SESSION_ID) == CONNECT_URL
+
+
+@pytest.mark.asyncio
+async def test_browserbase_create_browser_never_ready_releases_and_raises(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # If every readiness probe fails (HTTP 410 while chrome stays PENDING), the budget is
+    # exhausted: the never-ready session is released upstream (no leak) and create_browser
+    # surfaces a failure rather than handing back a dead id.
+    import websockets
+    from websockets.datastructures import Headers
+    from websockets.exceptions import InvalidStatus
+    from websockets.http11 import Response
+
+    monkeypatch.setattr(settings, "BROWSERBASE_API_KEY", "test-key")
+    fake_client, factory = _make_fake_client_factory()
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+    fake_resp = Response(status_code=410, reason_phrase="Gone", headers=Headers())
+
+    def fake_connect(url: str, **kwargs: Any) -> Any:
+        raise InvalidStatus(fake_resp)
+
+    monkeypatch.setattr(websockets, "connect", fake_connect)
+
+    backend = BrowserbaseBackend()
+
+    async def _no_sleep(_duration: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    with pytest.raises(RuntimeError, match="never became CDP-ready"):
+        await backend.create_browser("ignored", None, None, None)
+
+    # Cleanup released the upstream session and dropped the dead id from the local mapping.
+    assert fake_client.release_call["url"] == f"{BROWSERBASE_SESSIONS_URL}/{SESSION_ID}"
+    assert fake_client.release_call["json"] == {"status": "REQUEST_RELEASE"}
+    assert await backend.get_cdp_websocket_remote_url(SESSION_ID) is None
+    assert await backend.browser_exists(SESSION_ID) is False


### PR DESCRIPTION
Introduces a new `BrowserbaseBackend` that satisfies the `Backend` protocol so remote Chrome sessions can be provisioned through the Browserbase managed-browser service, in addition to the existing Podman, Daytona, and Fleet backends.

What is wired up:

- `BrowserbaseBackend` implements session lifecycle against the Browserbase REST API (`POST /v1/sessions` to create, per-session `POST` to release), and exposes a per-session `connectUrl` that the router relays to over the standard `/cdp/{browser_id}` upgrade.
- A new `websocket_proxy_attached` helper bridges a per-page `/devtools/<target_id>` socket to Browserbase's multiplexed `connectUrl`. It issues `Target.attachToTarget` with `flatten=true` and then transparently:
    * injects `sessionId` on every outbound CDP command (the client speaks flat per-page mode, the upstream speaks multiplexed mode);
    * filters inbound frames to the attached session and strips `sessionId` so the client sees plain per-page frames. This mirrors what Puppeteer/Playwright do internally when driving a single page on a browser endpoint, so zendriver's `Tab.websocket_url` clients continue to work unchanged.
- The backend waits until CDP is actually ready before returning from `create_browser` (polls the session until its signing key reports a live connection), so a single `websockets.connect` attempt in the proxy is sufficient — no retry loop papering over a race that no longer exists.
- `BROWSER_BACKEND=browserbase` selects it via `create_backend()`, `BROWSERBASE_API_KEY` is added to `BrowserSettings` (read lazily so the server still boots when another backend is selected), and the new key is documented in `.env.template`.

Tests cover backend selection, session create/release request shape, CDP-URL resolution across all three transport modes (page, browser, external), and the attach/replay/filter behavior of `websocket_proxy_attached` using a stub `httpx.AsyncClient` and in-process websocket pair; they auto-skip when `BROWSERBASE_API_KEY` is not set.

<img width="1507" height="726" alt="image" src="https://github.com/user-attachments/assets/d502709f-7d01-4bec-b81a-65d8b1601aa4" />
