### PR TITLE
feat(amazon): support deployed mock origin

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,6 +3,9 @@ ENVIRONMENT=local
 PORT=23456
 DATA_DIR=
 
+# Optional deployed Amazon US mock origin. Leave empty to use https://www.amazon.com.
+AMAZON_BASE_URL=
+
 # Local browser backend: "podman" (local containers, default) or "daytona" (on-demand sandboxes).
 # Ignored when CHROMEFLEET_URL is set (requests are proxied to the external Chrome Fleet).
 BROWSER_BACKEND=podman

--- a/README.md
+++ b/README.md
@@ -73,6 +73,28 @@ Follow the MCP install [guide](https://code.visualstudio.com/docs/copilot/chat/m
 
 </details>
 
+### Local mock Amazon
+
+The Amazon US connector can target a deployed instance of the deterministic `apps/mock-amazon`
+app from the [`corelens-engineering/demos` repository](https://github.com/corelens-engineering/demos)
+instead of the real site. Set its browser-reachable origin before starting Remote Browser:
+
+```bash
+AMAZON_BASE_URL=https://your-deployed-mock-amazon.example.com
+```
+
+The override applies to Amazon US only, including its Prime Video pagination APIs. Amazon Canada
+and an unset configuration continue to use the real sites.
+
+With both servers running, exercise all eleven Amazon US MCP tools with:
+
+```bash
+uv run pytest tests/mcp/test_amazon.py -s -p no:xdist
+```
+
+The test signs in with `joe@example.com` / `trustno1`. It is skipped when `AMAZON_BASE_URL` is
+unset, so the normal MCP suite does not require a deployed mock.
+
 ## API
 
 ### Start a new browser

--- a/getgather/config.py
+++ b/getgather/config.py
@@ -18,6 +18,9 @@ class Settings(BrowserSettings, BaseSettings):
 
     DATA_DIR: str = ""
 
+    # Optional Amazon US origin override for local deterministic mocks.
+    AMAZON_BASE_URL: str = ""
+
     # Logging
     LOG_LEVEL: str = "INFO"
     SENTRY_DSN: str = ""

--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -9,6 +9,7 @@ import zendriver as zd
 from loguru import logger
 
 from getgather.browser import get_url, page_query_selector, zen_navigate_with_retry
+from getgather.config import settings
 from getgather.mcp.dpage import (
     remote_zen_dpage_mcp_tool,
     remote_zen_dpage_with_action,
@@ -26,6 +27,7 @@ class AmazonCountry:
     """Configuration for an Amazon country domain."""
 
     domain: str
+    origin: str
     purchase_history_key: str
     watch_history_result_key: str
     watchlist_result_key: str
@@ -39,29 +41,36 @@ class AmazonCountry:
 
     @property
     def base_url(self) -> str:
-        return f"https://www.{self.domain}"
+        return self.origin.rstrip("/")
 
     @property
     def signin_url(self) -> str:
         return f"{self.base_url}/ax/account/manage"
 
 
-AMAZON_US = AmazonCountry(
-    domain="amazon.com",
-    purchase_history_key="amazon_purchase_history",
-    watch_history_result_key="amazon_watch_history",
-    watchlist_result_key="amazon_prime_watchlist",
-    prime_library_result_key="amazon_prime_library",
-    watch_history_url="https://www.amazon.com/gp/video/settings/watch-history",
-    watchlist_url="https://www.amazon.com/gp/video/mystuff/watchlist",
-    prime_library_url="https://www.amazon.com/gp/video/mystuff/library",
-    browsing_history_url="https://www.amazon.com/gp/history?ref_=nav_AccountFlyout_browsinghistory",
-    watchlist_pagination_api_url="https://www.amazon.com/gp/video/api/paginateCollection",
-    watch_history_pagination_api_url="https://www.amazon.com/gp/video/api/getWatchHistorySettingsPage",
-)
+def create_amazon_us(base_url: str = "") -> AmazonCountry:
+    origin = (base_url or "https://www.amazon.com").rstrip("/")
+    return AmazonCountry(
+        domain="amazon.com",
+        origin=origin,
+        purchase_history_key="amazon_purchase_history",
+        watch_history_result_key="amazon_watch_history",
+        watchlist_result_key="amazon_prime_watchlist",
+        prime_library_result_key="amazon_prime_library",
+        watch_history_url=f"{origin}/gp/video/settings/watch-history",
+        watchlist_url=f"{origin}/gp/video/mystuff/watchlist",
+        prime_library_url=f"{origin}/gp/video/mystuff/library",
+        browsing_history_url=f"{origin}/gp/history?ref_=nav_AccountFlyout_browsinghistory",
+        watchlist_pagination_api_url=f"{origin}/gp/video/api/paginateCollection",
+        watch_history_pagination_api_url=(f"{origin}/gp/video/api/getWatchHistorySettingsPage"),
+    )
+
+
+AMAZON_US = create_amazon_us(settings.AMAZON_BASE_URL)
 
 AMAZON_CA = AmazonCountry(
     domain="amazon.ca",
+    origin="https://www.amazon.ca",
     purchase_history_key="amazonca_purchase_history",
     watch_history_result_key="amazon_ca_watch_history",
     watchlist_result_key="amazon_ca_prime_watchlist",
@@ -822,7 +831,7 @@ async def _get_watch_history_with_pagination(
                         "headers": {{
                             "accept": "*/*",
                             "x-amzn-requestid": requestId,
-                            "Referer": "https://www.amazon.com/gp/video/settings/watch-history",
+                            "Referer": "{country.watch_history_url}",
                             "x-requested-with": "XMLHttpRequest"
                         }},
                         "body": null,

--- a/tests/mcp/test_amazon.py
+++ b/tests/mcp/test_amazon.py
@@ -1,0 +1,108 @@
+import json
+from typing import Any, cast
+
+import httpx
+import pytest
+from fastmcp import Client
+from mcp.types import TextContent
+
+from getgather.config import settings
+
+pytestmark = [
+    pytest.mark.mcp,
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        not settings.AMAZON_BASE_URL,
+        reason="Set AMAZON_BASE_URL to run the local mock Amazon MCP test",
+    ),
+]
+
+
+async def _call_json(
+    client: Client[Any], tool_name: str, arguments: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    result = await client.call_tool(tool_name, arguments or {})
+    assert result.content
+    assert isinstance(result.content[0], TextContent)
+    parsed = cast(object, json.loads(result.content[0].text))
+    assert isinstance(parsed, dict)
+    return cast(dict[str, Any], parsed)
+
+
+async def _complete_mock_signin(signin_url: str) -> None:
+    async with httpx.AsyncClient(follow_redirects=True, timeout=30) as browser:
+        signin_page = await browser.get(signin_url)
+        signin_page.raise_for_status()
+        assert 'name="email"' in signin_page.text
+        assert 'name="password"' in signin_page.text
+
+        completed = await browser.post(
+            signin_url,
+            data={"email": "joe@example.com", "password": "trustno1"},
+        )
+        completed.raise_for_status()
+        assert "Finished!" in completed.text
+
+
+async def test_amazon_mock_exercises_all_us_tools(mcp_config: dict[str, Any]) -> None:
+    mock_health_url = settings.AMAZON_BASE_URL.rstrip("/")
+    try:
+        async with httpx.AsyncClient(timeout=3) as health_client:
+            health = await health_client.get(f"{mock_health_url}/health")
+            health.raise_for_status()
+    except httpx.HTTPError as error:
+        pytest.fail(
+            f"Mock Amazon is not healthy at {mock_health_url}; "
+            f"start apps/mock-amazon first: {error}"
+        )
+
+    async with Client(mcp_config, timeout=180) as client:
+        first_signin = await _call_json(client, "amazon_signin")
+        assert isinstance(first_signin.get("url"), str)
+        assert isinstance(first_signin.get("signin_id"), str)
+
+        await _complete_mock_signin(first_signin["url"])
+
+        checked = await _call_json(
+            client,
+            "check_signin",
+            {"signin_id": first_signin["signin_id"]},
+        )
+        assert checked.get("status") == "SUCCESS"
+        assert checked.get("completed") is True
+
+        list_cases: list[tuple[str, dict[str, Any], str]] = [
+            ("amazon_signin", {}, "signin"),
+            ("amazon_get_purchase_history", {}, "amazon_purchase_history"),
+            (
+                "amazon_get_purchase_history_with_details",
+                {},
+                "amazon_purchase_history",
+            ),
+            ("amazon_search_purchase_history", {"keyword": ""}, "order_history"),
+            ("amazon_search_product", {"keyword": ""}, "product_list"),
+            ("amazon_get_browsing_history", {}, "browsing_history_data"),
+            ("amazon_get_watch_history", {}, "amazon_watch_history"),
+            ("amazon_get_watchlist", {}, "amazon_prime_watchlist"),
+            ("amazon_get_prime_library", {}, "amazon_prime_library"),
+        ]
+        for tool_name, arguments, result_key in list_cases:
+            payload = await _call_json(client, tool_name, arguments)
+            assert result_key in payload, f"{tool_name} did not return {result_key}"
+            assert isinstance(payload[result_key], list)
+            assert payload[result_key], f"{tool_name} returned an empty fixture"
+
+        watchlist_page = await _call_json(
+            client,
+            "amazon_get_watchlist_with_pagination",
+            {"start_index": 0},
+        )
+        assert isinstance(watchlist_page.get("amazon_prime_watchlist"), dict)
+        assert watchlist_page["amazon_prime_watchlist"].get("items")
+
+        watch_history_page = await _call_json(
+            client,
+            "amazon_get_watch_history_with_pagination",
+        )
+        assert isinstance(watch_history_page.get("amazon_watch_history"), dict)
+        assert watch_history_page["amazon_watch_history"].get("watchHistory")

--- a/tests/test_amazon.py
+++ b/tests/test_amazon.py
@@ -1,0 +1,38 @@
+from getgather.mcp.amazon import AMAZON_CA, create_amazon_us
+
+
+def test_amazon_us_uses_production_origin_by_default() -> None:
+    country = create_amazon_us()
+
+    assert country.base_url == "https://www.amazon.com"
+    assert country.signin_url == "https://www.amazon.com/ax/account/manage"
+    assert country.watch_history_url == ("https://www.amazon.com/gp/video/settings/watch-history")
+    assert country.watchlist_pagination_api_url == (
+        "https://www.amazon.com/gp/video/api/paginateCollection"
+    )
+    assert country.watch_history_pagination_api_url == (
+        "https://www.amazon.com/gp/video/api/getWatchHistorySettingsPage"
+    )
+
+
+def test_amazon_us_override_rewrites_every_absolute_origin() -> None:
+    origin = "https://deployed-mock-amazon.example.com"
+    country = create_amazon_us(f"{origin}/")
+
+    assert country.base_url == origin
+    assert country.signin_url == f"{origin}/ax/account/manage"
+    assert country.watch_history_url == f"{origin}/gp/video/settings/watch-history"
+    assert country.watchlist_url == f"{origin}/gp/video/mystuff/watchlist"
+    assert country.prime_library_url == f"{origin}/gp/video/mystuff/library"
+    assert country.browsing_history_url == (
+        f"{origin}/gp/history?ref_=nav_AccountFlyout_browsinghistory"
+    )
+    assert country.watchlist_pagination_api_url == (f"{origin}/gp/video/api/paginateCollection")
+    assert country.watch_history_pagination_api_url == (
+        f"{origin}/gp/video/api/getWatchHistorySettingsPage"
+    )
+
+
+def test_amazon_canada_is_not_affected_by_us_override() -> None:
+    assert AMAZON_CA.base_url == "https://www.amazon.ca"
+    assert AMAZON_CA.watch_history_url.startswith("https://www.primevideo.com/")


### PR DESCRIPTION
## Summary

- add an opt-in `AMAZON_BASE_URL` setting for the deployed mock Amazon app from corelens-engineering/demos#1244
- route every Amazon US page and pagination API through the configured origin while leaving Amazon Canada unchanged
- add unit coverage and an opt-in MCP test for all 11 Amazon US tools
- document deployed-mock setup and credentials

## Testing

- `uv run ruff check getgather/config.py getgather/mcp/amazon.py tests/test_amazon.py tests/mcp/test_amazon.py`
- `uv run ruff format --check getgather/config.py getgather/mcp/amazon.py tests/test_amazon.py tests/mcp/test_amazon.py`
- `uv run pytest tests/test_amazon.py tests/mcp/test_amazon.py -q` (3 passed, deployed mock test skipped while unset)
- `uv run pyright getgather/config.py getgather/mcp/amazon.py tests/test_amazon.py tests/mcp/test_amazon.py`
- `npx --yes prettier --check README.md`

## Dependency

The opt-in end-to-end test requires a deployed instance of the mock Amazon app introduced by corelens-engineering/demos#1244 and `AMAZON_BASE_URL` set before Remote Browser starts.