### PR TITLE
Add a namespacing-free CDP websocket proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ _Example_: `curl localhost:23456/api/v1/browsers/test/pages` returns:
 ["96FDE4162B8EEEBF98E26756D21CF0C5"]
 ```
 
+### Connect to a browser over CDP
+
+`GET /api/v1/browsers/{browser_id}/cdp` upgrades to a WebSocket and tunnels a CDP session to the specified browser. The browser is auto-launched if it isn't already running. Returns HTTP 4502 (WebSocket close code) if the remote debugger URL can't be resolved after retries.
+
+_Example (Playwright with Node.js)_:
+
+```js
+const { chromium } = require("@playwright/test");
+const target = "ws://localhost:23456/api/v1/browsers/xyz123/cdp";
+const browser = await chromium.connectOverCDP(target);
+```
+
 ### Get page HTML
 
 `GET /api/v1/browsers/{browser_id}/pages/{page_id}/html` returns the raw HTML of the specified page. Returns HTTP 404 if the browser or page is not found.

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -281,10 +281,10 @@ async def list_browsers() -> JSONResponse:
         raise HTTPException(status_code=500, detail=detail)
 
 
-@router.websocket("/cdp/{browser_id}")
-async def cdp_browser_websocket_proxy(client_ws: WebSocket, browser_id: str) -> None:
-    logger.debug(f"[CDP] Entered cdp_browser_websocket_proxy for browser_id={browser_id}")
-
+async def relay_browser_cdp(client_ws: WebSocket, browser_id: str, *, patch: bool) -> None:
+    """Shared body of the browser-level CDP routes: auto-launch the browser, resolve the
+    backend's remote wss URL, then relay. `patch` decides whether target ids are namespaced by
+    browser_id on the way through (`/cdp`) or passed verbatim (`/api/v1/browsers/{browser_id}/cdp`)."""
     await client_ws.accept()
     logger.debug("[CDP] WebSocket accepted")
 
@@ -326,13 +326,32 @@ async def cdp_browser_websocket_proxy(client_ws: WebSocket, browser_id: str) -> 
         await client_ws.close(code=4502, reason="Failed to get debugger URL")
         return
 
-    # (3) Relay. `cdp_targets_need_namespacing` lets each backend tell the router whether the URL
-    # it returned already namespaces target ids (Fleet's external /cdp proxy) — in which case we
-    # do not patch again (would double-prefix browser_id).
+    # (3) Relay.
     logger.info(f"[CDP] Client connected, proxying to {remote_url}")
-    patch = backend.cdp_targets_need_namespacing()
     await websocket_proxy(client_ws, remote_url, browser_id, patch)
+
+
+@router.websocket("/cdp/{browser_id}")
+async def cdp_browser_websocket_proxy(client_ws: WebSocket, browser_id: str) -> None:
+    # `cdp_targets_need_namespacing` lets each backend tell the router whether the URL it returned
+    # already namespaces target ids (Fleet's external /cdp proxy) — in which case we do not patch
+    # again (would double-prefix browser_id).
+    logger.debug(f"[CDP] Entered cdp_browser_websocket_proxy for browser_id={browser_id}")
+    await relay_browser_cdp(client_ws, browser_id, patch=backend.cdp_targets_need_namespacing())
     logger.debug("[CDP] cdp_browser_websocket_proxy exiting")
+
+
+@router.websocket("/api/v1/browsers/{browser_id}/cdp")
+async def cdp_browser_websocket_proxy_raw(client_ws: WebSocket, browser_id: str) -> None:
+    """Same relay as `/cdp/{browser_id}`, but byte-for-byte: no target-id namespacing at all, in
+    either direction. Clients see the browser's own raw target ids (`abc1234567`, not
+    `xyz@abc1234567`) and any id they send is forwarded untouched.
+
+    Note this route does not undo namespacing applied upstream: with `CHROMEFLEET_URL` set we
+    relay to the external fleet's own `/cdp` proxy, which namespaces on its side."""
+    logger.debug(f"[CDP] Entered cdp_browser_websocket_proxy_raw for browser_id={browser_id}")
+    await relay_browser_cdp(client_ws, browser_id, patch=False)
+    logger.debug("[CDP] cdp_browser_websocket_proxy_raw exiting")
 
 
 @router.websocket("/devtools/{path:path}")

--- a/tests/test_browser_backend.py
+++ b/tests/test_browser_backend.py
@@ -1,3 +1,8 @@
+import asyncio
+import json
+from typing import Any
+
+import websockets
 from pytest import MonkeyPatch
 
 from getgather.browser import _setup_cdp_url  # pyright: ignore[reportPrivateUsage]
@@ -67,3 +72,84 @@ def test_create_browser_auto_name_starts_with_b(monkeypatch: MonkeyPatch) -> Non
     assert response.status_code == 200
     data = response.json()
     assert data["browser_id"].startswith("B")
+
+
+class _FakeRemote:
+    """A stand-in for the browser's CDP socket: records what the relay forwards, and answers
+    every command with a canned result carrying the browser's own (raw) target id."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self._replies: asyncio.Queue[str] = asyncio.Queue()
+
+    async def send(self, message: str) -> None:
+        self.sent.append(message)
+        await self._replies.put(json.dumps({"id": 1, "result": {"targetId": "abc1234567"}}))
+
+    def __aiter__(self) -> "_FakeRemote":
+        return self
+
+    async def __anext__(self) -> str:
+        return await self._replies.get()
+
+
+class _FakeConnect:
+    def __init__(self, remote: _FakeRemote) -> None:
+        self._remote = remote
+
+    async def __aenter__(self) -> _FakeRemote:
+        return self._remote
+
+    async def __aexit__(self, *args: Any) -> bool:
+        return False
+
+
+class _FakeCDPBackend:
+    """The slice of Backend that the browser-level CDP relay touches."""
+
+    async def browser_exists(self, browser_id: str) -> bool:
+        return True
+
+    async def get_cdp_websocket_remote_url(self, browser_id: str) -> str:
+        return "ws://remote/devtools/browser/xyz"
+
+    def cdp_targets_need_namespacing(self) -> bool:
+        return True
+
+
+def _relay_roundtrip(monkeypatch: MonkeyPatch, path: str, sent_target_id: str) -> tuple[str, str]:
+    """Drive one command through `path` and return (what the browser saw, what the client saw)."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    remote = _FakeRemote()
+    monkeypatch.setattr(browsers_router, "backend", _FakeCDPBackend())
+    monkeypatch.setattr(websockets, "connect", lambda url, **kwargs: _FakeConnect(remote))  # pyright: ignore[reportUnknownLambdaType, reportUnknownArgumentType]
+
+    app = FastAPI()
+    app.include_router(browsers_router.router)
+    with TestClient(app).websocket_connect(path) as ws:
+        ws.send_text(
+            json.dumps({
+                "id": 1,
+                "method": "Target.attachToTarget",
+                "params": {"targetId": sent_target_id},
+            })
+        )
+        received: str = ws.receive_text()
+    return remote.sent[0], received
+
+
+def test_cdp_route_namespaces_target_ids(monkeypatch: MonkeyPatch) -> None:
+    # /cdp strips the browser_id off ids the client sends and prepends it to ids coming back.
+    to_browser, to_client = _relay_roundtrip(monkeypatch, "/cdp/BID", "BID@abc1234567")
+    assert json.loads(to_browser)["params"]["targetId"] == "abc1234567"
+    assert json.loads(to_client)["result"]["targetId"] == "BID@abc1234567"
+
+
+def test_cdp_raw_route_relays_verbatim(monkeypatch: MonkeyPatch) -> None:
+    # /api/v1/browsers/{browser_id}/cdp does no patching in either direction: the client speaks the browser's
+    # own raw target ids, and both frames cross the relay byte-for-byte.
+    to_browser, to_client = _relay_roundtrip(monkeypatch, "/api/v1/browsers/BID/cdp", "abc1234567")
+    assert json.loads(to_browser)["params"]["targetId"] == "abc1234567"
+    assert json.loads(to_client)["result"]["targetId"] == "abc1234567"


### PR DESCRIPTION
The existing `/cdp/{browser_id}` proxy namespaces traffic by rewriting target ids to prefix them with the `browser_id`, and stripping that prefix back out on certain inbound methods. This works fine for Zendriver, but Playwright and similar clients do not work correctly with this approach unless every call is patched and then unpatched, which is not practical.

To let Playwright use CDP over websocket, this change adds a new endpoint, `/api/v1/browsers/{browser_id}/cdp`, that relays the socket byte-for-byte in both directions without any modification.

The new route preserves the existing auto-launch, remote-URL resolution, and retry logic.

Note that this does not undo any namespacing applied upstream: when `CHROMEFLEET_URL` is set, we relay to the external fleet's own /cdp proxy, which may or may not namespace on its side.

To verify, launch with `make` as usual, then create a new browser with:
```bash
curl -X POST http://localhost:23456/api/v1/browsers
```

From the response, grab the `browser_id` and use it to construct a new env `CDP_WEBSOCKET_URL` such as:
```bash
export CDP_WEBSOCKET_URL=ws://localhost:23456/api/v1/browsers/Bemknfnf5/cdp
```

and run the something like the following Node.js script:

```
const { chromium } = require('@playwright/test');

(async () => {
  const cdpWs = process.env.CDP_WEBSOCKET_URL;
  const browser = await chromium.connectOverCDP(cdpWs);
  const context = browser.contexts()[0] || await browser.newContext();
  const page = await context.newPage();
  await page.goto('https://example.com', { waitUntil: 'domcontentloaded' });
  console.log(await page.title());
  await page.close();
  await browser.close();
})();
```