### PR TITLE
feat(dpage): add JSON sign-in step endpoint alongside the HTML dpage

### DIFF
--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -5,7 +5,7 @@ import re
 import socket
 import urllib.parse
 from dataclasses import dataclass
-from typing import Any, Self
+from typing import Any, Literal, Self
 
 import zendriver as zd
 from bs4 import BeautifulSoup, Tag
@@ -30,6 +30,7 @@ from getgather.browser import (
     zen_navigate_with_retry,
 )
 from getgather.config import settings
+from getgather.mcp.form_schema import SigninState, SigninSubmission, parse_blocks
 from getgather.mcp.html_renderer import DEFAULT_TITLE, render_form
 from getgather.zen_distill import (
     Match,
@@ -52,6 +53,12 @@ router = APIRouter(prefix="/dpage", tags=["dpage"])
 
 # Max seconds for the distillation polling loop in zen_post_dpage (per HTTP request).
 DEFAULT_DPAGE_POST_POLL_TIMEOUT = 60
+
+# Reading the current step submits nothing and re-distilling is idempotent, so a read can poll
+# briefly and let the client retry instead of occupying a request slot for a full minute. Each
+# in-flight request holds one of the machine's connection slots (fly.toml sets soft_limit = 20),
+# which is the real ceiling on concurrent sign-ins.
+DEFAULT_DPAGE_READ_POLL_TIMEOUT = 5
 
 FRIENDLY_CHARS: str = "23456789abcdefghijkmnpqrstuvwxyz"
 
@@ -278,8 +285,64 @@ async def get_dpage(id: str | None = None) -> HTMLResponse:
 FINISHED_MSG = "Finished! You can close this window now."
 
 
-@router.post("/{id}", response_class=HTMLResponse)
-async def post_dpage(id: str, request: Request) -> HTMLResponse:
+@dataclass
+class LoopOutcome:
+    """What one `distill_post_loop` pass concluded, before it is projected to HTML or JSON.
+
+    Keeping the loop's result structural is what lets the same engine serve the browser-facing
+    dpage and the JSON API without either one re-parsing the other's output.
+    """
+
+    kind: Literal["need_input", "finished", "timeout"]
+    title: str = DEFAULT_TITLE
+    document: BeautifulSoup | None = None
+    error_code: str | None = None
+
+
+def render_outcome(outcome: LoopOutcome, action: str) -> HTMLResponse:
+    """Project an outcome to the browser-facing dpage, preserving pre-JSON behaviour exactly."""
+    if outcome.kind == "timeout":
+        raise HTTPException(status_code=503, detail="Timeout reached")
+
+    options: dict[str, str] = {"title": outcome.title, "action": action}
+
+    if outcome.kind == "finished":
+        if outcome.error_code is not None:
+            options["error_code"] = outcome.error_code
+        return HTMLResponse(render(FINISHED_MSG, options))
+
+    body = outcome.document.find("body") if outcome.document is not None else None
+    return HTMLResponse(render(str(body), options))
+
+
+def signin_state(outcome: LoopOutcome, signin_id: str) -> SigninState:
+    """Project an outcome to JSON.
+
+    Note the HTML path treats an `rb-error` pattern as merely "finished" so that polling stops;
+    here that splits into ERROR vs SUCCESS on the presence of an error code, which is the
+    distinction consumers currently rebuild by keyword-matching the rendered page.
+    """
+    if outcome.kind == "timeout":
+        # Deliberately not a 503: a JSON client cannot tell our 503 apart from a proxy killing
+        # the connection.
+        return SigninState(status="TIMEOUT", signin_id=signin_id, title=outcome.title)
+
+    if outcome.kind == "finished":
+        return SigninState(
+            status="ERROR" if outcome.error_code is not None else "SUCCESS",
+            signin_id=signin_id,
+            title=outcome.title,
+            error_code=outcome.error_code,
+        )
+
+    blocks = parse_blocks(outcome.document) if outcome.document is not None else []
+    return SigninState(
+        status="NEED_SIGNIN", signin_id=signin_id, title=outcome.title, blocks=blocks
+    )
+
+
+async def _resolve_signin_page(request: Request) -> zd.Tab:
+    """Resolve the remote tab a sign-in id points at."""
     signin_id = SignInId.from_request(request)
     if signin_id is None:
         raise HTTPException(status_code=400, detail="Missing or invalid sign-in id")
@@ -292,7 +355,33 @@ async def post_dpage(id: str, request: Request) -> HTMLResponse:
     if page is None:
         raise HTTPException(status_code=404, detail="Page not found")
 
+    return page
+
+
+@router.post("/{id}", response_class=HTMLResponse)
+async def post_dpage(id: str, request: Request) -> HTMLResponse:
+    page = await _resolve_signin_page(request)
     return await zen_post_dpage(page, id, request)
+
+
+# Unlike GET /dpage/{id}, which only serves an auto-submit trampoline because a browser cannot
+# redirect GET to POST, this returns the current step directly. It submits nothing, so it polls
+# briefly and returns TIMEOUT for the client to retry rather than holding a slot for a minute.
+@router.get("/{id}/json")
+async def get_dpage_json(id: str, request: Request) -> SigninState:
+    page = await _resolve_signin_page(request)
+    outcome = await distill_post_loop(page, id, {}, timeout=DEFAULT_DPAGE_READ_POLL_TIMEOUT)
+    return signin_state(outcome, id)
+
+
+@router.post("/{id}/json")
+async def post_dpage_json(
+    id: str, request: Request, submission: SigninSubmission | None = None
+) -> SigninState:
+    page = await _resolve_signin_page(request)
+    body = submission if submission is not None else SigninSubmission()
+    outcome = await distill_post_loop(page, id, dict(body.values), button=body.button)
+    return signin_state(outcome, id)
 
 
 def is_local_address(host: str) -> bool:
@@ -325,10 +414,15 @@ async def distill_post_loop(
     page: zd.Tab,
     id: str,
     fields: dict[str, str],
-    action: str,
+    button: str | None = None,
     patterns: list[Pattern] | None = None,
     timeout: int = DEFAULT_DPAGE_POST_POLL_TIMEOUT,
-) -> HTMLResponse:
+) -> LoopOutcome:
+    """Drive the distillation/autofill loop one HTTP request's worth.
+
+    `button` picks a choice branch (`<button name="button" value="sms">`) and is kept out of
+    `fields` so that a site input whose name happens to be `button` cannot be mistaken for it.
+    """
     if patterns is None:
         path = os.path.join(os.path.dirname(__file__), "patterns", "**/*.html")
         patterns = load_distillation_patterns(path)
