### PR TITLE
feat(target): add pattern for invalid OTP code state

### DIFF
--- a/getgather/mcp/patterns/target-signin-otp-invalid.html
+++ b/getgather/mcp/patterns/target-signin-otp-invalid.html
@@ -1,0 +1,21 @@
+<html rb-domain="target">
+  <head>
+    <title>Target Sign In - OTP Invalid</title>
+  </head>
+  <body>
+    <div
+      rb-match="//div[contains(@class, 'styles_content__') and contains(text(), 'That code is invalid. Please try again.')]"
+    >
+      That code is invalid. Please try again.
+    </div>
+    <input
+      autofocus
+      name="otp"
+      type="tel"
+      placeholder="Enter your code"
+      data-testid="otp"
+      rb-match="input.styles_input__8Dfzg"
+    />
+    <button type="submit" data-testid="submit" rb-match="button#verify">Verify</button>
+  </body>
+</html>

--- a/getgather/mcp/patterns/target-survey-invite-dismiss.html
+++ b/getgather/mcp/patterns/target-survey-invite-dismiss.html
@@ -1,0 +1,8 @@
+<html rb-domain="target" rb-priority="1">
+  <head>
+    <title>Target Survey Invite Popup Dismiss</title>
+  </head>
+  <body>
+    <div rb-autoclick rb-match="button#kplDeclineButton"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/target-view-purchases-link.html
+++ b/getgather/mcp/patterns/target-view-purchases-link.html
@@ -1,8 +1,0 @@
-<html rb-domain="target" rb-priority="-2">
-  <head>
-    <title>Target View All Purchases</title>
-  </head>
-  <body>
-    <div rb-autoclick rb-match="a[aria-label='View all your purchases']"></div>
-  </body>
-</html>

--- a/getgather/mcp/patterns/target-view-purchases-link.html
+++ b/getgather/mcp/patterns/target-view-purchases-link.html
@@ -1,4 +1,4 @@
-<html rb-domain="target" rb-priority="1">
+<html rb-domain="target" rb-priority="-2">
   <head>
     <title>Target View All Purchases</title>
   </head>

--- a/getgather/mcp/patterns/target-view-purchases-link.html
+++ b/getgather/mcp/patterns/target-view-purchases-link.html
@@ -1,0 +1,8 @@
+<html rb-domain="target" rb-priority="1">
+  <head>
+    <title>Target View All Purchases</title>
+  </head>
+  <body>
+    <div rb-autoclick rb-match="a[aria-label='View all your purchases']"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- **`target-signin-otp-invalid.html`** — New: distillation pattern matching Target's "That code is invalid. Please try again." error state, with the same code input/verify button as the existing OTP pattern so the distill loop re-fills and resubmits on retry.
- **`target-survey-invite-dismiss.html`** — New: auto-dismiss pattern for Target's Kampyle-style feedback-invite popup ("Got a minute?"), auto-clicking the decline button.