### PR TITLE
feat(walgreens): add walgreens_get_purchases MCP tool

### DIFF
--- a/getgather/mcp/mcp-tools.yaml
+++ b/getgather/mcp/mcp-tools.yaml
@@ -559,6 +559,14 @@
     - function_name: get_order_history
       description: Get order history from a user's Walmart account.
 
+- id: walgreens
+  name: Walgreens MCP
+  custom: true
+  module: walgreens
+  tools:
+    - function_name: get_purchases
+      description: Get online order history from a user's Walgreens account.
+
 - id: youtube
   name: YouTube MCP
   custom: true

--- a/getgather/mcp/patterns/walgreens-2fa-choice.html
+++ b/getgather/mcp/patterns/walgreens-2fa-choice.html
@@ -1,0 +1,38 @@
+<html rb-domain="walgreens" rb-priority="2">
+  <head>
+    <title>Walgreens Verification Method</title>
+  </head>
+  <body>
+    <p rb-optional rb-match="//*[contains(normalize-space(.), 'Keeping your account safe')]"></p>
+
+    <div class="vertical-radios">
+      <div class="radio-wrapper">
+        <input
+          type="radio"
+          name="verificationMethod"
+          id="email"
+          data-testid="signin-method-email"
+          rb-match="input#radio-email-0"
+          value="email"
+          checked
+        />
+        <label rb-optional for="email" rb-match="label[for=radio-email-0]">Email</label>
+      </div>
+      <div class="radio-wrapper">
+        <input
+          rb-optional
+          type="radio"
+          name="verificationMethod"
+          id="phone"
+          data-testid="signin-method-sms"
+          rb-match="input#radio-phone-0"
+          value="phone"
+        />
+        <label rb-optional for="phone" rb-match="label[for=radio-phone-0]">Text message</label>
+      </div>
+    </div>
+    <button type="submit" data-testid="submit" rb-match="button#btn_send_verify_code">
+      Continue
+    </button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walgreens-2fa-choice.html
+++ b/getgather/mcp/patterns/walgreens-2fa-choice.html
@@ -3,8 +3,6 @@
     <title>Walgreens Verification Method</title>
   </head>
   <body>
-    <p rb-optional rb-match="//*[contains(normalize-space(.), 'Keeping your account safe')]"></p>
-
     <div class="vertical-radios">
       <div class="radio-wrapper">
         <input

--- a/getgather/mcp/patterns/walgreens-2fa-code.html
+++ b/getgather/mcp/patterns/walgreens-2fa-code.html
@@ -1,0 +1,22 @@
+<html rb-domain="walgreens" rb-priority="1">
+  <head>
+    <title>Walgreens Verification Code</title>
+  </head>
+  <body>
+    <p rb-optional rb-match="//*[contains(normalize-space(.), 'Enter verification code')]"></p>
+    <p rb-optional rb-match="div.alert__red[role='alert'] #error_msg"></p>
+
+    <input
+      autofocus
+      name="otp"
+      type="text"
+      inputmode="numeric"
+      placeholder="Enter 6-digit verification code"
+      data-testid="otp"
+      rb-match="input#auth-code"
+    />
+    <button type="submit" data-testid="submit" rb-match="button#validate_security_answer">
+      Verify
+    </button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walgreens-2fa-code.html
+++ b/getgather/mcp/patterns/walgreens-2fa-code.html
@@ -3,7 +3,6 @@
     <title>Walgreens Verification Code</title>
   </head>
   <body>
-    <p rb-optional rb-match="//*[contains(normalize-space(.), 'Enter verification code')]"></p>
     <p rb-optional rb-match="div.alert__red[role='alert'] #error_msg"></p>
 
     <input

