### PR TITLE
fix(pages): stop false "Browser not found!" 404 on transient CDP preflight

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -214,7 +214,7 @@ def _setup_cdp_url(browser_id: str) -> str:
 
 
 async def get_remote_browser_cdp_url(browser_id: str) -> str:
-    await call_chromefleet_api("GET", browser_id, timeout=2.0, retries=0)
+    await call_chromefleet_api("GET", browser_id, timeout=10.0)  # retries=3 default
     return _setup_cdp_url(browser_id)
 
 

--- a/getgather/cdp_client.py
+++ b/getgather/cdp_client.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 from typing import Any, cast
 
+import httpx
 import websockets
 import websockets.asyncio.client
 
@@ -22,10 +23,22 @@ class PageAttachError(CDPError):
     """Raised when attaching to a page target fails."""
 
 
+class BrowserNotFoundError(CDPError):
+    """Raised when the browser genuinely does not exist in Chrome Fleet."""
+
+
 async def open_cdp(browser_id: str) -> "CDPClient":
-    """Locate the browser and return a connected CDP client. Raises if the
-    browser is not found or the websocket cannot be opened."""
-    cdp_websocket_url = await get_remote_browser_cdp_url(browser_id)
+    """Locate the browser and return a connected CDP client. Raises
+    BrowserNotFoundError if the browser genuinely does not exist, or CDPError
+    if resolving/connecting fails transiently."""
+    try:
+        cdp_websocket_url = await get_remote_browser_cdp_url(browser_id)
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise BrowserNotFoundError(f"Browser {browser_id} not found") from e
+        raise CDPError(f"ChromeFleet error resolving {browser_id}: {e}") from e
+    except Exception as e:
+        raise CDPError(f"Failed to resolve browser {browser_id}: {e}") from e
     ws = await websockets.connect(
         cdp_websocket_url,
         open_timeout=settings.CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS,

--- a/getgather/pages_api_router.py
+++ b/getgather/pages_api_router.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 from getgather.browser import find_browser_tab, get_remote_browser
 from getgather.browsers.router import strip_browser_id_from_target_id
-from getgather.cdp_client import PageNotFoundError, open_cdp
+from getgather.cdp_client import BrowserNotFoundError, CDPError, PageNotFoundError, open_cdp
 from getgather.mcp.dpage import distill_post_loop
 from getgather.zen_distill import (
     convert,
@@ -24,8 +24,12 @@ router = APIRouter()
 async def list_pages(browser_id: str) -> JSONResponse:
     try:
         client = await open_cdp(browser_id)
-    except Exception:
+    except BrowserNotFoundError:
         raise HTTPException(status_code=404, detail=f"Browser {browser_id} not found!")
+    except CDPError as e:
+        raise HTTPException(
+            status_code=503, detail=f"Browser {browser_id} temporarily unavailable: {e}"
+        )
 
     try:
         result = await client.send("Target.getTargets")
@@ -45,8 +49,12 @@ async def get_page_html(browser_id: str, page_id: str) -> HTMLResponse:
     page_id = strip_browser_id_from_target_id(page_id)
     try:
         client = await open_cdp(browser_id)
-    except Exception:
+    except BrowserNotFoundError:
         raise HTTPException(status_code=404, detail=f"Browser {browser_id} not found!")
+    except CDPError as e:
+        raise HTTPException(
+            status_code=503, detail=f"Browser {browser_id} temporarily unavailable: {e}"
+        )
 
     try:
         try:
@@ -75,8 +83,12 @@ async def get_page_distilled(browser_id: str, page_id: str) -> JSONResponse | HT
     page_id = strip_browser_id_from_target_id(page_id)
     try:
         client = await open_cdp(browser_id)
-    except Exception:
+    except BrowserNotFoundError:
         raise HTTPException(status_code=404, detail=f"Browser {browser_id} not found!")
+    except CDPError as e:
+        raise HTTPException(
+            status_code=503, detail=f"Browser {browser_id} temporarily unavailable: {e}"
+        )
 
     try:
         try:
@@ -162,8 +174,12 @@ async def navigate_page(
     page_id = strip_browser_id_from_target_id(page_id)
     try:
         client = await open_cdp(browser_id)
-    except Exception:
+    except BrowserNotFoundError:
         raise HTTPException(status_code=404, detail=f"Browser {browser_id} not found!")
+    except CDPError as e:
+        raise HTTPException(
+            status_code=503, detail=f"Browser {browser_id} temporarily unavailable: {e}"
+        )
 
     try:
         try:


### PR DESCRIPTION
## Problem

`POST/GET /api/v1/browsers/{browser_id}/pages/{page_id}/navigate` intermittently returned `{"detail": "Browser {browser_id} not found!"}` on the first hit, then `{"status": "success"}` on retry. The browser existed the whole time.

## Root cause

Server is stateless — every request re-discovers the browser via a single preflight `GET /api/v1/browsers/{id}` to Chrome Fleet in `get_remote_browser_cdp_url` (`browser.py`), called with **`timeout=2.0, retries=0`**. Any transient failure (browser still booting/registering, fleet slow >2s, 5xx, connect blip) raised. All four page endpoints wrapped `open_cdp` in a blanket `except Exception` that flattened **every** failure into a `404 "Browser not found!"`. Retry → browser warm → success.

Contrast: the websocket route `/cdp/{browser_id}` handles this correctly (existence check, auto-launch, 10× retry). The HTTP page path had none of that.

## Fix

- **`browser.py`** — preflight now `timeout=10.0, retries=3` (default). `RetryTransport` retries `429/5xx` + connection errors with backoff; a genuine `404` is **not** forcelisted, so a truly-missing browser still fails fast.
- **`cdp_client.py`** — add `BrowserNotFoundError`; `open_cdp` classifies the preflight failure (`404` → `BrowserNotFoundError`, else → `CDPError`).
- **`pages_api_router.py`** — all 4 endpoints (`list_pages`, `get_page_html`, `get_page_distilled`, `navigate_page`) map `BrowserNotFoundError` → **404**, `CDPError` → **503** (retryable) instead of a lying 404.

Net: transient hiccup auto-retries; if still failing → 503 (retryable), not a false 404. Genuine missing browser → real 404.

## Test

- `make typecheck` (pyright strict + ty), `make check-backend-format`, `make test` — all green.
- Runtime not exercised here (needs live `CHROMEFLEET_URL` + server). To verify: `make dev`, then `curl -i .../browsers/DOES_NOT_EXIST/pages/x/navigate?url=https://example.com` → fast 404; real browser → `{"status":"success"}`.