@@ -372,7 +466,6 @@ async def distill_post_loop(
 
         title_element = BeautifulSoup(distilled, "html.parser").find("title")
         title = title_element.get_text() if title_element is not None else DEFAULT_TITLE
-        options = {"title": title, "action": action}
         inputs = document.find_all("input")
         pending_actions: list[dict[str, str]] = []
         html_element = document.find("html")
@@ -394,7 +487,7 @@ async def distill_post_loop(
             max_reached = iteration == max - 1
             if max_reached and has_inputs:
                 logger.info("Still the same after timeout and need inputs, render the page...")
-                return HTMLResponse(render(str(document.find("body")), options))
+                return LoopOutcome(kind="need_input", title=title, document=document)
             continue
 
         current = match
@@ -407,17 +500,16 @@ async def distill_post_loop(
                 logger.info(
                     f"Distillation reported page error pattern; sign-in still marked complete for polling. Pattern name: {match.name}"
                 )
-                options["error_code"] = error
 
-            return HTMLResponse(render(FINISHED_MSG, options))
+            return LoopOutcome(kind="finished", title=title, error_code=error)
 
         names: list[str] = []
 
-        if fields.get("button"):
-            button = document.find("button", value=str(fields.get("button")))
-            if button:
-                logger.info(f"Clicking button button[value={fields.get('button')}]")
-                await autoclick(page, distilled, f"button[value={fields.get('button')}]")
+        if button:
+            button_element = document.find("button", value=button)
+            if button_element:
+                logger.info(f"Clicking button button[value={button}]")
+                await autoclick(page, distilled, f"button[value={button}]")
                 continue
 
         processed_radio_groups: set[str] = set()
@@ -605,7 +697,7 @@ async def distill_post_loop(
                 should_submit = True
             else:
                 logger.warning("Not all form fields are filled")
-                return HTMLResponse(render(str(document.find("body")), options))
+                return LoopOutcome(kind="need_input", title=title, document=document)
 
         if len(pending_actions) > 0:
             action_results = await page_batch_actions(page, pending_actions)
@@ -659,13 +751,16 @@ async def distill_post_loop(
         hostname=hostname_attr or "unknown",
         iteration=max,
     )
-    raise HTTPException(status_code=503, detail="Timeout reached")
+    return LoopOutcome(kind="timeout")
 
 
 async def zen_post_dpage(page: zd.Tab, id: str, request: Request) -> HTMLResponse:
     form_data = await request.form()
     fields: dict[str, str] = {k: str(v) for k, v in form_data.items()}
-    return await distill_post_loop(page, id, fields, f"/dpage/{id}")
+    # The HTML form has one flat namespace, so `button` still arrives alongside the fields.
+    button = fields.pop("button", None)
+    outcome = await distill_post_loop(page, id, fields, button=button)
+    return render_outcome(outcome, f"/dpage/{id}")
 
 
 async def remote_zen_dpage_mcp_tool(

--- a/getgather/mcp/form_schema.py
+++ b/getgather/mcp/form_schema.py
@@ -1,0 +1,247 @@
+"""JSON projection of a distilled sign-in step.
+
+The distillation engine produces HTML (`zen_distill.Match.distilled`) — a pattern skeleton whose
+text and input values have been filled in from the live page. `parse_blocks` turns that document
+into an ordered list of typed blocks so a client can render its own native form instead of
+embedding ours.
+
+Order is preserved because it is load-bearing: the prose that precedes a radio group is what
+tells the user what the options mean.
+"""
+
+import re
+from typing import Annotated, Literal
+
+from bs4 import BeautifulSoup, Tag
+from pydantic import BaseModel, Field
+
+# Every input type that appears across getgather/mcp/patterns/**.html. There are no <select> or
+# <textarea> elements in any pattern, so this projection deliberately has no block for them.
+TEXT_INPUT_TYPES = frozenset({"text", "email", "password", "tel", "number"})
+
+# Tags whose text content is prose meant for the user. Their content is scraped from the live
+# page at distill time, so it carries things like masked phone numbers and challenge questions.
+PROSE_TAGS = frozenset({"p", "strong", "span", "h1", "h2", "h3", "h4", "h5", "h6"})
+
+_DISPLAY_NONE = re.compile(r"display\s*:\s*none", re.IGNORECASE)
+
+
+class TextBlock(BaseModel):
+    type: Literal["text"] = "text"
+    text: str
+
+
+class InputBlock(BaseModel):
+    type: Literal["input"] = "input"
+    name: str
+    input_type: str
+    placeholder: str | None = None
+    value: str | None = None
+    # Always true: the polling loop only submits once every non-radio field has a value
+    # (`expected_field_count == len(names)` in dpage.distill_post_loop), so a surfaced text
+    # input is required whether or not the markup says so. No pattern uses the `required`
+    # attribute.
+    required: bool = True
+    autofocus: bool = False
+
+
+class RadioOption(BaseModel):
+    value: str
+    label: str | None = None
+    hint: str | None = None
+    checked: bool = False
+
+
+class RadioGroupBlock(BaseModel):
+    type: Literal["radio_group"] = "radio_group"
+    name: str
+    options: list[RadioOption] = Field(default_factory=list[RadioOption])
+
+
+class CheckboxBlock(BaseModel):
+    type: Literal["checkbox"] = "checkbox"
+    name: str
+    label: str | None = None
+    checked: bool = False
+
+
+class ButtonBlock(BaseModel):
+    type: Literal["button"] = "button"
+    label: str = ""
+    # Present on choice buttons (`<button name="button" value="sms">`); the client echoes it
+    # back as the top-level `button` key to pick that branch.
+    value: str | None = None
+    submit: bool = False
+
+
+Block = Annotated[
+    TextBlock | InputBlock | RadioGroupBlock | CheckboxBlock | ButtonBlock,
+    Field(discriminator="type"),
+]
+
+
+class SigninState(BaseModel):
+    """A single step of a sign-in flow."""
+
+    status: Literal["NEED_SIGNIN", "SUCCESS", "ERROR", "TIMEOUT"]
+    signin_id: str
+    title: str | None = None
+    error_code: str | None = None
+    blocks: list[Block] = Field(default_factory=list["Block"])
+
+
+class SigninSubmission(BaseModel):
+    """Body of a sign-in step submission.
+
+    `values` holds the site's own field names. `button` stays outside it and is passed to
+    `distill_post_loop` separately, so a site field named `button` or `submit` cannot be
+    mistaken for the button-choice key — `google-signin-choose-method.html` declares
+    `<button name="button">`, `<input name="none">` and `<button name="submit">`.
+    """
+
+    values: dict[str, str] = Field(default_factory=dict[str, str])
+    button: str | None = None
+
+
+def _attr(tag: Tag, name: str) -> str | None:
+    value = tag.get(name)
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return " ".join(str(item) for item in value)  # pyright: ignore[reportUnknownVariableType]
+    return None
+
+
+def _is_hidden(tag: Tag) -> bool:
+    style = _attr(tag, "style")
+    return style is not None and _DISPLAY_NONE.search(style) is not None
+
+
+def _text_for(document: BeautifulSoup, element_id: str | None) -> tuple[str | None, str | None]:
+    """Resolve the label and hint that describe the element with `element_id`.
+
+    Only 12 of 463 patterns use a real `<label>`. The rest associate text with an input via a
+    `for` attribute on arbitrary tags (`<strong for="email">`, `<p for="sms">` in
+    nordstrom-mfa-choice.html). Matching is case-insensitive because that file pairs
+    `id="EMAIL"` with `for="email"`.
+
+    The first non-empty text becomes the label; anything further becomes the hint, which is
+    where masked contact details land.
+    """
+    if not element_id:
+        return None, None
+
+    wanted = element_id.casefold()
+    texts: list[str] = []
+    for tag in document.find_all(attrs={"for": True}):
+        if not isinstance(tag, Tag) or _is_hidden(tag):
+            continue
+        for_value = _attr(tag, "for")
+        if for_value is None or for_value.casefold() != wanted:
+            continue
+        text = tag.get_text(strip=True)
+        if text:
+            texts.append(text)
+
+    if not texts:
+        return None, None
+    return texts[0], " ".join(texts[1:]) or None
+
+
+def _button_block(tag: Tag, label: str) -> ButtonBlock:
+    button_type = (_attr(tag, "type") or "").lower()
+    submit = button_type == "submit" or "rb-autoclick" in tag.attrs or "gg-autoclick" in tag.attrs
+    return ButtonBlock(label=label, value=_attr(tag, "value"), submit=submit)
+
+
+def _handle_input(
+    tag: Tag,
+    document: BeautifulSoup,
+    blocks: list[Block],
+    groups: dict[str, RadioGroupBlock],
+) -> None:
+    input_type = (_attr(tag, "type") or "text").lower()
+    if input_type == "hidden":
+        return
+
+    if input_type == "submit":
+        blocks.append(_button_block(tag, _attr(tag, "value") or ""))
+        return
+
+    name = _attr(tag, "name")
+    if name is None:
+        return
+
+    if input_type == "radio":
+        group = groups.get(name)
+        if group is None:
+            # The group takes the document position of its first option.
+            group = RadioGroupBlock(name=name)
+            groups[name] = group
+            blocks.append(group)
+        label, hint = _text_for(document, _attr(tag, "id"))
+        group.options.append(
+            RadioOption(
+                value=_attr(tag, "value") or "",
+                label=label,
+                hint=hint,
+                checked="checked" in tag.attrs,
+            )
+        )
+        return
+
+    if input_type == "checkbox":
+        label, _ = _text_for(document, _attr(tag, "id"))
+        blocks.append(CheckboxBlock(name=name, label=label, checked="checked" in tag.attrs))
+        return
+
+    blocks.append(
+        InputBlock(
+            name=name,
+            input_type=input_type if input_type in TEXT_INPUT_TYPES else "text",
+            placeholder=_attr(tag, "placeholder"),
+            value=_attr(tag, "value"),
+            autofocus="autofocus" in tag.attrs,
+        )
+    )
+
+
+def _walk(
+    node: Tag,
+    document: BeautifulSoup,
+    blocks: list[Block],
+    groups: dict[str, RadioGroupBlock],
+) -> None:
+    for child in node.children:
+        if not isinstance(child, Tag) or _is_hidden(child):
+            continue
+
+        if child.name == "input":
+            _handle_input(child, document, blocks, groups)
+        elif child.name == "button":
+            blocks.append(_button_block(child, child.get_text(strip=True)))
+        elif child.name in PROSE_TAGS:
+            # A `for` attribute means this text describes an input and is already surfaced as
+            # that option's label or hint.
+            if "for" not in child.attrs:
+                text = child.get_text(strip=True)
+                if text:
+                    blocks.append(TextBlock(text=text))
+        else:
+            _walk(child, document, blocks, groups)
+
+
+def parse_blocks(document: BeautifulSoup) -> list[Block]:
+    """Project a distilled document into ordered, typed blocks.
+
+    Subtrees hidden with `display: none` are skipped — patterns use them to hold elements that
+    exist only to satisfy the autofill loop, such as the hidden `input[name=none]` and hidden
+    submit button in google-signin-choose-method.html.
+    """
+    body = document.find("body")
+    root = body if isinstance(body, Tag) else document
+
+    blocks: list[Block] = []
+    groups: dict[str, RadioGroupBlock] = {}
+    _walk(root, document, blocks, groups)
+    return blocks

--- a/getgather/pages_api_router.py
+++ b/getgather/pages_api_router.py
@@ -9,7 +9,7 @@ from loguru import logger
 from getgather.browser import find_browser_tab, get_remote_browser
 from getgather.browsers.router import strip_browser_id_from_target_id
 from getgather.cdp_client import BrowserNotFoundError, CDPError, PageNotFoundError, open_cdp
-from getgather.mcp.dpage import distill_post_loop
+from getgather.mcp.dpage import distill_post_loop, render_outcome
 from getgather.zen_distill import (
     convert,
     distill,
@@ -155,8 +155,10 @@ async def post_page_distill(
     logger.info(f"POST /distill for browser: {browser_id}  page: {page_id}")
     form_data = await request.form()
     fields: dict[str, str] = {k: str(v) for k, v in form_data.items()}
+    button = fields.pop("button", None)
     action = f"/api/v1/browsers/{browser_id}/pages/{page_id}/distill"
-    return await distill_post_loop(page, page_id, fields, action, timeout=15)
+    outcome = await distill_post_loop(page, page_id, fields, button=button, timeout=15)
+    return render_outcome(outcome, action)
 
 
 @router.post("/api/v1/browsers/{browser_id}/pages/{page_id}/navigate")

--- a/tests/test_dpage_json_routes.py
+++ b/tests/test_dpage_json_routes.py
@@ -1,0 +1,213 @@
+"""Route-level tests for the JSON sign-in endpoints.
+
+The remote browser and the distillation loop are stubbed out, so these run without Chrome Fleet.
+What they pin down is the wire contract and the error paths — neither of which had any coverage.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import zendriver as zd
+from bs4 import BeautifulSoup
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
+
+from getgather.mcp import dpage
+from getgather.mcp.dpage import (
+    DEFAULT_DPAGE_POST_POLL_TIMEOUT,
+    DEFAULT_DPAGE_READ_POLL_TIMEOUT,
+    LoopOutcome,
+)
+
+PATTERNS = Path(__file__).parent.parent / "getgather" / "mcp" / "patterns"
+SIGNIN_ID = "browser1--target1--session1"
+TIMEOUT_NOT_PASSED = -1
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(dpage.router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def stub_page(monkeypatch: MonkeyPatch) -> None:
+    """Make sign-in id resolution succeed without a real browser."""
+
+    async def fake_get_remote_browser(browser_id: str) -> object:
+        return object()
+
+    def fake_find_browser_tab(browser: object, target_id: str) -> object:
+        return object()
+
+    monkeypatch.setattr(dpage, "get_remote_browser", fake_get_remote_browser)
+    monkeypatch.setattr(dpage, "find_browser_tab", fake_find_browser_tab)
+
+
+def stub_loop(monkeypatch: MonkeyPatch, outcome: LoopOutcome) -> list[dict[str, Any]]:
+    """Replace the distillation loop, recording how it was called."""
+    calls: list[dict[str, Any]] = []
+
+    async def fake_loop(
+        page: zd.Tab,
+        id: str,
+        fields: dict[str, str],
+        button: str | None = None,
+        patterns: Any = None,
+        # Sentinel, so a recorded timeout means "the route passed one explicitly" rather than
+        # echoing a default this stub invented.
+        timeout: int = TIMEOUT_NOT_PASSED,
+    ) -> LoopOutcome:
+        calls.append({"id": id, "fields": fields, "button": button, "timeout": timeout})
+        return outcome
+
+    monkeypatch.setattr(dpage, "distill_post_loop", fake_loop)
+    return calls
+
+
+def amazon_outcome() -> LoopOutcome:
+    document = BeautifulSoup((PATTERNS / "amazon-signin.html").read_text(), "html.parser")
+    return LoopOutcome(kind="need_input", title="Amazon Sign In", document=document)
+
+
+def test_get_json_returns_the_current_step(
+    client: TestClient, stub_page: None, monkeypatch: MonkeyPatch
+) -> None:
+    calls = stub_loop(monkeypatch, amazon_outcome())
+
+    response = client.get(f"/dpage/{SIGNIN_ID}/json")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "NEED_SIGNIN"
+    assert body["signin_id"] == SIGNIN_ID
+    assert body["title"] == "Amazon Sign In"
+    assert [b["type"] for b in body["blocks"]] == ["input", "input", "button"]
+    assert body["blocks"][0]["name"] == "email"
+    # A GET submits nothing — unlike GET /dpage/{id}, it does real work rather than trampolining.
+    assert calls[0]["fields"] == {}
+    assert calls[0]["button"] is None
+
+
+def test_read_polls_briefly_but_submit_long_polls(
+    client: TestClient, stub_page: None, monkeypatch: MonkeyPatch
+) -> None:
+    # A read is idempotent, so it must not occupy a request slot for the full submit window;
+    # each in-flight request costs one of the machine's connection slots.
+    calls = stub_loop(monkeypatch, amazon_outcome())
+
+    client.get(f"/dpage/{SIGNIN_ID}/json")
+    client.post(f"/dpage/{SIGNIN_ID}/json", json={"values": {"email": "a@b.c"}})
+
+    # The read asks for the short window explicitly...
+    assert calls[0]["timeout"] == DEFAULT_DPAGE_READ_POLL_TIMEOUT
+    # ...while the submit passes nothing and so inherits the loop's own long default.
+    assert calls[1]["timeout"] == TIMEOUT_NOT_PASSED
+    assert DEFAULT_DPAGE_READ_POLL_TIMEOUT < DEFAULT_DPAGE_POST_POLL_TIMEOUT
+
+
+def test_post_json_forwards_values_and_button_separately(
+    client: TestClient, stub_page: None, monkeypatch: MonkeyPatch
+) -> None:
+    calls = stub_loop(monkeypatch, LoopOutcome(kind="finished", title="Done"))
+
+    response = client.post(
+        f"/dpage/{SIGNIN_ID}/json",
+        json={"values": {"email": "a@b.c", "password": "hunter2"}, "button": "sms"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "SUCCESS"
+    assert calls[0]["fields"] == {"email": "a@b.c", "password": "hunter2"}
+    assert calls[0]["button"] == "sms"
+
+
+def test_a_site_field_named_button_is_not_treated_as_a_choice(
+    client: TestClient, stub_page: None, monkeypatch: MonkeyPatch
+) -> None:
+    calls = stub_loop(monkeypatch, LoopOutcome(kind="finished", title="Done"))
+
+    client.post(f"/dpage/{SIGNIN_ID}/json", json={"values": {"button": "literal-field"}})
+
+    # This is the collision the namespaced body exists to prevent.
+    assert calls[0]["fields"] == {"button": "literal-field"}
+    assert calls[0]["button"] is None
+
+
+def test_post_json_accepts_an_empty_body(
+    client: TestClient, stub_page: None, monkeypatch: MonkeyPatch
+) -> None:
+    calls = stub_loop(monkeypatch, amazon_outcome())
+
+    response = client.post(f"/dpage/{SIGNIN_ID}/json")
+
+    assert response.status_code == 200
+    assert calls[0]["fields"] == {}
+
+
+def test_error_pattern_reports_error_status_and_code(
+    client: TestClient, stub_page: None, monkeypatch: MonkeyPatch
+) -> None:
+    stub_loop(
+        monkeypatch,
+        LoopOutcome(kind="finished", title="Closed", error_code="reset_password"),
+    )
+
+    body = client.get(f"/dpage/{SIGNIN_ID}/json").json()
+
+    assert body["status"] == "ERROR"
+    assert body["error_code"] == "reset_password"
+
+
+def test_timeout_is_200_with_a_status_not_503(
+    client: TestClient, stub_page: None, monkeypatch: MonkeyPatch
+) -> None:
+    stub_loop(monkeypatch, LoopOutcome(kind="timeout"))
+
+    response = client.get(f"/dpage/{SIGNIN_ID}/json")
+
+    # A JSON client cannot tell our 503 apart from a proxy killing a long-poll.
+    assert response.status_code == 200
+    assert response.json()["status"] == "TIMEOUT"
+
+
+def test_invalid_signin_id_is_400(client: TestClient) -> None:
+    response = client.get("/dpage/nodelimiter/json")
+    assert response.status_code == 400
+
+
+def test_missing_browser_is_404(client: TestClient, monkeypatch: MonkeyPatch) -> None:
+    async def no_browser(browser_id: str) -> None:
+        return None
+
+    monkeypatch.setattr(dpage, "get_remote_browser", no_browser)
+
+    response = client.get(f"/dpage/{SIGNIN_ID}/json")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Remote browser not found"
+
+
+def test_missing_tab_is_404(client: TestClient, monkeypatch: MonkeyPatch) -> None:
+    async def a_browser(browser_id: str) -> object:
+        return object()
+
+    def no_tab(browser: object, target_id: str) -> None:
+        return None
+
+    monkeypatch.setattr(dpage, "get_remote_browser", a_browser)
+    monkeypatch.setattr(dpage, "find_browser_tab", no_tab)
+
+    response = client.get(f"/dpage/{SIGNIN_ID}/json")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Page not found"
+
+
+def test_json_route_does_not_shadow_the_html_route(client: TestClient) -> None:
+    # GET /dpage/{id} still serves the auto-submit trampoline, untouched.
+    response = client.get(f"/dpage/{SIGNIN_ID}")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert f'action="/dpage/{SIGNIN_ID}" method="post"' in response.text

--- a/tests/test_form_schema.py
+++ b/tests/test_form_schema.py
@@ -1,0 +1,281 @@
+"""Tests for the JSON projection of a distilled sign-in step.
+
+These are pure parsing tests — no browser and no Chrome Fleet. They run against the real
+pattern files in `getgather/mcp/patterns/`, so a pattern change that breaks the contract shows
+up here.
+
+Note that pattern files ship *empty* prose and label elements; distillation fills them from the
+live page. Tests that care about that text fill it in first, the way `distill()` would.
+"""
+
+from pathlib import Path
+
+import pytest
+from bs4 import BeautifulSoup, Tag
+from fastapi import HTTPException
+from fastapi.responses import HTMLResponse
+
+from getgather.mcp.dpage import FINISHED_MSG, LoopOutcome, render_outcome, signin_state
+from getgather.mcp.form_schema import (
+    ButtonBlock,
+    CheckboxBlock,
+    InputBlock,
+    RadioGroupBlock,
+    SigninSubmission,
+    TextBlock,
+    parse_blocks,
+)
+
+PATTERNS = Path(__file__).parent.parent / "getgather" / "mcp" / "patterns"
+
+
+def load(name: str) -> BeautifulSoup:
+    return BeautifulSoup((PATTERNS / name).read_text(), "html.parser")
+
+
+def html_of(response: HTMLResponse) -> str:
+    return bytes(response.body).decode()
+
+
+def test_amazon_signin_yields_two_inputs_and_a_submit() -> None:
+    blocks = parse_blocks(load("amazon-signin.html"))
+
+    assert [b.type for b in blocks] == ["input", "input", "button"]
+
+    email, password, submit = blocks
+    assert isinstance(email, InputBlock)
+    assert (email.name, email.input_type) == ("email", "email")
+    assert email.placeholder == "Email or mobile phone number"
+    assert email.autofocus is True
+
+    assert isinstance(password, InputBlock)
+    assert (password.name, password.input_type) == ("password", "password")
+
+    assert isinstance(submit, ButtonBlock)
+    assert submit.label == "Sign in"
+    assert submit.submit is True
+
+
+def test_text_inputs_are_required_because_the_loop_demands_every_field() -> None:
+    # No pattern uses the `required` attribute; the loop only submits once every non-radio
+    # field has a value, so a surfaced input is required regardless of markup.
+    blocks = parse_blocks(load("amazon-signin.html"))
+    assert all(b.required for b in blocks if isinstance(b, InputBlock))
+
+
+def test_google_choice_buttons_exclude_hidden_elements() -> None:
+    blocks = parse_blocks(load("google-signin-choose-method.html"))
+
+    # The hidden `input[name=none]` and hidden `button[name=submit]` exist only to satisfy the
+    # autofill loop and must not reach the client.
+    assert all(isinstance(b, ButtonBlock) for b in blocks)
+    assert [b.value for b in blocks if isinstance(b, ButtonBlock)] == [
+        "phone-tap-yes",
+        "authenticator",
+        "sms",
+        "recovery-email-tap",
+    ]
+    # These are branch choices, not form submissions.
+    assert all(not b.submit for b in blocks if isinstance(b, ButtonBlock))
+
+
+def fill(document: BeautifulSoup, tag_name: str, texts: list[str]) -> None:
+    """Fill empty elements with text, the way `distill()` does from the live page."""
+    tags = [t for t in document.find_all(tag_name) if isinstance(t, Tag)]
+    for tag, text in zip(tags, texts):
+        tag.string = text
+
+
+def _filled_nordstrom() -> BeautifulSoup:
+    """nordstrom-mfa-choice.html as distillation would leave it after a real page load."""
+    document = load("nordstrom-mfa-choice.html")
+    fill(
+        document,
+        "p",
+        [
+            "Verify your identity",
+            "How should we send your code?",
+            "Standard rates apply",  # the <p for="sms"> hint
+        ],
+    )
+    fill(document, "strong", ["j•••@x.com", "•••-1234"])
+    return document
+
+
+def test_nordstrom_groups_radios_and_keeps_prose_order() -> None:
+    blocks = parse_blocks(_filled_nordstrom())
+
+    # Order matters: the prose explaining the choice must precede the choice.
+    assert [b.type for b in blocks] == ["text", "text", "radio_group", "button"]
+
+    intro, question, group, send = blocks
+    assert isinstance(intro, TextBlock) and intro.text == "Verify your identity"
+    assert isinstance(question, TextBlock)
+    assert question.text == "How should we send your code?"
+
+    assert isinstance(group, RadioGroupBlock)
+    assert group.name == "delivery-method"
+    assert [(o.value, o.label, o.checked) for o in group.options] == [
+        ("EMAIL", "Email", True),
+        ("sms", "Text Message", False),
+    ]
+
+    assert isinstance(send, ButtonBlock) and send.label == "Send Code"
+
+
+def test_nordstrom_option_hints_carry_masked_contact_details() -> None:
+    blocks = parse_blocks(_filled_nordstrom())
+    group = next(b for b in blocks if isinstance(b, RadioGroupBlock))
+
+    # `id="EMAIL"` pairs with `for="email"`, so association must be case-insensitive.
+    assert group.options[0].hint == "j•••@x.com"
+    # Multiple `for=` elements collapse into one hint; this is how the user tells options apart.
+    assert group.options[1].hint == "•••-1234 Standard rates apply"
+
+
+def test_label_text_is_not_also_emitted_as_a_standalone_block() -> None:
+    blocks = parse_blocks(_filled_nordstrom())
+    texts = [b.text for b in blocks if isinstance(b, TextBlock)]
+    assert "j•••@x.com" not in texts
+    assert "Email" not in texts
+
+
+def test_hidden_subtrees_are_skipped_but_visible_display_rules_are_not() -> None:
+    document = BeautifulSoup(
+        """
+        <html><body>
+          <div style="display: none"><input name="secret" type="text"/></div>
+          <div style="display: flex; align-items: center"><input name="shown" type="text"/></div>
+        </body></html>
+        """,
+        "html.parser",
+    )
+    blocks = parse_blocks(document)
+    assert [b.name for b in blocks if isinstance(b, InputBlock)] == ["shown"]
+
+
+def test_checkbox_becomes_its_own_block() -> None:
+    document = BeautifulSoup(
+        """
+        <html><body>
+          <input type="checkbox" name="remember" id="rm" checked/>
+          <span for="rm">Keep me signed in</span>
+        </body></html>
+        """,
+        "html.parser",
+    )
+    checkbox = parse_blocks(document)[0]
+    assert isinstance(checkbox, CheckboxBlock)
+    assert (checkbox.name, checkbox.label, checkbox.checked) == (
+        "remember",
+        "Keep me signed in",
+        True,
+    )
+
+
+def test_unknown_input_type_falls_back_to_text() -> None:
+    document = BeautifulSoup(
+        '<html><body><input type="date" name="dob"/></body></html>', "html.parser"
+    )
+    block = parse_blocks(document)[0]
+    assert isinstance(block, InputBlock)
+    assert block.input_type == "text"
+
+
+# --- outcome projection ------------------------------------------------------------------
+
+
+def _outcome_from(name: str) -> LoopOutcome:
+    return LoopOutcome(kind="need_input", title="Amazon Sign In", document=load(name))
+
+
+def test_need_input_projects_to_need_signin_with_blocks() -> None:
+    state = signin_state(_outcome_from("amazon-signin.html"), "b--t")
+    assert state.status == "NEED_SIGNIN"
+    assert state.signin_id == "b--t"
+    assert state.title == "Amazon Sign In"
+    assert state.error_code is None
+    assert [b.type for b in state.blocks] == ["input", "input", "button"]
+
+
+def test_finished_without_error_is_success() -> None:
+    state = signin_state(LoopOutcome(kind="finished", title="Done"), "b--t")
+    assert state.status == "SUCCESS"
+    assert state.blocks == []
+
+
+def test_finished_with_error_code_is_error() -> None:
+    # The HTML path deliberately treats an rb-error pattern as merely "finished" so polling
+    # stops; JSON splits it out so consumers stop keyword-matching the page.
+    outcome = LoopOutcome(kind="finished", title="Closed", error_code="reset_password")
+    state = signin_state(outcome, "b--t")
+    assert state.status == "ERROR"
+    assert state.error_code == "reset_password"
+
+
+def test_timeout_is_a_status_not_a_503() -> None:
+    state = signin_state(LoopOutcome(kind="timeout"), "b--t")
+    assert state.status == "TIMEOUT"
+
+
+def test_error_pattern_still_reports_the_page_text() -> None:
+    document = load("amazon-error-account-closed.html")
+    blocks = parse_blocks(document)
+    assert any(isinstance(b, TextBlock) and b.text for b in blocks)
+
+
+# --- HTML path must be unchanged ---------------------------------------------------------
+
+
+def test_render_outcome_still_raises_503_on_timeout() -> None:
+    with pytest.raises(HTTPException) as excinfo:
+        render_outcome(LoopOutcome(kind="timeout"), "/dpage/x")
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.detail == "Timeout reached"
+
+
+def test_render_outcome_finished_renders_the_finished_message() -> None:
+    body = html_of(render_outcome(LoopOutcome(kind="finished", title="Done"), "/dpage/x"))
+    assert FINISHED_MSG in body
+    assert "<title>Done</title>" in body
+
+
+def test_render_outcome_surfaces_error_code_as_meta_tag() -> None:
+    outcome = LoopOutcome(kind="finished", title="Closed", error_code="reset_password")
+    body = html_of(render_outcome(outcome, "/dpage/x"))
+    assert 'name="error-message" content="reset_password"' in body
+
+
+def test_render_outcome_need_input_embeds_the_distilled_body_and_action() -> None:
+    document = load("amazon-signin.html")
+    outcome = LoopOutcome(kind="need_input", title="Amazon Sign In", document=document)
+    body = html_of(render_outcome(outcome, "/dpage/abc"))
+
+    assert 'action="/dpage/abc"' in body
+    original_body = document.find("body")
+    assert isinstance(original_body, Tag)
+    # The HTML path passes the distilled body through verbatim, exactly as it did before.
+    assert str(original_body) in body
+
+
+# --- submission ---------------------------------------------------------------------------
+
+
+def test_button_stays_out_of_values() -> None:
+    submission = SigninSubmission(values={"email": "a@b.c"}, button="sms")
+    assert submission.values == {"email": "a@b.c"}
+    assert submission.button == "sms"
+
+
+def test_a_site_field_named_button_is_not_a_button_choice() -> None:
+    # google-signin-choose-method.html declares `<button name="button">` alongside real inputs,
+    # so the two namespaces must stay separate all the way into distill_post_loop.
+    submission = SigninSubmission(values={"button": "not-a-choice"})
+    assert submission.button is None
+    assert submission.values == {"button": "not-a-choice"}
+
+
+def test_empty_submission_is_valid() -> None:
+    submission = SigninSubmission()
+    assert submission.values == {}
+    assert submission.button is None


### PR DESCRIPTION
## Why

Today the only representation of a sign-in step is HTML. `distill_post_loop` returns a page rendered by `html_renderer.render_form`, so a client that can't embed our page has to scrape it back.

That is exactly what happens: `demos/packages/connector-sdk/src/server/signin-form-schema.ts` re-parses the rendered dpage with cheerio to rebuild a `SigninFormSchema`. Deriving that server-side, from the DOM we already have, removes three defects caused by the round trip:

1. **Completion is detected by an English sentence** — `data.includes('Finished! You can close this window now')`, in two places (`connector/src/core/connector.ts:273`, `connector-sdk/src/server/router.ts:148`).
2. **Error taxonomy is regex-over-HTML** — a 10-rule keyword table (`connector/src/core/mcp-client.ts:265-328`) matching values that began life as a structured `rb-error` attribute.
3. **Grouped radios are unrepresentable** because `SigninFormField` is flat. This is the specific reason the iframe can't be deleted: the OTP-delivery screen (`patterns/nordstrom-mfa-choice.html`) can't be rendered natively.

## What

A JSON sibling of the existing route, in the same router:

```
GET  /dpage/{id}          -> HTML   (unchanged)
POST /dpage/{id}          -> HTML   (unchanged)
GET  /dpage/{id}/json     -> SigninState
POST /dpage/{id}/json     -> SigninState
```

- **`getgather/mcp/form_schema.py`** (new) — `parse_blocks()` projects a distilled document into ordered, typed blocks. Rules derived from the 463 files in `getgather/mcp/patterns/`: hidden-subtree skipping, radio grouping by `name`, and the ad-hoc `for=`-on-non-label-tags association `nordstrom-mfa-choice.html` uses (case-insensitively, since it pairs `id="EMAIL"` with `for="email"`).
- **`distill_post_loop` now returns a `LoopOutcome`** instead of an `HTMLResponse`, with `render_outcome()` and `signin_state()` as the two projections. Order is preserved because it is load-bearing: the prose before a radio group is what explains the options.
- Timeout returns **200 with `status: "TIMEOUT"`** on the JSON path — a JSON client can't tell our 503 apart from a proxy killing a long-poll. The HTML path still raises 503, unchanged.
- Reads use a short poll (`DEFAULT_DPAGE_READ_POLL_TIMEOUT = 5`); a GET submits nothing and re-distilling is idempotent, so it shouldn't hold a request slot for the full submit window (`fly.toml` sets `soft_limit = 20`).
- `button` is now a separate parameter rather than a reserved key inside `fields`, so a site input named `button` can't be mistaken for a branch choice — `google-signin-choose-method.html` declares `<button name="button">`, `<input name="none">` **and** `<button name="submit">`.

## Verification

- `make check` clean (ruff, prettier, yamlfix, ty, pyright strict, pattern check).
- 31 new tests; `parse_blocks` covered against real pattern files, plus the first route-level coverage dpage has had.
- **HTML output proven byte-identical**: all 463 patterns rendered through both the pre-refactor expressions and `render_outcome`, for `need_input` and `finished` with and without an error code — 0 differences.
- Driven end to end against a real remote browser and a live Amazon sign-in: the read returns the email step, and submitting returns `{"status":"ERROR","error_code":"email_not_found"}` — the fact that today's consumer recovers by substring-matching HTML.

## Notes

- `AGENTS.md:79` claims `browser_id` derives from an auth user `{sub}-{auth_provider}`; it does not — it's `mcp_session_id or get_host_id()`. Not changed here.
- The new routes require an explicit `signin_id`, so they never reach the `get_host_id()` fallback (`hostname + "-noauth"`), which is the one genuine horizontal-scaling hazard on the MCP tool path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
