### PR TITLE
Add CVS sign-in patterns with trusted CDP actions

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -1115,16 +1115,6 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
                         dispatchClick(element);
                         output[key] = true;
                     }}
-                }} else if (kind === "press_enter") {{
-                    element.focus();
-                    for (const type of ["keydown", "keypress", "keyup"]) {{
-                        element.dispatchEvent(new KeyboardEvent(type, {{
-                            key: "Enter",
-                            code: "Enter",
-                            bubbles: true,
-                        }}));
-                    }}
-                    output[key] = true;
                 }} else if (kind === "set_value") {{
                     const value = typeof action?.value === "string" ? action.value : "";
                     const requestedDelay = Number(action?.typing_delay_ms);

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -1097,12 +1097,8 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
 
             try {{
                 if (kind === "click") {{
-                    if (element.disabled || element.getAttribute("aria-disabled") === "true") {{
-                        output[key] = false;
-                    }} else {{
-                        element.click();
-                        output[key] = true;
-                    }}
+                    element.click();
+                    output[key] = true;
                 }} else if (kind === "set_value") {{
                     const value = typeof action?.value === "string" ? action.value : "";
                     const requestedDelay = Number(action?.typing_delay_ms);

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -1027,7 +1027,7 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
         }}
 
         async function setValueWithPoll(selector, value, typingDelayMs, timeout) {{
-            const el = findCss(selector, document);
+            const el = document.querySelector(selector);
             if (!el) return {{ success: false, reason: "element not found" }};
             await fillInput(el, value, typingDelayMs);
 
@@ -1036,7 +1036,7 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
             const deadline = Date.now() + timeout;
             while (Date.now() < deadline) {{
                 await sleep(50);
-                const inputEl = findCss(selector, document);
+                const inputEl = document.querySelector(selector);
                 if (!inputEl) {{ stableCount = 0; continue; }}
                 if (inputEl.value !== value) {{
                     stableCount = 0;

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -1026,18 +1026,6 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
             el.dispatchEvent(new Event("blur", {{ bubbles: true }}));
         }}
 
-        function dispatchClick(el) {{
-            el.scrollIntoView({{ block: "center" }});
-            el.dispatchEvent(new PointerEvent("pointerdown", {{ bubbles: true, composed: true }}));
-            el.dispatchEvent(new PointerEvent("pointerup", {{ bubbles: true, composed: true }}));
-            el.dispatchEvent(new MouseEvent("click", {{
-                bubbles: true,
-                cancelable: true,
-                composed: true,
-                view: window,
-            }}));
-        }}
-
         async function setValueWithPoll(selector, value, typingDelayMs, timeout) {{
             const el = findCss(selector, document);
             if (!el) return {{ success: false, reason: "element not found" }};
@@ -1112,7 +1100,7 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
                     if (element.disabled || element.getAttribute("aria-disabled") === "true") {{
                         output[key] = false;
                     }} else {{
-                        dispatchClick(element);
+                        element.click();
                         output[key] = true;
                     }}
                 }} else if (kind === "set_value") {{

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -1023,10 +1023,23 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
                 if (typingDelayMs > 0) await sleep(typingDelayMs);
             }}
             el.dispatchEvent(new Event("change", {{ bubbles: true }}));
+            el.dispatchEvent(new Event("blur", {{ bubbles: true }}));
+        }}
+
+        function dispatchClick(el) {{
+            el.scrollIntoView({{ block: "center" }});
+            el.dispatchEvent(new PointerEvent("pointerdown", {{ bubbles: true, composed: true }}));
+            el.dispatchEvent(new PointerEvent("pointerup", {{ bubbles: true, composed: true }}));
+            el.dispatchEvent(new MouseEvent("click", {{
+                bubbles: true,
+                cancelable: true,
+                composed: true,
+                view: window,
+            }}));
         }}
 
         async function setValueWithPoll(selector, value, typingDelayMs, timeout) {{
-            const el = document.querySelector(selector);
+            const el = findCss(selector, document);
             if (!el) return {{ success: false, reason: "element not found" }};
             await fillInput(el, value, typingDelayMs);
 
@@ -1035,7 +1048,7 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
             const deadline = Date.now() + timeout;
             while (Date.now() < deadline) {{
                 await sleep(50);
-                const inputEl = document.querySelector(selector);
+                const inputEl = findCss(selector, document);
                 if (!inputEl) {{ stableCount = 0; continue; }}
                 if (inputEl.value !== value) {{
                     stableCount = 0;
@@ -1096,7 +1109,21 @@ async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dic
 
             try {{
                 if (kind === "click") {{
-                    element.click();
+                    if (element.disabled || element.getAttribute("aria-disabled") === "true") {{
+                        output[key] = false;
+                    }} else {{
+                        dispatchClick(element);
+                        output[key] = true;
+                    }}
+                }} else if (kind === "press_enter") {{
+                    element.focus();
+                    for (const type of ["keydown", "keypress", "keyup"]) {{
+                        element.dispatchEvent(new KeyboardEvent(type, {{
+                            key: "Enter",
+                            code: "Enter",
+                            bubbles: true,
+                        }}));
+                    }}
                     output[key] = true;
                 }} else if (kind === "set_value") {{
                     const value = typeof action?.value === "string" ? action.value : "";

--- a/getgather/mcp/cvs.py
+++ b/getgather/mcp/cvs.py
@@ -1,0 +1,97 @@
+from typing import Any, cast
+
+import zendriver as zd
+from loguru import logger
+
+from getgather.browser import retry_with_navigation, zen_navigate_with_retry
+from getgather.mcp.dpage import (
+    remote_zen_dpage_mcp_tool,
+    remote_zen_dpage_with_action,
+)
+from getgather.mcp.registry import MCPTool
+
+cvs_mcp = MCPTool.registry["cvs"]
+
+
+@cvs_mcp.tool
+async def signin() -> dict[str, Any]:
+    """Signin to a user's CVS account (local zen)."""
+    return await remote_zen_dpage_mcp_tool("https://www.cvs.com/account-login", "cvs_signin")
+
+
+async def get_perscription_history_action(tab: zd.Tab, _) -> dict[str, Any]:
+    """Get the perscription history from a user's CVS account (local zen)."""
+
+    logger.info("Starting get_perscription_history_action")
+
+    async def fetch_orders() -> dict[str, Any]:
+        orders = None
+
+        await zen_navigate_with_retry(tab, "https://www.cvs.com/pharmacy/rx/prescriptions", wait_for_ready=False)
+        orders = await tab.evaluate(
+            f"""
+                (async () => {{
+                    const httpRequest = await new Promise(resolve => {{
+                        const originalFetch = window.fetch;
+                        window.fetch = async function (...args) {{
+                            if(args[0].includes('mcapi/client/experience/v2/load') && args[0].includes('ice_plp_web_retail_blocks') && args[1].method === 'POST'){{
+                                window.fetch = originalFetch;
+                                resolve(args);
+                            }}
+                            const response = await originalFetch.apply(this, args);
+                            return response;
+                        }};
+                    }})
+                    
+                    const url = httpRequest[0]
+                    const headers = httpRequest[1].headers
+                    const originalBody = JSON.parse(httpRequest[1].body);
+                    const endDateObj = new Date(originalBody.data.endDate);
+                    const startDateObj = new Date(endDateObj);
+                    startDateObj.setMonth(startDateObj.getMonth() - 24);
+                    const startDate = String(originalBody.data.endDate).includes("T")
+                        ? startDateObj.toISOString()
+                        : startDateObj.toISOString().slice(0, 10);
+                    const body = {{
+                        ...originalBody,
+                        data: {{
+                            ...originalBody.data,
+                            startDate,
+                        }}
+                    }};
+                    
+                    const res = await fetch(url, {{
+                        method: 'POST',
+                        credentials: 'include',
+                        headers,
+                        body: JSON.stringify(body)
+                    }});
+                    if (!res.ok) {{
+                        const error_text = await res.text();
+                        throw new Error(`HTTP error! status: ${{res.status}} - ${{error_text}}`);
+                    }}
+                    return await res.json();
+                }})()
+            """,
+            True,
+        )
+        return cast(dict[str, Any], orders)
+
+    return await retry_with_navigation(
+        tab=tab,
+        operation=fetch_orders,
+        max_retries=3,
+        exceptions=(Exception,),
+        re_raise_on_max_retries=True,
+        timeout_seconds=30,
+        operation_name="get_perscription_history_action",
+    )
+
+
+@cvs_mcp.tool
+async def get_perscription_history() -> dict[str, Any]:
+    """Get the perscription history from a user's CVS account."""
+    return await remote_zen_dpage_with_action(
+        "https://www.cvs.com/pharmacy/rx/prescriptions",
+        get_perscription_history_action,
+    )

--- a/getgather/mcp/cvs.py
+++ b/getgather/mcp/cvs.py
@@ -27,7 +27,9 @@ async def get_perscription_history_action(tab: zd.Tab, _) -> dict[str, Any]:
     async def fetch_orders() -> dict[str, Any]:
         orders = None
 
-        await zen_navigate_with_retry(tab, "https://www.cvs.com/pharmacy/rx/prescriptions", wait_for_ready=False)
+        await zen_navigate_with_retry(
+            tab, "https://www.cvs.com/pharmacy/rx/prescriptions", wait_for_ready=False
+        )
         orders = await tab.evaluate(
             f"""
                 (async () => {{

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -376,11 +376,16 @@ async def distill_post_loop(
         inputs = document.find_all("input")
         pending_actions: list[dict[str, str]] = []
         html_element = document.find("html")
-        action_delay_ms = (
-            int(str(html_element.get("gg-action-delay") or 0))
-            if isinstance(html_element, Tag)
-            else 0
-        )
+        action_delay_ms = 0
+        if isinstance(html_element, Tag):
+            for delay_attr in ("rb-action-delay", "gg-action-delay"):
+                raw_delay = html_element.get(delay_attr)
+                if raw_delay is not None:
+                    try:
+                        action_delay_ms = int(str(raw_delay))
+                    except ValueError:
+                        action_delay_ms = 0
+                    break
         element_config = (
             ElementConfig(action_delay_ms=action_delay_ms) if action_delay_ms > 0 else None
         )

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -385,7 +385,7 @@ async def distill_post_loop(
             ElementConfig(action_delay_ms=action_delay_ms) if action_delay_ms > 0 else None
         )
         trusted_actions = (
-            isinstance(html_element, Tag) and "gg-trusted-actions" in html_element.attrs
+            isinstance(html_element, Tag) and "rb-trusted-actions" in html_element.attrs
         )
 
         if match.distilled == current.distilled:

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -577,9 +577,7 @@ async def distill_post_loop(
                 })
 
         should_submit = False
-        SUBMIT_BUTTON = (
-            "button[rb-autoclick], button[gg-autoclick], button[type=submit], button[type=button]"
-        )
+        SUBMIT_BUTTON = "button[rb-autoclick], button[gg-autoclick], button[type=submit]"
         if document.select(SUBMIT_BUTTON):
             if len(names) > 0 and expected_field_count == len(names):
                 logger.info("Submitting form, all fields are filled...")

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -576,61 +576,39 @@ async def distill_post_loop(
                     "selector": str(auto_click_selector),
                 })
 
-        submit_enter_selectors: list[str] = []
-        for input in inputs:
-            if not isinstance(input, Tag) or "gg-submit-enter" not in input.attrs:
-                continue
-            name = input.get("name")
-            if name is None or str(name) not in names:
-                continue
-            gg_match = get_match_attr(input)
-            selector, _ = get_selector(str(gg_match) if gg_match is not None else "")
-            if selector:
-                submit_enter_selectors.append(str(selector))
-
         should_submit = False
         SUBMIT_BUTTON = (
             "button[rb-autoclick], button[gg-autoclick], button[type=submit], button[type=button]"
         )
         if document.select(SUBMIT_BUTTON):
             if len(names) > 0 and expected_field_count == len(names):
-                if submit_enter_selectors:
-                    logger.info("Submitting form via Enter key, all fields are filled...")
-                    for selector in submit_enter_selectors:
+                logger.info("Submitting form, all fields are filled...")
+                for submit_button in document.select(SUBMIT_BUTTON):
+                    submit_selector, frame_selector = get_selector(
+                        str(get_match_attr(submit_button))
+                    )
+                    if not submit_selector:
+                        continue
+                    if trusted_actions:
+                        submit_element = await page_query_selector(
+                            page,
+                            submit_selector,
+                            iframe_selector=frame_selector,
+                            config=element_config,
+                        )
+                        if submit_element:
+                            logger.info(f"Trusted CDP mouse click on {submit_selector}")
+                            await submit_element.element.mouse_click()
+                            await asyncio.sleep(0.25)
+                        else:
+                            logger.warning(f"Trusted submit could not find {submit_selector}")
+                    else:
                         pending_actions.append({
-                            "key": f"press_enter:{len(pending_actions)}",
-                            "kind": "press_enter",
-                            "selector": selector,
+                            "key": f"click:submit:{len(pending_actions)}",
+                            "kind": "click",
+                            "selector": str(submit_selector),
                             "action_delay_ms": str(action_delay_ms),
                         })
-                else:
-                    logger.info("Submitting form, all fields are filled...")
-                    for submit_button in document.select(SUBMIT_BUTTON):
-                        submit_selector, frame_selector = get_selector(
-                            str(get_match_attr(submit_button))
-                        )
-                        if not submit_selector:
-                            continue
-                        if trusted_actions:
-                            submit_element = await page_query_selector(
-                                page,
-                                submit_selector,
-                                iframe_selector=frame_selector,
-                                config=element_config,
-                            )
-                            if submit_element:
-                                logger.info(f"Trusted CDP mouse click on {submit_selector}")
-                                await submit_element.element.mouse_click()
-                                await asyncio.sleep(0.25)
-                            else:
-                                logger.warning(f"Trusted submit could not find {submit_selector}")
-                        else:
-                            pending_actions.append({
-                                "key": f"click:submit:{len(pending_actions)}",
-                                "kind": "click",
-                                "selector": str(submit_selector),
-                                "action_delay_ms": str(action_delay_ms),
-                            })
                 should_submit = True
             else:
                 logger.warning("Not all form fields are filled")
@@ -661,39 +639,6 @@ async def distill_post_loop(
                 try:
                     if kind == "click":
                         await element.click()
-                    elif kind == "press_enter":
-                        escaped_selector = selector.replace("\\", "\\\\").replace('"', '\\"')
-                        await page.evaluate(
-                            f"""
-                            (() => {{
-                                function findCss(sel, doc) {{
-                                    try {{
-                                        const direct = doc.querySelector(sel);
-                                        if (direct) return direct;
-                                    }} catch (e) {{}}
-                                    for (const iframe of doc.querySelectorAll("iframe")) {{
-                                        try {{
-                                            const childDoc = iframe.contentDocument || iframe.contentWindow.document;
-                                            const nested = findCss(sel, childDoc);
-                                            if (nested) return nested;
-                                        }} catch (e) {{}}
-                                    }}
-                                    return null;
-                                }}
-                                const el = findCss("{escaped_selector}", document);
-                                if (!el) return false;
-                                el.focus();
-                                for (const type of ["keydown", "keypress", "keyup"]) {{
-                                    el.dispatchEvent(new KeyboardEvent(type, {{
-                                        key: "Enter",
-                                        code: "Enter",
-                                        bubbles: true,
-                                    }}));
-                                }}
-                                return true;
-                            }})()
-                            """
-                        )
                     elif kind == "set_value":
                         value = pending_action.get("value")
                         await element.type_text(value if isinstance(value, str) else "")

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -384,6 +384,9 @@ async def distill_post_loop(
         element_config = (
             ElementConfig(action_delay_ms=action_delay_ms) if action_delay_ms > 0 else None
         )
+        trusted_actions = (
+            isinstance(html_element, Tag) and "gg-trusted-actions" in html_element.attrs
+        )
 
         if match.distilled == current.distilled:
             logger.info(f"Still the same: {match.name}")
@@ -533,13 +536,26 @@ async def distill_post_loop(
                         names.append(name_str)
                         input["value"] = value
                         current.distilled = str(document)
-                        pending_actions.append({
-                            "key": f"set:{name}:{len(pending_actions)}",
-                            "kind": "set_value",
-                            "selector": str(selector),
-                            "value": str(value),
-                            "action_delay_ms": str(action_delay_ms),
-                        })
+                        if trusted_actions and input_type not in ("checkbox", "radio"):
+                            text_element = await page_query_selector(
+                                page,
+                                selector if selector is not None else "",
+                                iframe_selector=frame_selector,
+                                config=element_config,
+                            )
+                            if text_element:
+                                await text_element.type_text(str(value))
+                                await asyncio.sleep(0.25)
+                            else:
+                                logger.warning(f"Trusted fill could not find {selector}")
+                        else:
+                            pending_actions.append({
+                                "key": f"set:{name}:{len(pending_actions)}",
+                                "kind": "set_value",
+                                "selector": str(selector),
+                                "value": str(value),
+                                "action_delay_ms": str(action_delay_ms),
+                            })
                         del fields[name_str]
                     else:
                         logger.info(f"No form data found for {name}")
@@ -555,20 +571,61 @@ async def distill_post_loop(
                     "selector": str(auto_click_selector),
                 })
 
+        submit_enter_selectors: list[str] = []
+        for input in inputs:
+            if not isinstance(input, Tag) or "gg-submit-enter" not in input.attrs:
+                continue
+            name = input.get("name")
+            if name is None or str(name) not in names:
+                continue
+            gg_match = get_match_attr(input)
+            selector, _ = get_selector(str(gg_match) if gg_match is not None else "")
+            if selector:
+                submit_enter_selectors.append(str(selector))
+
         should_submit = False
-        SUBMIT_BUTTON = "button[rb-autoclick], button[gg-autoclick], button[type=submit]"
+        SUBMIT_BUTTON = (
+            "button[rb-autoclick], button[gg-autoclick], button[type=submit], button[type=button]"
+        )
         if document.select(SUBMIT_BUTTON):
             if len(names) > 0 and expected_field_count == len(names):
-                logger.info("Submitting form, all fields are filled...")
-                for submit_button in document.select(SUBMIT_BUTTON):
-                    submit_selector, _ = get_selector(str(get_match_attr(submit_button)))
-                    if submit_selector:
+                if submit_enter_selectors:
+                    logger.info("Submitting form via Enter key, all fields are filled...")
+                    for selector in submit_enter_selectors:
                         pending_actions.append({
-                            "key": f"click:submit:{len(pending_actions)}",
-                            "kind": "click",
-                            "selector": str(submit_selector),
+                            "key": f"press_enter:{len(pending_actions)}",
+                            "kind": "press_enter",
+                            "selector": selector,
                             "action_delay_ms": str(action_delay_ms),
                         })
+                else:
+                    logger.info("Submitting form, all fields are filled...")
+                    for submit_button in document.select(SUBMIT_BUTTON):
+                        submit_selector, frame_selector = get_selector(
+                            str(get_match_attr(submit_button))
+                        )
+                        if not submit_selector:
+                            continue
+                        if trusted_actions:
+                            submit_element = await page_query_selector(
+                                page,
+                                submit_selector,
+                                iframe_selector=frame_selector,
+                                config=element_config,
+                            )
+                            if submit_element:
+                                logger.info(f"Trusted CDP mouse click on {submit_selector}")
+                                await submit_element.element.mouse_click()
+                                await asyncio.sleep(0.25)
+                            else:
+                                logger.warning(f"Trusted submit could not find {submit_selector}")
+                        else:
+                            pending_actions.append({
+                                "key": f"click:submit:{len(pending_actions)}",
+                                "kind": "click",
+                                "selector": str(submit_selector),
+                                "action_delay_ms": str(action_delay_ms),
+                            })
                 should_submit = True
             else:
                 logger.warning("Not all form fields are filled")
@@ -599,6 +656,39 @@ async def distill_post_loop(
                 try:
                     if kind == "click":
                         await element.click()
+                    elif kind == "press_enter":
+                        escaped_selector = selector.replace("\\", "\\\\").replace('"', '\\"')
+                        await page.evaluate(
+                            f"""
+                            (() => {{
+                                function findCss(sel, doc) {{
+                                    try {{
+                                        const direct = doc.querySelector(sel);
+                                        if (direct) return direct;
+                                    }} catch (e) {{}}
+                                    for (const iframe of doc.querySelectorAll("iframe")) {{
+                                        try {{
+                                            const childDoc = iframe.contentDocument || iframe.contentWindow.document;
+                                            const nested = findCss(sel, childDoc);
+                                            if (nested) return nested;
+                                        }} catch (e) {{}}
+                                    }}
+                                    return null;
+                                }}
+                                const el = findCss("{escaped_selector}", document);
+                                if (!el) return false;
+                                el.focus();
+                                for (const type of ["keydown", "keypress", "keyup"]) {{
+                                    el.dispatchEvent(new KeyboardEvent(type, {{
+                                        key: "Enter",
+                                        code: "Enter",
+                                        bubbles: true,
+                                    }}));
+                                }}
+                                return true;
+                            }})()
+                            """
+                        )
                     elif kind == "set_value":
                         value = pending_action.get("value")
                         await element.type_text(value if isinstance(value, str) else "")

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -376,16 +376,11 @@ async def distill_post_loop(
         inputs = document.find_all("input")
         pending_actions: list[dict[str, str]] = []
         html_element = document.find("html")
-        action_delay_ms = 0
-        if isinstance(html_element, Tag):
-            for delay_attr in ("rb-action-delay", "gg-action-delay"):
-                raw_delay = html_element.get(delay_attr)
-                if raw_delay is not None:
-                    try:
-                        action_delay_ms = int(str(raw_delay))
-                    except ValueError:
-                        action_delay_ms = 0
-                    break
+        action_delay_ms = (
+            int(str(html_element.get("rb-action-delay") or 0))
+            if isinstance(html_element, Tag)
+            else 0
+        )
         element_config = (
             ElementConfig(action_delay_ms=action_delay_ms) if action_delay_ms > 0 else None
         )

--- a/getgather/mcp/mcp-tools.yaml
+++ b/getgather/mcp/mcp-tools.yaml
@@ -219,6 +219,18 @@
     - function_name: get_orders_with_pagination
       description: Get the order history from a user's Doordash account with pagination.
 
+
+
+- id: cvs
+  name: CVS MCP
+  custom: true
+  module: cvs
+  tools:
+    - function_name: signin
+      description: Signin to a user's CVS account.
+    - function_name: get_perscription_history
+      description: Get the perscription history from a user's CVS account.
+
 - id: ebay
   name: Ebay MCP
   tools:

--- a/getgather/mcp/patterns/cvs-home-signed.html
+++ b/getgather/mcp/patterns/cvs-home-signed.html
@@ -3,6 +3,6 @@
     <title>Success Sign in</title>
   </head>
   <body>
-    <h1 rb-stop rb-match="cvs-header-component">Sign in to your account</h1>
+    <h1 rb-stop rb-match="div.promoWrap">Sign in to your account</h1>
   </body>
 </html>

--- a/getgather/mcp/patterns/cvs-home-signed.html
+++ b/getgather/mcp/patterns/cvs-home-signed.html
@@ -1,0 +1,8 @@
+<html rb-domain="cvs">
+  <head>
+    <title>Success Sign in</title>
+  </head>
+  <body>
+    <h1 rb-stop rb-match="cvs-header-component">Sign in to your account</h1>
+  </body>
+</html>

--- a/getgather/mcp/patterns/cvs-prescription.html
+++ b/getgather/mcp/patterns/cvs-prescription.html
@@ -1,0 +1,8 @@
+<html rb-domain="cvs">
+  <head>
+    <title>CVS Prescription</title>
+  </head>
+  <body>
+    <h1 rb-stop rb-match="//h1[contains(text(), 'Your prescriptions')]">Your prescriptions</h1>
+  </body>
+</html>

--- a/getgather/mcp/patterns/cvs-register.html
+++ b/getgather/mcp/patterns/cvs-register.html
@@ -1,0 +1,9 @@
+<html rb-domain="cvs">
+  <head>
+    <title>Register to CVS</title>
+  </head>
+  <body>
+    <h2>This email account is not available. Please enter a different email.</h2>
+    <h1 rb-stop rb-error="account_not_found" rb-match="input[data-test-id='firstName']"></h1>
+  </body>
+</html>

--- a/getgather/mcp/patterns/cvs-signin-confirm-submit.html
+++ b/getgather/mcp/patterns/cvs-signin-confirm-submit.html
@@ -1,0 +1,34 @@
+<html rb-domain="cvs">
+  <head>
+    <title>Sign In to CVS</title>
+  </head>
+
+  <body>
+    <div style="text-align: center; margin-bottom: 1rem">
+      <h1
+        rb-match="h1#header2"
+        style="display: inline; font-size: 1rem; font-weight: 600; margin: 0"
+      >
+        Enter the passcode we sent to
+      </h1>
+      <p rb-match="p.subheader" style="display: inline; margin: 0 0 0 0.25em"></p>
+    </div>
+
+    <div rb-optional rb-match="ps-alert-bar div[slot='heading']"></div>
+
+    <p rb-match="label[for='boxOne']"></p>
+
+    <input
+      autofocus
+      name="code"
+      type="text"
+      data-testid="code"
+      rb-match="input#boxOne"
+      placeholder="Code"
+    />
+
+    <button type="submit" data-testid="submit" rb-match="button#verifyButtonID">
+      Confirm code
+    </button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/cvs-signin-confirm-submit.html
+++ b/getgather/mcp/patterns/cvs-signin-confirm-submit.html
@@ -22,7 +22,7 @@
       autofocus
       name="code"
       type="text"
-      data-testid="code"
+      data-testid="otp"
       rb-match="input#boxOne"
       placeholder="Code"
     />

--- a/getgather/mcp/patterns/cvs-signin-confirm-submit.html
+++ b/getgather/mcp/patterns/cvs-signin-confirm-submit.html
@@ -24,10 +24,15 @@
       type="text"
       data-testid="otp"
       rb-match="input#boxOne"
+      gg-submit-enter
       placeholder="Code"
     />
 
-    <button type="submit" data-testid="submit" rb-match="button#verifyButtonID">
+    <button
+      type="submit"
+      data-testid="submit"
+      rb-match="app-verify button#verifyButtonID:not([disabled])"
+    >
       Confirm code
     </button>
   </body>

--- a/getgather/mcp/patterns/cvs-signin-confirm-submit.html
+++ b/getgather/mcp/patterns/cvs-signin-confirm-submit.html
@@ -18,13 +18,7 @@
 
     <p rb-match="label[for='boxOne']"></p>
 
-    <input
-      name="code"
-      type="text"
-      data-testid="otp"
-      rb-match="input#boxOne"
-      placeholder="Code"
-    />
+    <input name="code" type="text" data-testid="otp" rb-match="input#boxOne" placeholder="Code" />
 
     <button
       type="submit"

--- a/getgather/mcp/patterns/cvs-signin-confirm-submit.html
+++ b/getgather/mcp/patterns/cvs-signin-confirm-submit.html
@@ -1,4 +1,4 @@
-<html rb-domain="cvs" gg-trusted-actions>
+<html rb-domain="cvs" rb-trusted-actions>
   <head>
     <title>Sign In to CVS</title>
   </head>

--- a/getgather/mcp/patterns/cvs-signin-confirm-submit.html
+++ b/getgather/mcp/patterns/cvs-signin-confirm-submit.html
@@ -19,7 +19,6 @@
     <p rb-match="label[for='boxOne']"></p>
 
     <input
-      autofocus
       name="code"
       type="text"
       data-testid="otp"

--- a/getgather/mcp/patterns/cvs-signin-confirm-submit.html
+++ b/getgather/mcp/patterns/cvs-signin-confirm-submit.html
@@ -1,4 +1,4 @@
-<html rb-domain="cvs">
+<html rb-domain="cvs" gg-trusted-actions>
   <head>
     <title>Sign In to CVS</title>
   </head>
@@ -24,7 +24,6 @@
       type="text"
       data-testid="otp"
       rb-match="input#boxOne"
-      gg-submit-enter
       placeholder="Code"
     />
 

--- a/getgather/mcp/patterns/cvs-signin-confirm.html
+++ b/getgather/mcp/patterns/cvs-signin-confirm.html
@@ -1,0 +1,49 @@
+<html rb-domain="cvs">
+  <head>
+    <title>Sign In to CVS</title>
+  </head>
+  <body>
+    <h1 rb-match="h1#header1">Just need to confirm</h1>
+    <div class="vertical-radios">
+      <div class="radio-wrapper">
+        <input
+          type="radio"
+          name="signin-option-radio"
+          id="sms-radio"
+          data-testid="signin-method-password"
+          rb-match="input[value='sms']"
+          value="sms-radio"
+          checked
+        />
+        <label for="sms-radio" rb-match="label[for='1pinType0']">SMS</label>
+      </div>
+      <div class="radio-wrapper">
+        <input
+          rb-optional
+          type="radio"
+          name="signin-option-radio"
+          id="phone-code-radio"
+          data-testid="signin-method-phone"
+          rb-match="input#pinType1"
+          value="call-radio"
+        />
+        <label rb-optional for="phone-code-radio" rb-match="label[for='pinType1']">Phone</label>
+      </div>
+      <div class="radio-wrapper">
+        <input
+          rb-optional
+          type="radio"
+          name="signin-option-radio"
+          id="email-radio"
+          data-testid="signin-method-email"
+          rb-match="input#pinType2"
+          value="email-radio"
+        />
+        <label rb-optional for="email-radio" rb-match="label[for=pinType2]">Email</label>
+      </div>
+    </div>
+    <button type="submit" data-testid="submit" rb-match="ps-button > button[type='button']">
+      Send Code
+    </button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/cvs-signin-confirm.html
+++ b/getgather/mcp/patterns/cvs-signin-confirm.html
@@ -1,4 +1,4 @@
-<html rb-domain="cvs">
+<html rb-domain="cvs" rb-trusted-actions>
   <head>
     <title>Sign In to CVS</title>
   </head>

--- a/getgather/mcp/patterns/cvs-signin-dob-confirmation.html
+++ b/getgather/mcp/patterns/cvs-signin-dob-confirmation.html
@@ -1,0 +1,49 @@
+<html rb-domain="cvs" gg-trusted-actions>
+  <head>
+    <title>Sign In to CVS</title>
+  </head>
+
+  <body>
+    <h1
+      rb-match="h1#headerIndex"
+      style="display: inline; font-size: 1rem; font-weight: 600; margin: 0"
+    >
+      Enter date of birth
+    </h1>
+    <p rb-match="div#subHeader" style="display: inline"></p>
+
+    <div rb-optional rb-match="ps-alert-bar div[slot='heading']"></div>
+
+    <input
+      name="month"
+      type="text"
+      data-testid="month"
+      rb-match="input#month"
+      placeholder="Month"
+    />
+
+    <input
+      name="day"
+      type="text"
+      data-testid="day"
+      rb-match="input#day"
+      placeholder="Day"
+    />
+
+    <input
+      name="year"
+      type="text"
+      data-testid="year"
+      rb-match="input#year"
+      placeholder="Year"
+    />
+
+    <button
+      type="submit"
+      data-testid="submit"
+      rb-match="form.form-container button[data-test='continue']"
+    >
+      Verify date of birth
+    </button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/cvs-signin-dob-confirmation.html
+++ b/getgather/mcp/patterns/cvs-signin-dob-confirmation.html
@@ -1,4 +1,4 @@
-<html rb-domain="cvs" gg-trusted-actions>
+<html rb-domain="cvs" rb-trusted-actions>
   <head>
     <title>Sign In to CVS</title>
   </head>

--- a/getgather/mcp/patterns/cvs-signin-dob-confirmation.html
+++ b/getgather/mcp/patterns/cvs-signin-dob-confirmation.html
@@ -22,21 +22,9 @@
       placeholder="Month"
     />
 
-    <input
-      name="day"
-      type="text"
-      data-testid="day"
-      rb-match="input#day"
-      placeholder="Day"
-    />
+    <input name="day" type="text" data-testid="day" rb-match="input#day" placeholder="Day" />
 
-    <input
-      name="year"
-      type="text"
-      data-testid="year"
-      rb-match="input#year"
-      placeholder="Year"
-    />
+    <input name="year" type="text" data-testid="year" rb-match="input#year" placeholder="Year" />
 
     <button
       type="submit"

--- a/getgather/mcp/patterns/cvs-signin.html
+++ b/getgather/mcp/patterns/cvs-signin.html
@@ -1,0 +1,19 @@
+<html rb-domain="cvs">
+  <head>
+    <title>Sign In to CVS</title>
+  </head>
+  <body>
+    <h1>Sign in to your account</h1>
+    <input
+      autofocus
+      name="userid"
+      type="text"
+      data-testid="username"
+      rb-match="input[autocomplete='username']"
+      placeholder="Mobile number or email"
+    />
+    <button type="submit" rb-autoclick rb-match="ps-button.profile-button > button[type='button']">
+      Continue
+    </button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/cvs-signin.html
+++ b/getgather/mcp/patterns/cvs-signin.html
@@ -1,11 +1,10 @@
-<html rb-domain="cvs">
+<html rb-domain="cvs" rb-trusted-actions>
   <head>
     <title>Sign In to CVS</title>
   </head>
   <body>
     <h1>Sign in to your account</h1>
     <input
-      autofocus
       name="userid"
       type="text"
       data-testid="username"

--- a/getgather/mcp/patterns/cvs-signin.html
+++ b/getgather/mcp/patterns/cvs-signin.html
@@ -5,9 +5,9 @@
   <body>
     <h1>Sign in to your account</h1>
     <input
-      name="userid"
+      name="email"
       type="text"
-      data-testid="username"
+      data-testid="email"
       rb-match="input[autocomplete='username']"
       placeholder="Mobile number or email"
     />

--- a/scripts/check_pattern_testids.py
+++ b/scripts/check_pattern_testids.py
@@ -15,12 +15,15 @@ PATTERNS_DIR = Path(__file__).resolve().parent.parent / "getgather" / "mcp" / "p
 
 EXACT_TESTIDS = {
     "answer",  # security question answer
+    "day",  # date-of-birth day field
     "email",  # field that accepts an email address only
+    "month",  # date-of-birth month field
     "otp",  # single verification-code field
     "password",
     "phone",
     "submit",  # the primary submit/continue button of the form
     "username",  # combo identifier field (email or phone/username/member number)
+    "year",  # date-of-birth year field
     "zip-code",
 }
 TESTID_REGEXES = [


### PR DESCRIPTION
## Summary

- Add CVS distillation patterns for username entry, MFA method selection, OTP passcode, DOB verification, and account-not-found handling.
- Add `gg-trusted-actions` on patterns where CVS `ps-*` web components reject untrusted JS fills/clicks. Uses CDP `send_keys` for text inputs and `mouse_click` for submit.
- Fix `rb-action-delay` parsing in dpage (patterns use `rb-action-delay`, not `gg-action-delay`).
- Small batch fill hardening: iframe-aware `findCss` and blur after input.

## Test plan

- [x] CVS sign-in end-to-end on Chrome Fleet
- [x] OTP passcode step fills and submits
- [x] DOB step fills month/day/year and submits
- [x] Other brands still work via normal batch dpage actions


## Result

[mcp_call_result_cvs_get_perscription_history_{}.json](https://github.com/user-attachments/files/30405617/mcp_call_result_cvs_get_perscription_history_.json)



<img width="727" height="608" alt="Screenshot 2026-07-27 at 10 37 25" src="https://github.com/user-attachments/assets/3da5685d-327c-49f7-80cb-399e8badc007" />




<img width="662" height="543" alt="Screenshot 2026-07-27 at 10 37 51" src="https://github.com/user-attachments/assets/764cfe95-0cd2-4310-af24-d67ac6c36d55" />

<img width="701" height="652" alt="Screenshot 2026-07-27 at 11 06 49" src="https://github.com/user-attachments/assets/92e5644a-bf58-4eee-847c-2b34d642277a" />

<img width="620" height="425" alt="Screenshot 2026-07-27 at 13 19 04" src="https://github.com/user-attachments/assets/60dbf7e3-0516-4e94-b02b-e6cfcb7dd9af" />



