### PR TITLE
feat: store browser session recordings in Tigris

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -43,3 +43,10 @@ MAXMIND_LICENSE_KEY=
 LOG_LEVEL=INFO
 SENTRY_DSN=
 LOGFIRE_TOKEN=
+
+# Tigris storage for session recordings (all three required to enable uploads)
+TIGRIS_BUCKET=
+TIGRIS_ACCESS_KEY_ID=
+TIGRIS_SECRET_ACCESS_KEY=
+TIGRIS_ENDPOINT_URL=https://t3.storage.dev
+TIGRIS_REGION=auto

--- a/getgather/config.py
+++ b/getgather/config.py
@@ -23,11 +23,28 @@ class Settings(BrowserSettings, BaseSettings):
     SENTRY_DSN: str = ""
     LOGFIRE_TOKEN: str = ""
 
+    # Tigris (S3-compatible) storage for browser session recordings
+    TIGRIS_BUCKET: str = ""
+    TIGRIS_ACCESS_KEY_ID: str = ""
+    TIGRIS_SECRET_ACCESS_KEY: str = ""
+    TIGRIS_ENDPOINT_URL: str = "https://t3.storage.dev"
+    TIGRIS_REGION: str = "auto"
+
+    # How long to keep polling Chrome Fleet for recordings that are still encoding.
+    RECORDING_POLL_TIMEOUT_SECONDS: float = 120.0
+    RECORDING_POLL_INTERVAL_SECONDS: float = 3.0
+
     @property
     def data_dir(self) -> Path:
         path = Path(self.DATA_DIR).resolve() if self.DATA_DIR else PROJECT_DIR / "data"
         path.mkdir(parents=True, exist_ok=True)
         return path
+
+    @property
+    def RECORDING_UPLOAD_ENABLED(self) -> bool:
+        return bool(
+            self.TIGRIS_BUCKET and self.TIGRIS_ACCESS_KEY_ID and self.TIGRIS_SECRET_ACCESS_KEY
+        )
 
     @property
     def screenshots_dir(self) -> Path:

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -31,6 +31,7 @@ from getgather.browser import (
 )
 from getgather.config import settings
 from getgather.mcp.html_renderer import DEFAULT_TITLE, render_form
