### PR TITLE
fix(browser): bump chromefleet GET timeout to 20s

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -214,7 +214,7 @@ def _setup_cdp_url(browser_id: str) -> str:
 
 
 async def get_remote_browser_cdp_url(browser_id: str) -> str:
-    await call_chromefleet_api("GET", browser_id, timeout=10.0)  # retries=3 default
+    await call_chromefleet_api("GET", browser_id, timeout=20.0)  # retries=3 default
     return _setup_cdp_url(browser_id)
 
 


### PR DESCRIPTION
## Summary
- Cold-started flyfleet chrome apps can take >10s to answer `GET /api/v1/browsers/{id}` (seen in Logfire traces: `019fe1f5d066a3421efde6d33c31b793`, `019fe1f6465b2b5180fcec8f27f24f62`)
- Caused `httpx.ReadTimeout` on navigate flow and spurious 404 "Browser not found" on delete (`browser_exists` racing a slow flyfleet cold start)
- Bumps `get_remote_browser_cdp_url`'s chromefleet GET timeout from 10s to 20s

## Test plan
- [x] Manual: trigger navigate right after a cold browser start, confirm no ReadTimeout

<img width="898" height="698" alt="Screenshot 2026-08-08 at 22 36 26" src="https://github.com/user-attachments/assets/717b9dda-76a8-46be-8e56-0699e47e3280" />