--- a/getgather/mcp/patterns/walgreens-pre-signin.html
+++ b/getgather/mcp/patterns/walgreens-pre-signin.html
@@ -1,0 +1,14 @@
+<html rb-domain="walgreens">
+  <head>
+    <title>Walgreens Order Lookup</title>
+  </head>
+  <body>
+    <!--
+      Signed-out visits to /orderhistory/orders-ui land on the guest "Look up your
+      order details" page (order-number lookup + a "Sign in" button) rather than
+      redirecting to the login form. Auto-click the contextual Sign in button to
+      advance to login.jsp, where walgreens-signin.html takes over.
+    -->
+    <div rb-autoclick rb-match="button#lookup-signin-btn"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walgreens-purchase.html
+++ b/getgather/mcp/patterns/walgreens-purchase.html
@@ -1,0 +1,8 @@
+<html rb-domain="walgreens" rb-priority="-3">
+  <head>
+    <title>Walgreens Purchases</title>
+  </head>
+  <body>
+    <div rb-match="select#wag-purchase-history-filter-by-select-dropdown" rb-stop></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walgreens-signin.html
+++ b/getgather/mcp/patterns/walgreens-signin.html
@@ -1,0 +1,25 @@
+<html rb-domain="walgreens">
+  <head>
+    <title>Walgreens Sign In</title>
+  </head>
+  <body>
+    <p rb-optional rb-match="div.alert__red[role='alert'] #error_msg"></p>
+
+    <input
+      autofocus
+      name="username"
+      type="text"
+      placeholder="Email or username"
+      data-testid="username"
+      rb-match="input#user_name"
+    />
+    <input
+      name="password"
+      type="password"
+      placeholder="Password"
+      data-testid="password"
+      rb-match="input#user_password"
+    />
+    <button type="submit" data-testid="submit" rb-match="button#submit_btn">Sign in</button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/walgreens-signin.html
+++ b/getgather/mcp/patterns/walgreens-signin.html
@@ -7,7 +7,7 @@
 
     <input
       autofocus
-      name="username"
+      name="email"
       type="text"
       placeholder="Email or username"
       data-testid="username"

--- a/getgather/mcp/walgreens.py
+++ b/getgather/mcp/walgreens.py
@@ -1,0 +1,162 @@
+from typing import Any, cast
+
+import zendriver as zd
+from loguru import logger
+
+from getgather.mcp.dpage import remote_zen_dpage_with_action
+from getgather.mcp.registry import MCPTool
+
+walgreens_mcp = MCPTool.registry["walgreens"]
+
+ORDERS_UI_URL = "https://www.walgreens.com/orderhistory/orders-ui"
+SEARCH_URL = "https://www.walgreens.com/orderhistory/v1/orders/search"
+
+# Walgreens' purchase-history page requests up to 100 orders per page and exposes
+# order history in 6-month buckets going back ~2 years. The /orders/search backend
+# accepts an arbitrary date window, so a single 2-year window covers full history.
+PAGE_SIZE = 100
+YEARS_BACK = 2
+
+
+def build_purchases_response(data: dict[str, Any], page_number: int) -> dict[str, Any]:
+    """Turn a successful ``/orders/search`` JSON body into the tool's response.
+
+    ``orders`` are preserved as raw Walgreens objects (no normalization). The
+    Walgreens response has no total-count field, so ``total_pages`` is DERIVED and
+    is ``None`` whenever it cannot be known:
+      - empty page 1        -> 0 (the account has no orders)
+      - partial page (<size)-> this is the last page, so total_pages = page_number
+      - full page           -> more may exist, total unknown -> None
+      - empty page > 1       -> past the end / indeterminate -> None
+    """
+    orders_raw = data.get("orders", [])
+    orders: list[dict[str, Any]]
+    if isinstance(orders_raw, list):
+        orders = [item for item in cast(list[Any], orders_raw) if isinstance(item, dict)]
+    else:
+        orders = []
+
+    count = len(orders)
+    total_pages: int | None
+    if count == 0:
+        total_pages = 0 if page_number == 1 else None
+    elif count < PAGE_SIZE:
+        total_pages = page_number
+    else:
+        total_pages = None
+
+    return {
+        "walgreens_purchases": orders,
+        "pagination": {
+            "current_page": page_number,
+            "total_pages": total_pages,
+            "page_size": PAGE_SIZE,
+        },
+    }
+
+
+@walgreens_mcp.tool
+async def get_purchases(page_number: int = 1) -> dict[str, Any]:
+    """Get online order history from a user's Walgreens account.
+
+    Args:
+        page_number: Page to fetch (1-indexed). Default 1.
+
+    Returns a dict with ``walgreens_purchases`` (the raw Walgreens order objects,
+    unmodified) and a ``pagination`` object. Note: the Walgreens
+    ``/orderhistory/v1/orders/search`` response carries no total-count field, so
+    ``total_pages`` is DERIVED and is ``None`` whenever it cannot be known: 0 for an
+    empty first page, the current page number when a short (< page size) page is
+    returned (last page), and ``None`` when a full page is returned (more may exist)
+    or an empty page beyond the first is requested. ``page_size`` is the request
+    size (100).
+    """
+    if page_number < 1:
+        raise ValueError(f"page_number must be >= 1, got {page_number}")
+
+    async def action(page: zd.Tab, browser: zd.Browser) -> dict[str, Any]:
+        logger.info(f"Walgreens: signed in, fetching order history (page {page_number})")
+
+        # Walgreens uses the Spring Security CSRF meta-tag pattern: the token lives
+        # in <meta name="_csrf"> and the header name in <meta name="_csrfHeader">.
+        # The XSRF-TOKEN cookie itself is httpOnly, so it must be read from the meta
+        # tag. The request is issued from the page context with credentials so the
+        # session cookies are attached.
+        js_code = f"""
+            (async () => {{
+                const token = document.querySelector('meta[name=_csrf]')?.content;
+                const header = document.querySelector('meta[name=_csrfHeader]')?.content
+                    || 'X-XSRF-TOKEN';
+                if (!token) {{
+                    return {{ tokenPresent: false }};
+                }}
+                const now = new Date();
+                const pad = n => String(n).padStart(2, '0');
+                const day = pad(now.getDate());
+                const month = pad(now.getMonth() + 1);
+                const year = now.getFullYear();
+                const body = {{
+                    filter: {{
+                        type: ['ALL'],
+                        fromDate: {{ day, month, year: year - {YEARS_BACK} }},
+                        toDate: {{ day, month, year }},
+                        filterType: 'ALL',
+                        tab: 'ONLINE',
+                        p: {page_number},
+                        s: {PAGE_SIZE},
+                        sortColumn: 'purchaseDate',
+                        sortType: 'DESC',
+                    }},
+                }};
+                const res = await fetch('{SEARCH_URL}', {{
+                    method: 'POST',
+                    credentials: 'include',
+                    headers: {{
+                        'Accept': 'application/json, text/plain, */*',
+                        'Content-Type': 'application/json; charset=UTF-8',
+                        [header]: token,
+                    }},
+                    body: JSON.stringify(body),
+                }});
+                const text = await res.text();
+                let json = null;
+                try {{ json = JSON.parse(text); }} catch (e) {{}}
+                return {{
+                    tokenPresent: true,
+                    status: res.status,
+                    json: json,
+                    isJson: json !== null,
+                    textHead: json === null ? text.slice(0, 200) : null,
+                }};
+            }})()
+        """
+        result = cast(dict[str, Any], await page.evaluate(js_code, await_promise=True))
+
+        if not result.get("tokenPresent", False):
+            raise Exception("Walgreens: CSRF token missing — user is not signed in")
+
+        status = int(result.get("status", 0))
+        if status in (401, 403):
+            raise Exception(f"Walgreens: order search returned {status} — user is not signed in")
+
+        if not result.get("isJson", False):
+            # A non-JSON body (e.g. an Akamai HTML challenge) indicates bot detection
+            # or an unexpected error rather than a valid empty result.
+            head = result.get("textHead") or ""
+            raise Exception(
+                f"Walgreens: order search returned non-JSON (status {status}); "
+                f"possible bot-detection/challenge. Body starts: {head!r}"
+            )
+
+        data = cast(dict[str, Any], result.get("json") or {})
+        call_status = data.get("callStatus")
+        if call_status != "SUCCESS":
+            messages = data.get("messages")
+            raise Exception(
+                f"Walgreens: order search callStatus={call_status!r} (status {status}); "
+                f"messages={messages!r}"
+            )
+
+        return build_purchases_response(data, page_number)
+
+    return await remote_zen_dpage_with_action(ORDERS_UI_URL, action=action)

