### PR TITLE
feat(amazon): add optional base_url to the US MCP tools

### DIFF
--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -1,12 +1,14 @@
 import asyncio
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import Any, cast
+from typing import Annotated, Any, cast
+from urllib.parse import urlsplit, urlunsplit
 
 import zendriver as zd
 from loguru import logger
+from pydantic import Field
 
 from getgather.browser import get_url, page_query_selector, zen_navigate_with_retry
 from getgather.mcp.dpage import (
@@ -21,11 +23,30 @@ from getgather.zen_distill import (
 )
 
 
+def _normalize_origin(base_url: str) -> str:
+    """Validate a caller-supplied origin and strip any trailing slash."""
+    parts = urlsplit(base_url.strip())
+    if parts.scheme not in ("http", "https"):
+        raise ValueError(f"base_url must start with http:// or https://, got {base_url!r}")
+    if not parts.hostname:
+        raise ValueError(f"base_url must include a hostname, got {base_url!r}")
+    if parts.path not in ("", "/") or parts.query or parts.fragment:
+        raise ValueError(f"base_url must be an origin with no path or query, got {base_url!r}")
+    return urlunsplit((parts.scheme, parts.netloc, "", "", ""))
+
+
+def _rebase_url(url: str, origin: str) -> str:
+    """Repoint an absolute URL at `origin`, keeping its path, query and fragment."""
+    target = urlsplit(origin)
+    parts = urlsplit(url)
+    return urlunsplit((target.scheme, target.netloc, parts.path, parts.query, parts.fragment))
+
+
 @dataclass(frozen=True)
 class AmazonCountry:
     """Configuration for an Amazon country domain."""
 
-    domain: str
+    base_url: str
     purchase_history_key: str
     watch_history_result_key: str
     watchlist_result_key: str
@@ -38,16 +59,32 @@ class AmazonCountry:
     watch_history_pagination_api_url: str
 
     @property
-    def base_url(self) -> str:
-        return f"https://www.{self.domain}"
-
-    @property
     def signin_url(self) -> str:
         return f"{self.base_url}/ax/account/manage"
 
+    def with_base_url(self, base_url: str) -> "AmazonCountry":
+        """Return a copy with every absolute URL repointed at `base_url`.
+
+        The video URLs are rebased individually rather than derived from `base_url`, since
+        Amazon CA serves them from a different origin than its storefront.
+        """
+        origin = _normalize_origin(base_url)
+        return replace(
+            self,
+            base_url=origin,
+            watch_history_url=_rebase_url(self.watch_history_url, origin),
+            watchlist_url=_rebase_url(self.watchlist_url, origin),
+            prime_library_url=_rebase_url(self.prime_library_url, origin),
+            browsing_history_url=_rebase_url(self.browsing_history_url, origin),
+            watchlist_pagination_api_url=_rebase_url(self.watchlist_pagination_api_url, origin),
+            watch_history_pagination_api_url=_rebase_url(
+                self.watch_history_pagination_api_url, origin
+            ),
+        )
+
 
 AMAZON_US = AmazonCountry(
-    domain="amazon.com",
+    base_url="https://www.amazon.com",
     purchase_history_key="amazon_purchase_history",
     watch_history_result_key="amazon_watch_history",
     watchlist_result_key="amazon_prime_watchlist",
@@ -61,7 +98,7 @@ AMAZON_US = AmazonCountry(
 )
 
 AMAZON_CA = AmazonCountry(
-    domain="amazon.ca",
+    base_url="https://www.amazon.ca",
     purchase_history_key="amazonca_purchase_history",
     watch_history_result_key="amazon_ca_watch_history",
     watchlist_result_key="amazon_ca_prime_watchlist",
@@ -822,7 +859,7 @@ async def _get_watch_history_with_pagination(
                         "headers": {{
                             "accept": "*/*",
                             "x-amzn-requestid": requestId,
-                            "Referer": "https://www.amazon.com/gp/video/settings/watch-history",
+                            "Referer": "{country.watch_history_url}",
                             "x-requested-with": "XMLHttpRequest"
                         }},
                         "body": null,
@@ -854,76 +891,104 @@ amazon_us_mcp = MCPTool(brand_id="amazon", name="Amazon MCP")
 amazon_ca_mcp = MCPTool(brand_id="amazonca", name="Amazon CA MCP")
 
 
+BaseUrlParam = Annotated[
+    str | None,
+    Field(
+        description=(
+            "Testing only: alternate origin to use instead of https://www.amazon.com."
+            " Omit for real Amazon data."
+        )
+    ),
+]
+
+
+def us_config(base_url: str | None) -> AmazonCountry:
+    """Resolve the Amazon US config, optionally repointed at an alternate origin.
+
+    Amazon CA is intentionally not overridable.
+    """
+    return AMAZON_US if base_url is None else AMAZON_US.with_base_url(base_url)
+
+
 @amazon_us_mcp.tool("search_purchase_history")
-async def amazon_us_search_purchase_history(keyword: str, page_number: int = 1) -> dict[str, Any]:
+async def amazon_us_search_purchase_history(
+    keyword: str, page_number: int = 1, base_url: BaseUrlParam = None
+) -> dict[str, Any]:
     """Search purchase history from amazon."""
-    return await _search_purchase_history(AMAZON_US, keyword, page_number)
+    return await _search_purchase_history(us_config(base_url), keyword, page_number)
 
 
 @amazon_us_mcp.tool("get_purchase_history")
 async def amazon_us_get_purchase_history(
-    year: str | int | None = None, start_index: int = 0
+    year: str | int | None = None, start_index: int = 0, base_url: BaseUrlParam = None
 ) -> dict[str, Any]:
     """Get purchase/order history of a amazon with dpage."""
-    return await _get_purchase_history(AMAZON_US, year, start_index)
+    return await _get_purchase_history(us_config(base_url), year, start_index)
 
 
 @amazon_us_mcp.tool("search_product")
-async def amazon_us_search_product(keyword: str) -> dict[str, Any]:
+async def amazon_us_search_product(keyword: str, base_url: BaseUrlParam = None) -> dict[str, Any]:
     """Search product on amazon."""
-    return await _search_product(AMAZON_US, keyword)
+    return await _search_product(us_config(base_url), keyword)
 
 
 @amazon_us_mcp.tool("get_browsing_history")
-async def amazon_us_get_browsing_history() -> dict[str, Any]:
+async def amazon_us_get_browsing_history(base_url: BaseUrlParam = None) -> dict[str, Any]:
     """Get browsing history from amazon."""
-    return await _get_browsing_history(AMAZON_US)
+    return await _get_browsing_history(us_config(base_url))
 
 
 @amazon_us_mcp.tool("get_purchase_history_with_details")
 async def amazon_us_get_purchase_history_with_details(
-    year: str | int | None = None, start_index: int = 0, timeFilter: str | None = None
+    year: str | int | None = None,
+    start_index: int = 0,
+    timeFilter: str | None = None,
+    base_url: BaseUrlParam = None,
 ) -> dict[str, Any]:
     """Get purchase/order history of a amazon with dpage."""
-    return await _get_purchase_history_with_details(AMAZON_US, year, start_index, timeFilter)
+    return await _get_purchase_history_with_details(
+        us_config(base_url), year, start_index, timeFilter
+    )
 
 
 @amazon_us_mcp.tool("signin")
-async def amazon_us_signin() -> dict[str, Any]:
+async def amazon_us_signin(base_url: BaseUrlParam = None) -> dict[str, Any]:
     """Signin to amazon."""
-    return await _signin(AMAZON_US)
+    return await _signin(us_config(base_url))
 
 
 @amazon_us_mcp.tool("get_watch_history")
-async def amazon_us_get_watch_history() -> dict[str, Any]:
+async def amazon_us_get_watch_history(base_url: BaseUrlParam = None) -> dict[str, Any]:
     """Get video watch history from Amazon."""
-    return await _get_watch_history(AMAZON_US)
+    return await _get_watch_history(us_config(base_url))
 
 
 @amazon_us_mcp.tool("get_watchlist")
-async def amazon_us_get_watchlist() -> dict[str, Any]:
+async def amazon_us_get_watchlist(base_url: BaseUrlParam = None) -> dict[str, Any]:
     """Get Prime Video watchlist from Amazon."""
-    return await _get_watchlist(AMAZON_US)
+    return await _get_watchlist(us_config(base_url))
 
 
 @amazon_us_mcp.tool("get_prime_library")
-async def amazon_us_get_prime_library() -> dict[str, Any]:
+async def amazon_us_get_prime_library(base_url: BaseUrlParam = None) -> dict[str, Any]:
     """Get Prime Video purchases and rentals library from Amazon."""
-    return await _get_prime_library(AMAZON_US)
+    return await _get_prime_library(us_config(base_url))
 
 
 @amazon_us_mcp.tool("get_watchlist_with_pagination")
-async def amazon_us_get_watchlist_with_pagination(start_index: int = 0) -> dict[str, Any]:
+async def amazon_us_get_watchlist_with_pagination(
+    start_index: int = 0, base_url: BaseUrlParam = None
+) -> dict[str, Any]:
     """Get Prime Video watchlist from Amazon US with pagination."""
-    return await _get_watchlist_with_pagination(AMAZON_US, start_index)
+    return await _get_watchlist_with_pagination(us_config(base_url), start_index)
 
 
 @amazon_us_mcp.tool("get_watch_history_with_pagination")
 async def amazon_us_get_watch_history_with_pagination(
-    nextToken: str | None = None,
+    nextToken: str | None = None, base_url: BaseUrlParam = None
 ) -> dict[str, Any]:
-    """Get Prime Video watchlist from Amazon US with pagination."""
-    return await _get_watch_history_with_pagination(AMAZON_US, nextToken)
+    """Get video watch history from Amazon US with pagination."""
+    return await _get_watch_history_with_pagination(us_config(base_url), nextToken)
 
 
 @amazon_ca_mcp.tool("search_purchase_history")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,42 @@ import pytest
 from pytest import MonkeyPatch
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Runtime inputs for tests that take no configuration from the environment."""
+    parser.addoption(
+        "--amazon-base-url",
+        default="",
+        help=(
+            "Alternate origin for the Amazon US tools; enables tests/mcp/test_amazon_alt_origin.py."
+        ),
+    )
+    parser.addoption("--amazon-email", default="", help="Sign-in email for --amazon-base-url.")
+    parser.addoption(
+        "--amazon-password", default="", help="Sign-in password for --amazon-base-url."
+    )
+
+
+def _required_option(request: pytest.FixtureRequest, name: str) -> str:
+    value = str(request.config.getoption(name))
+    if not value:
+        # `pytest.skip()` itself is a callable protocol that `ty` cannot resolve.
+        raise pytest.skip.Exception(f"pass {name}=<value> to run against an alternate origin")
+    return value
+
+
+@pytest.fixture
+def amazon_base_url(request: pytest.FixtureRequest) -> str:
+    return _required_option(request, "--amazon-base-url")
+
+
+@pytest.fixture
+def amazon_credentials(request: pytest.FixtureRequest) -> tuple[str, str]:
+    return (
+        _required_option(request, "--amazon-email"),
+        _required_option(request, "--amazon-password"),
+    )
+
+
 @pytest.fixture
 def temp_project_dir(monkeypatch: MonkeyPatch) -> Generator[Path, None, None]:
     """Create a temporary directory for testing."""

--- a/tests/mcp/test_amazon_alt_origin.py
+++ b/tests/mcp/test_amazon_alt_origin.py
@@ -1,0 +1,94 @@
+"""Exercise the Amazon US tools against an alternate origin via their runtime `base_url` parameter.
+
+Needs a running server and a reachable stand-in for Amazon; skips without `--amazon-base-url`.
+"""
+
+import json
+from typing import Any, cast
+
+import pytest
+import zendriver as zd
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+from mcp.types import TextContent
+
+# (tool name, arguments besides base_url, key the payload must carry)
+DATA_TOOLS: list[tuple[str, dict[str, Any], str]] = [
+    ("amazon_search_purchase_history", {"keyword": ""}, "order_history"),
+    ("amazon_get_purchase_history", {}, "amazon_purchase_history"),
+    ("amazon_get_purchase_history_with_details", {}, "amazon_purchase_history"),
+    ("amazon_search_product", {"keyword": ""}, "product_list"),
+    ("amazon_get_browsing_history", {}, "browsing_history_data"),
+    ("amazon_get_watch_history", {}, "amazon_watch_history"),
+    ("amazon_get_watchlist", {}, "amazon_prime_watchlist"),
+    ("amazon_get_prime_library", {}, "amazon_prime_library"),
+    ("amazon_get_watchlist_with_pagination", {"start_index": 0}, "amazon_prime_watchlist"),
+    ("amazon_get_watch_history_with_pagination", {}, "amazon_watch_history"),
+]
+
+
+async def _call_json(client: Client[Any], tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    result = await client.call_tool(tool, arguments)
+    assert result.content, f"{tool} returned no content"
+    assert isinstance(result.content[0], TextContent), (
+        f"Expected TextContent from {tool}, got {type(result.content[0])}"
+    )
+    parsed: object = json.loads(result.content[0].text)
+    assert isinstance(parsed, dict), f"Expected a JSON object from {tool}, got {type(parsed)}"
+    return cast(dict[str, Any], parsed)
+
+
+async def _sign_in(signin_url: str, email: str, password: str) -> None:
+    browser = await zd.start(no_sandbox=True, headless=True)
+    try:
+        page = await browser.get(signin_url)
+        email_input = await page.wait_for("input[name=email]")
+        await email_input.send_keys(email)
+        password_input = await page.wait_for("input[name=password]")
+        await password_input.send_keys(password)
+        submit = await page.select("button[type='submit']")
+        await submit.click()
+        await page.wait_for(text="Finished!", timeout=30)
+    finally:
+        await browser.stop()
+
+
+@pytest.mark.mcp
+@pytest.mark.asyncio
+async def test_amazon_us_tools_against_an_alternate_origin(
+    mcp_config: dict[str, Any],
+    amazon_base_url: str,
+    amazon_credentials: tuple[str, str],
+) -> None:
+    """All eleven Amazon US tools work when repointed at another origin at runtime.
+
+    One client session means one `mcp-session-id`, so a single browser and cookie jar is
+    shared across every call.
+    """
+    email, password = amazon_credentials
+
+    async with Client(mcp_config, timeout=180) as client:
+        signin = await _call_json(client, "amazon_signin", {"base_url": amazon_base_url})
+        if signin.get("signin_id"):
+            await _sign_in(str(signin["url"]), email, password)
+            checked = await _call_json(client, "check_signin", {"signin_id": signin["signin_id"]})
+            assert checked.get("status") == "SUCCESS", checked
+
+        for tool, arguments, result_key in DATA_TOOLS:
+            payload = await _call_json(client, tool, {**arguments, "base_url": amazon_base_url})
+            # A signin_id here means the override dropped the session, or the call reached
+            # real Amazon rather than the alternate origin.
+            assert "signin_id" not in payload, f"{tool} asked to sign in again: {payload}"
+            assert result_key in payload, f"{tool} did not return {result_key}: {payload}"
+            assert payload[result_key], f"{tool} returned an empty {result_key}"
+
+
+@pytest.mark.mcp
+@pytest.mark.asyncio
+async def test_invalid_base_url_is_rejected(mcp_config: dict[str, Any]) -> None:
+    """The validation message survives the FastMCP boundary. Needs no alternate site."""
+    async with Client(mcp_config, timeout=30) as client:
+        with pytest.raises(ToolError, match="base_url"):
+            await client.call_tool(
+                "amazon_search_product", {"keyword": "book", "base_url": "not-an-origin"}
+            )

--- a/tests/test_amazon.py
+++ b/tests/test_amazon.py
@@ -1,0 +1,88 @@
+from dataclasses import fields
+
+import pytest
+
+from getgather.mcp.amazon import AMAZON_CA, AMAZON_US, us_config
+
+ALT = "https://amazon-test.example.com"
+
+
+def test_every_absolute_url_is_rebased() -> None:
+    """Guards `with_base_url` against a URL field being added and forgotten."""
+    rebased = AMAZON_US.with_base_url(ALT)
+
+    rebased_urls = 0
+    for field in fields(rebased):
+        value = getattr(rebased, field.name)
+        if isinstance(value, str) and value.startswith("http"):
+            assert value.startswith(ALT), f"{field.name} was not rebased: {value}"
+            rebased_urls += 1
+
+    assert rebased_urls == 7
+
+
+def test_rebasing_preserves_path_and_query() -> None:
+    rebased = AMAZON_US.with_base_url(ALT)
+
+    assert rebased.signin_url == f"{ALT}/ax/account/manage"
+    assert rebased.browsing_history_url == (
+        f"{ALT}/gp/history?ref_=nav_AccountFlyout_browsinghistory"
+    )
+    assert rebased.watch_history_url == f"{ALT}/gp/video/settings/watch-history"
+    assert rebased.watchlist_url == f"{ALT}/gp/video/mystuff/watchlist"
+    assert rebased.prime_library_url == f"{ALT}/gp/video/mystuff/library"
+    assert rebased.watchlist_pagination_api_url == f"{ALT}/gp/video/api/paginateCollection"
+    assert rebased.watch_history_pagination_api_url == (
+        f"{ALT}/gp/video/api/getWatchHistorySettingsPage"
+    )
+
+
+@pytest.mark.parametrize(
+    ("supplied", "expected"),
+    [
+        (ALT, ALT),
+        (f"{ALT}/", ALT),
+        (f"  {ALT}  ", ALT),
+        ("http://localhost:3000", "http://localhost:3000"),
+        ("http://localhost:3000/", "http://localhost:3000"),
+    ],
+)
+def test_origin_is_normalized(supplied: str, expected: str) -> None:
+    assert AMAZON_US.with_base_url(supplied).base_url == expected
+
+
+@pytest.mark.parametrize(
+    "supplied",
+    [
+        "",
+        "   ",
+        "amazon-test.example.com",
+        "ftp://amazon-test.example.com",
+        "javascript:alert(1)",
+        "https://",
+        "https://amazon-test.example.com/prefix",
+        "https://amazon-test.example.com?a=1",
+        "https://amazon-test.example.com#frag",
+    ],
+)
+def test_invalid_origin_is_rejected(supplied: str) -> None:
+    with pytest.raises(ValueError, match="base_url"):
+        AMAZON_US.with_base_url(supplied)
+
+
+def test_override_does_not_leak_into_the_shared_config() -> None:
+    AMAZON_US.with_base_url(ALT)
+
+    assert AMAZON_US.base_url == "https://www.amazon.com"
+    assert AMAZON_US.watch_history_url == "https://www.amazon.com/gp/video/settings/watch-history"
+
+
+def test_rebasing_ca_collapses_both_of_its_origins() -> None:
+    rebased = AMAZON_CA.with_base_url(ALT)
+
+    assert rebased.browsing_history_url.startswith(ALT)  # was amazon.ca
+    assert rebased.watchlist_url == f"{ALT}/region/na/mystuff/watchlist"  # was primevideo.com
+
+
+def test_omitting_the_override_reuses_the_shared_config() -> None:
+    assert us_config(None) is AMAZON_US


### PR DESCRIPTION
Supersedes #1430. That PR pointed the Amazon US connector at a stand-in site with a deploy-time `AMAZON_BASE_URL` env var; @ariya asked for a runtime choice instead:

> Is it possible to do this via runtime choice instead of deployment flag? An example: an optional parameter in the Amazon MCP tools to supply the target domain.

## What changed

Each of the 11 Amazon US tools now takes an optional `base_url` — a full origin used instead of `https://www.amazon.com`. The choice is made per call. **There is no environment variable and no deployment setting anywhere**: omit `base_url` and the tools hit real Amazon exactly as before. Amazon CA is unchanged.

`base_url` is a full origin rather than a bare hostname so an `http://` site works.

`AmazonCountry.domain` becomes a `base_url` field — the old derived property was its only reader — plus `with_base_url()`, which rebases every absolute URL onto a new origin. The video URLs are rebased individually rather than derived from the base, since Amazon CA serves them from a different origin than its storefront.

## Testing

- `tests/test_amazon.py` — unit tests for the rebasing, including a reflection guard that fails if a future URL field is added and not rebased. No server, no configuration; runs in `make test`.
- `tests/mcp/test_amazon_alt_origin.py` — drives all 11 US tools through an alternate origin, gated on `--amazon-base-url`. Skips without the flag, so `-m mcp` is unaffected.

`make check` clean; `make test` 143 passed / 12 skipped. Verified by hand that the override applies, the default path is unchanged, CA is unaffected, and an invalid origin surfaces a legible `ToolError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)