### PR TITLE
Maintain a consistent JSON response

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Follow the MCP install [guide](https://code.visualstudio.com/docs/copilot/chat/m
 _Example_: `curl -X POST localhost:8300/api/v1/browsers/xyz123` creates a container named `chromium-xyz123` and returns:
 
 ```json
-{ "container_name": "chromium-xyz123", "status": "created" }
+{ "browser_id": "xyz123", "status": "created" }
 ```
 
 ### Stop a browser
@@ -92,7 +92,7 @@ _Example_: `curl -X POST localhost:8300/api/v1/browsers/xyz123` creates a contai
 _Example_: `curl -X DELETE localhost:8300/api/v1/browsers/xyz123` terminates the container named `chromium-xyz123` and returns:
 
 ```json
-{ "container_name": "chromium-xyz123", "status": "deleted" }
+{ "status": "deleted" }
 ```
 
 ### Query a browser

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -233,7 +233,7 @@ async def create_browser(browser_id: str, request: Request) -> dict[str, Any]:
         browser_type = request.headers.get("x-browser-type")
         result = await backend.create_browser(browser_id, origin_ip, target_domain, browser_type)
         logger.info(f"Browser {browser_id} is started.")
-        return result
+        return {"browser_id": browser_id, **result}
     except Exception as e:
         detail = f"Unable to start browser {browser_id}!"
         logger.error(f"{detail} Exception={e}")


### PR DESCRIPTION
- Always return `browser_id`.
- Drop `container_name`, since it's Podman-specific and can be derived from `browser_id` anyway.

Tested by launching the server and hitting the API:

    curl -X POST http://127.0.0.1:23456/api/v1/browsers/

The response now includes the `browser_id` field.