--- a/tests/test_walgreens.py
+++ b/tests/test_walgreens.py
@@ -1,0 +1,85 @@
+"""Unit tests for the Walgreens purchase-history response builder.
+
+These use sanitized, synthetic fixtures derived from the observed
+``/orderhistory/v1/orders/search`` response shape (no real personal data). They
+exercise the pure pagination/parsing logic without a live browser or server.
+"""
+
+from typing import Any
+
+# Importing declarative_mcp runs create_declarative_mcp_tools() at import time,
+# registering all brands (incl. walgreens) and importing the walgreens custom
+# module — which must happen before `from getgather.mcp.walgreens import ...`
+# resolves, since that module looks up MCPTool.registry["walgreens"] at import.
+from getgather.mcp import declarative_mcp
+from getgather.mcp.walgreens import PAGE_SIZE, build_purchases_response
+
+assert "walgreens" in declarative_mcp.MCPTool.registry
+
+
+def _empty_response() -> dict[str, Any]:
+    """The exact shape observed for an authenticated account with no orders."""
+    return {
+        "filter": {"filterType": "ALL", "tab": "ONLINE", "p": 1, "s": PAGE_SIZE},
+        "failedSvcs": [],
+        "callStatus": "SUCCESS",
+        "messages": [],
+        "orders": [],
+    }
+
+
+def _order(order_id: str) -> dict[str, Any]:
+    """A synthetic raw order object (arbitrary fields; not real data)."""
+    return {
+        "orderId": order_id,
+        "orderStatus": "Delivered",
+        "purchaseDate": "2026-01-15",
+        "channel": "ONLINE",
+        "orderTotal": {"amount": "12.34", "currency": "USD"},
+        "items": [{"description": "Synthetic Item", "quantity": 1}],
+    }
+
+
+def test_empty_first_page_is_success_not_error():
+    result = build_purchases_response(_empty_response(), page_number=1)
+    assert result["walgreens_purchases"] == []
+    assert result["pagination"] == {"current_page": 1, "total_pages": 0, "page_size": PAGE_SIZE}
+
+
+def test_empty_page_beyond_first_has_unknown_total():
+    result = build_purchases_response(_empty_response(), page_number=3)
+    assert result["walgreens_purchases"] == []
+    assert result["pagination"] == {"current_page": 3, "total_pages": None, "page_size": PAGE_SIZE}
+
+
+def test_partial_page_is_last_page():
+    data = {"callStatus": "SUCCESS", "orders": [_order("A1"), _order("A2")]}
+    result = build_purchases_response(data, page_number=1)
+    assert len(result["walgreens_purchases"]) == 2
+    assert result["pagination"] == {"current_page": 1, "total_pages": 1, "page_size": PAGE_SIZE}
+
+
+def test_partial_page_two_reports_that_page_as_total():
+    data = {"callStatus": "SUCCESS", "orders": [_order(f"B{i}") for i in range(30)]}
+    result = build_purchases_response(data, page_number=2)
+    assert result["pagination"] == {"current_page": 2, "total_pages": 2, "page_size": PAGE_SIZE}
+
+
+def test_full_page_total_is_unknown():
+    data = {"callStatus": "SUCCESS", "orders": [_order(f"C{i}") for i in range(PAGE_SIZE)]}
+    result = build_purchases_response(data, page_number=1)
+    assert len(result["walgreens_purchases"]) == PAGE_SIZE
+    assert result["pagination"] == {"current_page": 1, "total_pages": None, "page_size": PAGE_SIZE}
+
+
+def test_raw_order_objects_are_preserved_unmodified():
+    order = _order("D1")
+    order["someVendorField"] = {"nested": [1, 2, 3]}
+    result = build_purchases_response({"orders": [order]}, page_number=1)
+    assert result["walgreens_purchases"][0] == order  # no fields dropped or renamed
+
+
+def test_non_list_orders_yields_empty():
+    result = build_purchases_response({"orders": None}, page_number=1)
+    assert result["walgreens_purchases"] == []
+    assert result["pagination"]["total_pages"] == 0


