### PR TITLE
feat(target): route in-store purchases through detail fetch for price data

### DIFF
--- a/getgather/mcp/target.py
+++ b/getgather/mcp/target.py
@@ -131,19 +131,15 @@ async def _get_purchases(
         "page_size": LIST_PAGE_SIZE,
     }
 
-    # STORE orders have no order_number and already embed full order_lines
-    # (tcin, description, images) in the list response, so no detail fetch needed.
-    if order_purchase_type == "STORE":
-        return {"target_purchases": orders, "pagination": pagination}
+    id_field = _ORDER_ID_FIELD[order_purchase_type]
+    identifiers = [o[id_field] for o in orders if id_field in o]
 
-    order_numbers = [o["order_number"] for o in orders if "order_number" in o]
-
-    if not order_numbers:
+    if not identifiers:
         return {"target_purchases": [], "pagination": pagination}
 
     try:
         details = await asyncio.wait_for(
-            _fetch_all_details(page, order_numbers, x_api_key), timeout=60.0
+            _fetch_all_details(page, order_purchase_type, identifiers, x_api_key), timeout=60.0
         )
     except asyncio.TimeoutError:
         logger.warning("Target: detail fetch timed out")

--- a/getgather/mcp/target.py
+++ b/getgather/mcp/target.py
@@ -51,14 +51,15 @@ async def _fetch_list_page(
 
 
 async def _fetch_all_details(
-    page: zd.Tab, order_numbers: list[str], x_api_key: str
+    page: zd.Tab, order_purchase_type: str, identifiers: list[str], x_api_key: str
 ) -> list[dict[str, Any]]:
-    numbers_json = json.dumps(order_numbers)
+    urls = [_detail_url(order_purchase_type, identifier) for identifier in identifiers]
+    urls_json = json.dumps(urls)
     js_code = f"""
         (async () => {{
-            const orderNumbers = {numbers_json};
-            const results = await Promise.all(orderNumbers.map(n =>
-                fetch('{_DETAIL_BASE}/' + n, {{
+            const urls = {urls_json};
+            const results = await Promise.all(urls.map(u =>
+                fetch(u, {{
                     credentials: 'include',
                     headers: {{
                         'accept': 'application/json',

--- a/getgather/mcp/target.py
+++ b/getgather/mcp/target.py
@@ -21,6 +21,14 @@ _LIST_URL = (
 )
 _DETAIL_BASE = f"{API_BASE}/post_orders/v1"
 
+_ORDER_ID_FIELD = {"ONLINE": "order_number", "STORE": "store_receipt_id"}
+
+
+def _detail_url(order_purchase_type: str, identifier: str) -> str:
+    if order_purchase_type == "STORE":
+        return f"{_DETAIL_BASE}/orders/{identifier}/store"
+    return f"{_DETAIL_BASE}/{identifier}"
+
 
 async def _fetch_list_page(
     page: zd.Tab, page_number: int, x_api_key: str, order_purchase_type: str

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -9,11 +9,20 @@ Pure-function tests only — no browser or live server involved.
 # resolves, since that module looks up MCPTool.registry["target"] at import.
 import asyncio
 from typing import Any
+from unittest.mock import AsyncMock
 
 from getgather.mcp import declarative_mcp
-from getgather.mcp.target import _DETAIL_BASE, _ORDER_ID_FIELD, _detail_url, _fetch_all_details
 
 assert "target" in declarative_mcp.MCPTool.registry
+
+import getgather.mcp.target as target_module  # noqa: E402
+from getgather.mcp.target import (  # noqa: E402
+    _DETAIL_BASE,  # pyright: ignore[reportPrivateUsage]
+    _ORDER_ID_FIELD,  # pyright: ignore[reportPrivateUsage]
+    _detail_url,  # pyright: ignore[reportPrivateUsage]
+    _fetch_all_details,  # pyright: ignore[reportPrivateUsage]
+    _get_purchases,  # pyright: ignore[reportPrivateUsage]
+)
 
 
 def test_online_detail_url_is_unchanged():
@@ -61,3 +70,61 @@ def test_fetch_all_details_builds_online_url_in_js():
     assert fake_page.last_js_code is not None
     assert "post_orders/v1/1234567890" in fake_page.last_js_code
     assert "/orders/" not in fake_page.last_js_code
+
+
+async def _run_get_purchases(
+    monkeypatch: Any, order_purchase_type: str, orders: list[dict[str, Any]]
+):
+    monkeypatch.setattr(target_module, "zen_navigate_with_retry", AsyncMock(return_value=None))
+
+    # ONLINE + page 1 reuses this intercepted page1 payload directly (see _get_purchases);
+    # every other case calls the mocked _fetch_list_page below instead.
+    intercept_page = _FakeTab({
+        "page1": {"orders": orders, "total_pages": 1},
+        "x_api_key": "test-api-key",
+    })
+
+    fetch_list_page_mock = AsyncMock(return_value={"orders": orders, "total_pages": 1})
+    monkeypatch.setattr(target_module, "_fetch_list_page", fetch_list_page_mock)
+
+    fetch_all_details_mock = AsyncMock(return_value=[{**o, "unit_price": "9.99"} for o in orders])
+    monkeypatch.setattr(target_module, "_fetch_all_details", fetch_all_details_mock)
+
+    result = await _get_purchases(intercept_page, 1, order_purchase_type)  # type: ignore[arg-type]
+    return result, fetch_all_details_mock
+
+
+def test_store_purchases_now_hit_detail_fetch(monkeypatch: Any):
+    orders = [{"store_receipt_id": "R1"}, {"store_receipt_id": "R2"}]
+    result, fetch_all_details_mock = asyncio.run(_run_get_purchases(monkeypatch, "STORE", orders))
+
+    # full replace: target_purchases comes from the detail fetch, not the raw list orders
+    assert result["target_purchases"] == [
+        {"store_receipt_id": "R1", "unit_price": "9.99"},
+        {"store_receipt_id": "R2", "unit_price": "9.99"},
+    ]
+    fetch_all_details_mock.assert_awaited_once()
+    call_args = fetch_all_details_mock.await_args
+    assert call_args is not None
+    _page, order_purchase_type, identifiers, _x_api_key = call_args.args
+    assert order_purchase_type == "STORE"
+    assert identifiers == ["R1", "R2"]
+
+
+def test_online_purchases_still_use_order_number(monkeypatch: Any):
+    orders = [{"order_number": "O1"}]
+    result, fetch_all_details_mock = asyncio.run(_run_get_purchases(monkeypatch, "ONLINE", orders))
+
+    assert result["target_purchases"] == [{"order_number": "O1", "unit_price": "9.99"}]
+    call_args = fetch_all_details_mock.await_args
+    assert call_args is not None
+    _page, order_purchase_type, identifiers, _x_api_key = call_args.args
+    assert order_purchase_type == "ONLINE"
+    assert identifiers == ["O1"]
+
+
+def test_store_with_no_orders_skips_detail_fetch(monkeypatch: Any):
+    result, fetch_all_details_mock = asyncio.run(_run_get_purchases(monkeypatch, "STORE", []))
+
+    assert result["target_purchases"] == []
+    fetch_all_details_mock.assert_not_awaited()

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,0 +1,27 @@
+"""Unit tests for Target purchase-detail URL/identifier resolution.
+
+Pure-function tests only — no browser or live server involved.
+"""
+
+# Importing declarative_mcp runs create_declarative_mcp_tools() at import time,
+# registering all brands (incl. target) and importing the target custom
+# module — which must happen before `from getgather.mcp.target import ...`
+# resolves, since that module looks up MCPTool.registry["target"] at import.
+from getgather.mcp import declarative_mcp
+from getgather.mcp.target import _DETAIL_BASE, _ORDER_ID_FIELD, _detail_url
+
+assert "target" in declarative_mcp.MCPTool.registry
+
+
+def test_online_detail_url_is_unchanged():
+    url = _detail_url("ONLINE", "1234567890")
+    assert url == f"{_DETAIL_BASE}/1234567890"
+
+
+def test_store_detail_url_has_orders_and_store_suffix():
+    url = _detail_url("STORE", "5228-0324-0172-6691")
+    assert url == f"{_DETAIL_BASE}/orders/5228-0324-0172-6691/store"
+
+
+def test_order_id_field_mapping():
+    assert _ORDER_ID_FIELD == {"ONLINE": "order_number", "STORE": "store_receipt_id"}

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -7,8 +7,11 @@ Pure-function tests only — no browser or live server involved.
 # registering all brands (incl. target) and importing the target custom
 # module — which must happen before `from getgather.mcp.target import ...`
 # resolves, since that module looks up MCPTool.registry["target"] at import.
+import asyncio
+from typing import Any
+
 from getgather.mcp import declarative_mcp
-from getgather.mcp.target import _DETAIL_BASE, _ORDER_ID_FIELD, _detail_url
+from getgather.mcp.target import _DETAIL_BASE, _ORDER_ID_FIELD, _detail_url, _fetch_all_details
 
 assert "target" in declarative_mcp.MCPTool.registry
 
@@ -25,3 +28,36 @@ def test_store_detail_url_has_orders_and_store_suffix():
 
 def test_order_id_field_mapping():
     assert _ORDER_ID_FIELD == {"ONLINE": "order_number", "STORE": "store_receipt_id"}
+
+
+class _FakeTab:
+    """Captures the JS handed to evaluate() and returns a canned result."""
+
+    def __init__(self, result: Any) -> None:
+        self.result = result
+        self.last_js_code: str | None = None
+
+    async def evaluate(self, js_code: str, return_by_value: bool = True) -> Any:
+        self.last_js_code = js_code
+        return self.result
+
+
+def test_fetch_all_details_builds_store_url_in_js():
+    fake_page = _FakeTab([{"store_receipt_id": "R1", "unit_price": "9.99"}])
+    result = asyncio.run(
+        _fetch_all_details(fake_page, "STORE", ["5228-0324-0172-6691"], "test-api-key")  # type: ignore[arg-type]
+    )
+    assert result == [{"store_receipt_id": "R1", "unit_price": "9.99"}]
+    assert fake_page.last_js_code is not None
+    assert "/orders/5228-0324-0172-6691/store" in fake_page.last_js_code
+
+
+def test_fetch_all_details_builds_online_url_in_js():
+    fake_page = _FakeTab([{"order_number": "O1"}])
+    result = asyncio.run(
+        _fetch_all_details(fake_page, "ONLINE", ["1234567890"], "test-api-key")  # type: ignore[arg-type]
+    )
+    assert result == [{"order_number": "O1"}]
+    assert fake_page.last_js_code is not None
+    assert "post_orders/v1/1234567890" in fake_page.last_js_code
+    assert "/orders/" not in fake_page.last_js_code


### PR DESCRIPTION
## Summary

- **`getgather/mcp/target.py`** — generalize detail-fetch URL builder to branch on `order_purchase_type`, add per-type identifier field lookup, route STORE purchases through detail fetch so unit price data is populated.
- **`tests/test_target.py`** — New: coverage for detail URL construction and STORE purchase flow.

## Demo

```json
{
  "target_purchases": [
    {
      "store_receipt_id": "5228-0324-0172-6691",
      "packages": [
        {
          "order_lines": [
            {
              "item": {
                "tcin": "81968633",
                "description": "Vive Organic Immunity Boost Original Ginger + Turmeric Shot, 4ct 2 fl oz",
                "unit_price": "3.49",
                "list_price": "3.49",
                "images": ["https://target.scene7.com/is/image/Target/GUEST_..."]
              },
              "quantity": 1
            }
          ]
        }
      ],
      "summary": {
        "subtotal": "3.49",
        "tax": "0.24",
        "grand_total": "3.73"
      },
      "payments": [
        { "type": "CREDIT_CARD", "amount": "3.73" }
      ],
      "addresses": [
        { "store_name": "Target Store #1234" }
      ]
    }
  ],
  "pagination": {
    "current_page": 1,
    "total_pages": 3,
    "page_size": 10
  }
}
```