### PR TITLE
feat(browserbase): live view for Browserbase

### DIFF
--- a/getgather/browsers/browserbase_browsers.py
+++ b/getgather/browsers/browserbase_browsers.py
@@ -394,10 +394,6 @@ class BrowserbaseBackend:
         return None
 
     async def get_live_view_url(self, browser_id: str) -> str | None:
-        # Browserbase has no VNC port; it serves its own hosted debugger UI instead. `debug`
-        # returns a fullscreen iframe-able URL for the whole browser (as opposed to `pages[].
-        # debuggerFullscreenUrl`, which is per-tab) — good enough for the single-page flows this
-        # router drives.
         if browser_id not in self._sessions:
             return None
         headers = {"x-bb-api-key": _api_key()}

--- a/getgather/browsers/browserbase_browsers.py
+++ b/getgather/browsers/browserbase_browsers.py
@@ -394,4 +394,22 @@ class BrowserbaseBackend:
         return None
 
     async def get_live_view_url(self, browser_id: str) -> str | None:
-        return None
+        # Browserbase has no VNC port; it serves its own hosted debugger UI instead. `debug`
+        # returns a fullscreen iframe-able URL for the whole browser (as opposed to `pages[].
+        # debuggerFullscreenUrl`, which is per-tab) — good enough for the single-page flows this
+        # router drives.
+        if browser_id not in self._sessions:
+            return None
+        headers = {"x-bb-api-key": _api_key()}
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            try:
+                response = await client.get(
+                    f"{BROWSERBASE_API_URL}/{browser_id}/debug", headers=headers
+                )
+                response.raise_for_status()
+            except httpx.HTTPError as e:
+                logger.warning(f"Browserbase live view lookup failed for {browser_id}: {e}")
+                return None
+        data: dict[str, Any] = response.json()
+        url: Any = data.get("debuggerFullscreenUrl")  # pyright: ignore[reportUnknownMemberType]
+        return url if isinstance(url, str) else None


### PR DESCRIPTION
## Summary
- Implements `BrowserbaseBackend.get_live_view_url()` using Browserbase's `GET /v1/sessions/{id}/debug` API, which returns `debuggerFullscreenUrl` — their own hosted devtools UI for a session.

## Tests

https://github.com/user-attachments/assets/d01f9320-748c-41de-b9d1-09f09a51598c