+from getgather.recordings import schedule_sweep
 from getgather.zen_distill import (
     Match,
     Pattern,
@@ -143,6 +144,7 @@ def _target_domain_from_initial_url(initial_url: str) -> str:
 
 async def _try_action_with_probe(
     browser: zd.Browser,
+    browser_id: str,
     initial_url: str,
     action: Any,
     timeout: int,
@@ -163,6 +165,7 @@ async def _try_action_with_probe(
         if terminated:
             result = await action(page, browser)
             await safe_close_page(page)
+            schedule_sweep(browser_id)
             return result
         await safe_close_page(page)
         return None
@@ -731,6 +734,7 @@ async def remote_zen_dpage_mcp_tool(
     )
     if terminated:
         await safe_close_page(page)
+        schedule_sweep(browser_id)
         distillation_result = converted if converted is not None else distilled
         return {result_key: distillation_result}
 
@@ -762,12 +766,17 @@ async def remote_zen_dpage_with_action(
 
     # Probe any existing browser for an authenticated session before opening dpage.
     probe_browser = None
+    probe_browser_id = ""
     if incoming:
-        probe_browser = await get_remote_browser(incoming.browser_id)
+        probe_browser_id = incoming.browser_id
+        probe_browser = await get_remote_browser(probe_browser_id)
     elif not incognito:
-        probe_browser = await get_remote_browser(mcp_session_id or get_host_id())
+        probe_browser_id = mcp_session_id or get_host_id()
+        probe_browser = await get_remote_browser(probe_browser_id)
     if probe_browser is not None:
-        result = await _try_action_with_probe(probe_browser, initial_url, action, timeout)
+        result = await _try_action_with_probe(
+            probe_browser, probe_browser_id, initial_url, action, timeout
+        )
         if result is not None:
             return result
 
@@ -823,6 +832,7 @@ async def remote_zen_dpage_with_action(
     if terminated:
         result = await action(page, browser)
         await safe_close_page(page)
+        schedule_sweep(browser_id)
         return result
 
     page.hostname = urllib.parse.urlparse(initial_url).hostname  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]

--- a/getgather/recordings.py
+++ b/getgather/recordings.py
@@ -1,0 +1,157 @@
+"""Pull browser session recordings from Chrome Fleet and store them in Tigris.
+
+chrome-live records every tab and finalizes the MP4 only after the tab closes and ffmpeg has
+encoded it, so a sweep keeps polling the fleet for a while after a tool closes its page. The
+container's disk is ephemeral, so anything not pulled before the browser is deleted is lost.
+"""
+
+import asyncio
+import json
+from functools import lru_cache
+from typing import Any
+
+import boto3
+import httpx
+from botocore.client import Config
+from botocore.exceptions import ClientError
+from loguru import logger
+
+from getgather.config import settings
+
+LIST_TIMEOUT = 15.0
+DOWNLOAD_TIMEOUT = 120.0
+S3_TIMEOUT = 120.0
+
+_sweeps: dict[str, asyncio.Task[None]] = {}
+
+# boto3/botocore ship no type information, so everything crossing that boundary is Any.
+_boto3: Any = boto3
+_config: Any = Config
+
+
+def schedule_sweep(browser_id: str) -> None:
+    """Start a background upload sweep for a browser, unless one is already running."""
+    if not settings.RECORDING_UPLOAD_ENABLED:
+        return
+
+    running = _sweeps.get(browser_id)
+    if running is not None and not running.done():
+        return
+
+    task = asyncio.create_task(_sweep(browser_id))
+    _sweeps[browser_id] = task
+
+    def _forget(finished: asyncio.Task[None]) -> None:
+        if _sweeps.get(browser_id) is finished:
+            del _sweeps[browser_id]
+
+    task.add_done_callback(_forget)
+
+
+async def _sweep(browser_id: str) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + settings.RECORDING_POLL_TIMEOUT_SECONDS
+    uploaded: set[str] = set()
+
+    while True:
+        try:
+            recordings = await _list_recordings(browser_id)
+        except Exception as e:
+            logger.warning(f"Could not list recordings for browser {browser_id}: {e}")
+            recordings = []
+
+        fresh = [r for r in recordings if r["recording_id"] not in uploaded]
+        for meta in fresh:
+            recording_id: str = meta["recording_id"]
+            try:
+                await _store_recording(browser_id, recording_id, meta)
+                uploaded.add(recording_id)
+            except Exception as e:
+                logger.warning(f"Failed to store recording {recording_id}: {e}")
+
+        if loop.time() >= deadline:
+            break
+        # Once a pass adds nothing new, every tab that was open has flushed.
+        if uploaded and not fresh:
+            break
+        await asyncio.sleep(settings.RECORDING_POLL_INTERVAL_SECONDS)
+
+    logger.info(f"Stored {len(uploaded)} recording(s) for browser {browser_id}")
+
+
+async def _list_recordings(browser_id: str) -> list[dict[str, Any]]:
+    base_url = settings.effective_chromefleet_url.rstrip("/")
+    url = f"{base_url}/api/v1/browsers/{browser_id}/recordings"
+    async with httpx.AsyncClient(timeout=LIST_TIMEOUT) as client:
+        response = await client.get(url)
+        # The browser is gone, or its image has no recordings server.
+        if response.status_code in (404, 501):
+            return []
+        response.raise_for_status()
+        payload: dict[str, Any] = response.json()
+
+    recordings: list[dict[str, Any]] = payload.get("recordings", [])
+    return [r for r in recordings if r.get("recording_id")]
+
+
+async def _store_recording(browser_id: str, recording_id: str, meta: dict[str, Any]) -> None:
+    prefix = f"recordings/{browser_id}/{recording_id}"
+    if await _object_exists(f"{prefix}.mp4"):
+        return
+
+    base_url = settings.effective_chromefleet_url.rstrip("/")
+    url = f"{base_url}/api/v1/browsers/{browser_id}/recordings/{recording_id}/video"
+    async with httpx.AsyncClient(timeout=DOWNLOAD_TIMEOUT) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        video = response.content
+
+    await _put_object(f"{prefix}.mp4", video, "video/mp4")
+    await _put_object(f"{prefix}.json", json.dumps(meta).encode(), "application/json")
+    logger.info(f"Stored recording {recording_id} ({len(video)} bytes) at {prefix}.mp4")
+
+
+@lru_cache(maxsize=1)
+def _client() -> Any:
+    """Shared S3 client. Call only from the event loop thread: botocore client construction is
+    not thread-safe, while calls on a built client are."""
+    return _boto3.client(
+        "s3",
+        endpoint_url=settings.TIGRIS_ENDPOINT_URL,
+        region_name=settings.TIGRIS_REGION,
+        aws_access_key_id=settings.TIGRIS_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.TIGRIS_SECRET_ACCESS_KEY,
+        # Tigris only serves virtual-hosted-style addressing (bucket.t3.storage.dev).
+        config=_config(
+            s3={"addressing_style": "virtual"},
+            connect_timeout=S3_TIMEOUT,
+            read_timeout=S3_TIMEOUT,
+        ),
+    )
+
+
+async def _object_exists(key: str) -> bool:
+    client = _client()
+
+    def head() -> bool:
+        try:
+            client.head_object(Bucket=settings.TIGRIS_BUCKET, Key=key)
+        except ClientError as e:
+            response: Any = e.response
+            if response.get("ResponseMetadata", {}).get("HTTPStatusCode") == 404:
+                return False
+            raise
+        return True
+
+    return await asyncio.to_thread(head)
+
+
+async def _put_object(key: str, body: bytes, content_type: str) -> None:
+    client = _client()
+
+    def put() -> None:
+        client.put_object(
+            Bucket=settings.TIGRIS_BUCKET, Key=key, Body=body, ContentType=content_type
+        )
+
+    await asyncio.to_thread(put)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "async-lru>=2.0",
   "geoip2>=5.2.0",
   "daytona>=0.183.0",
+  "boto3>=1.35",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -337,6 +337,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.62"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/c7/f7732c5e1abf7270a6bbbce47338d25ea66a30df658cffd1d17bb5f735fb/boto3-1.43.62.tar.gz", hash = "sha256:0bf920e0739346e81c7310b685a3f783bf1fcc62ce7d5c7016508fa25c0d261f", size = 112668, upload-time = "2026-07-31T19:35:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/5e1a392c817e395b140c18c12a00c0c65c69f8d63da26ad4387aebf2172b/boto3-1.43.62-py3-none-any.whl", hash = "sha256:0bb298e7ffd72b91615df44bf71c417df80a29d844971e5d665b8bd743a4bb35", size = 140025, upload-time = "2026-07-31T19:35:15.347Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.62"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8d/36af6d99269a701f83809b87a01f4728699eb825ebdedee3a3d515b18f61/botocore-1.43.62.tar.gz", hash = "sha256:94efc419c9f0f41dc2415e4b6b62f04ae21b3ce3930fac47214c4d3f361ea8b8", size = 15818261, upload-time = "2026-07-31T19:35:06.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/65/d5dae96de68ffc55acf87c3bae76e9dabeeca92aadf1223f20e9a7860aef/botocore-1.43.62-py3-none-any.whl", hash = "sha256:76de153de1ba3e242b2e6df6a13ab8a3fb35d17db562462969e661457b63166e", size = 15502622, upload-time = "2026-07-31T19:35:02.697Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "6.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1205,6 +1233,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -2428,6 +2465,7 @@ dependencies = [
     { name = "aiofiles" },
     { name = "async-lru" },
     { name = "beautifulsoup4" },
+    { name = "boto3" },
     { name = "daytona" },
     { name = "fastapi" },
     { name = "fastmcp" },
@@ -2474,6 +2512,7 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "async-lru", specifier = ">=2.0" },
     { name = "beautifulsoup4", specifier = ">=4.13.4" },
+    { name = "boto3", specifier = ">=1.35" },
     { name = "daytona", specifier = ">=0.183.0" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.183.0" },
     { name = "fastapi", specifier = ">=0.115.12" },
@@ -2690,6 +2729,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4b/75/abbc7eab08bad7f47887a0555d3ac9e3947f89d2416678c08e025e449fdc/ruyaml-0.91.0.tar.gz", hash = "sha256:6ce9de9f4d082d696d3bde264664d1bcdca8f5a9dff9d1a1f1a127969ab871ab", size = 239075, upload-time = "2021-12-07T16:19:58.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/9a/16ca152a04b231c179c626de40af1d5d0bc2bc57bc875c397706016ddb2b/ruyaml-0.91.0-py3-none-any.whl", hash = "sha256:50e0ee3389c77ad340e209472e0effd41ae0275246df00cdad0a067532171755", size = 108906, upload-time = "2021-12-07T16:19:56.798Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Pulls browser session recordings off Chrome Fleet and stores them in Tigris (S3-compatible) object storage.

## Testing

<img width="1699" height="319" alt="image" src="https://github.com/user-attachments/assets/d7ca3e68-0c87-4601-a606-c2651656de79" />

https://github.com/user-attachments/assets/98c44adb-4909-49ea-98c7-54430f8dc262


https://github.com/user-attachments/assets/01d92a6f-8508-43ba-9082-0053c2565212


