### PR TITLE
fix(amazon): update orders JSON selectors for enhanced card layout

### DIFF
--- a/getgather/mcp/patterns/amazon-orders.json
+++ b/getgather/mcp/patterns/amazon-orders.json
@@ -19,18 +19,18 @@
     },
     {
       "name": "product_names",
-      "selector": "div.yohtmlc-product-title a",
+      "selector": "div.yohtmlc-product-title a, div.yo-enhanced-card div.yo-enhanced-title",
       "kind": "list"
     },
     {
       "name": "image_urls",
-      "selector": "div.product-image img, .item-view-left-col-inner img",
+      "selector": "div.product-image img, .item-view-left-col-inner img, div.yo-enhanced-card-image a img",
       "attribute": "src",
       "kind": "list"
     },
     {
       "name": "product_urls",
-      "selector": "div.yohtmlc-product-title a",
+      "selector": "div.yohtmlc-product-title a, div.yo-enhanced-card div.yo-enhanced-title a",
       "attribute": "href",
       "kind": "list"
     },


### PR DESCRIPTION
## Summary
- Update `amazon-orders.json` column selectors to match Amazon's revised order history HTML
- Add `yo-enhanced-card` selectors for product names, image URLs, and product URLs alongside the existing `yohtmlc` selectors

## Test plan
- [x] Call `amazon_get_purchase_history_with_details` against a signed-in Amazon account
- [x] Verify product names, images, and URLs are extracted from orders using the new enhanced card layout

Result:
[amazon-after.json](https://github.com/user-attachments/files/30821544/amazon-after.json)