### PR DESCRIPTION
https://github.com/corelens-engineering/demos/issues/1163

## Summary

Adds Walgreens support as a MCP brand exposing `walgreens_get_purchases`.

## Tests

- [x] Wrong email and password

https://github.com/user-attachments/assets/2400102c-d7c4-4256-8014-010850b34ced

- [x] 2FA via phone wrong code 

https://github.com/user-attachments/assets/3ba9722f-b7ce-4411-98d8-e6c3ff1f6a7c

- [x] 2FA via Email wrong code

https://github.com/user-attachments/assets/ae8b97a9-e26b-45ff-a40e-7bc3d6fcd75c

- [x] Success login

https://github.com/user-attachments/assets/d49e6486-903f-4e16-a253-3792c9819512

- [x] `walgreens_get_purchases` returns the authenticated empty result

<img width="1663" height="203" alt="image" src="https://github.com/user-attachments/assets/974e07f3-c171-4c90-9091-249adf4cb1d4" />


## Note (for future investigation)

Sign-in / 2FA button clicks through the automated dpage flow are **flaky**: the click sometimes surfaces Walgreens' *"No internet connection. Please check your network settings and try again."* and the step doesn't advance. Clicking the same button **manually via noVNC works reliably**.

Root cause not fully pinned down yet. What we know so far:

- **Possibly bot detection** — not confirmed.
- **Akamai already checked — likely NOT the cause.** The failing requests showed no `403` and no bot-challenge.
- CDP network capture showed proxy **tunnel errors** (`net::ERR_TUNNEL_CONNECTION_FAILED` on companion requests, `net::ERR_ABORTED` / `canceled=True` on the login POST). But **manual action still works reliably even when those appear**, so the flaky proxy alone doesn't explain it.
- The automated click is a synthetic JS `element.click()` (no real pointer/mouse events); a real noVNC pointer click succeeds — so the trigger may be the synthetic click and/or fill→submit timing rather than a server-side block. A hover + real CDP `mouse_click` is worth trying.