### PR TITLE
DO NOT MERGE — feat(amazon): repoint Amazon at the amazon-mock fixture (deploy branch)

### DIFF
--- a/MOCK-OVERRIDES.md
+++ b/MOCK-OVERRIDES.md
@@ -1,0 +1,88 @@
+# The amazon-mock overrides, and what this branch leaves behind
+
+`feat/tap-connect-sidecar` carries **the amazon-mock repointing and nothing
+else**, extracted from the `mock` branch.
+
+It is the remotebrowser half of a pair. The other half is the branch of the same
+name in **corelens-engineering/demos**, which carries the sidecar deployment —
+`Dockerfile.sidecar`, `start-sidecar.sh`, `sync-remotebrowser.sh` and three Fly
+configs for `tap-connect-mock-{flyfleet,browserbase,daytona}`. That repo's
+`sync-remotebrowser.sh` vendors `getgather` out of *this* checkout into its build
+context, so **whichever branch this repo is on is what gets deployed.** The two
+branches are meaningfully deployable only together; see `apps/tap-connect/SIDECAR.md`
+and `SIDECAR-GAPS.md` over there.
+
+> **Do not merge this branch.** It repoints Amazon at a mock fixture. On `main`
+> that would send every production caller at `amazon-mock.dataportrait.app`.
+> `main` merges *in* to pick up upstream changes, never the reverse.
+
+Extracted from `mock` at `869e5a9`, against `main` at `181421c`.
+
+## What the repointing is
+
+65 files, every one of them a host substitution:
+
+| Files | Change |
+| --- | --- |
+| `getgather/mcp/amazon.py` | `AMAZON_US.domain` and its five absolute `*_url` fields → `amazon-mock.dataportrait.app` |
+| 64 × `getgather/mcp/patterns/*.html` | `rb-domain="amazon"` → `rb-domain="amazon-mock.dataportrait.app"` |
+
+Two changes in `amazon.py` are not pure substitution and are worth a look:
+
+- **`base_url` no longer hard-codes `www.`.** It was `f"https://www.{self.domain}"`;
+  `domain` is now the full host so a mock host with no `www.` works unchanged.
+  `AMAZON_CA` compensates by carrying `www.amazon.ca` as its domain, so its
+  behaviour is byte-identical to before.
+- **The watch-history `Referer` now interpolates `{country.watch_history_url}`**
+  instead of a literal `https://www.amazon.com/...`. That is a real fix
+  independent of the mock: `_get_watch_history_with_pagination` is
+  country-parameterised, so an `AMAZON_CA` call was sending a `.com` referer.
+
+That second one is the only thing on this branch that would be worth landing on
+`main` on its own merits.
+
+## What was left on `mock`
+
+One commit, `869e5a9` — five files of leak fixes for the loopback CDP path.
+Excluded because they are product changes to the browser lifecycle, not mock
+configuration, and they belong in their own PR with their own review.
+
+**They matter operationally, though.** Without them, a sidecar deployed from this
+branch leaks roughly **300 sockets and ~284 MB per run** on the `browserbase` and
+`daytona` backends, reaching ~600 MB on a 1 GB VM. Past that, memory pressure
+kills `tailscaled`, the tailnet database goes unreachable, `/health` 500s, Fly
+deroutes the machine, and every test against it fails while the machine
+simultaneously goes dark in telemetry. Deployments that set `CHROMEFLEET_URL`
+(the flyfleet tenant) do not take the leaking path and are unaffected.
+
+| File | Change | Status when the notes stop |
+| --- | --- | --- |
+| `browsers/settings.py` | `BROWSERBASE_SESSION_TIMEOUT: int = 900` | shipped 08-08. Sessions were dying at the 300s project default mid-sync |
+| `browsers/browserbase_browsers.py` | create body sends `timeout` alongside `keepAlive` | shipped 08-08 |
+| `browser.py` | `_local_instances` + `close_local_browsers`; one process-level `asyncio_atexit` hook replacing the per-browser closures; explicit per-target connection close | shipped 08-09 / 08-10 |
+| `browser.py` | `_reusable_instance` in `get_remote_browser`; `reap_idle_browsers` on `BROWSER_LOCAL_IDLE_TTL_SECONDS` (1200s) | shipped 08-09, **partial** — `create_remote_browser` calls the same constructor and was missed, so it still mints ~73 instances per browser |
+| `browsers/router.py` | `websocket_proxy` `close_timeout` 7200 → 10; a `finally` closing the **inbound** client socket | shipped 08-10. This is the one that stopped the accumulation |
+| `main.py` | reaper hooked into the existing `timer_loop` in `lifespan` | shipped 08-09 |
+
+After all six, sockets returned to baseline across a completed sync (peak
+970 → 799 → 256; 600 → 26 idle, RSS 614 → 275 MB). Two known remainders: the
+over-creation above, and `HTTP 410`s that still occur but now fail fast instead of
+blocking 120s each.
+
+The evidence for all of this is in the demos repo on `mock`, at
+`apps/tap-connect/DEBUG-mock-tests.md` — it is not on that repo's
+`feat/tap-connect-sidecar` either.
+
+## Keeping it alive
+
+Same rule as `mock`. Merge `main` in, verify the override survived, then re-vendor
+on the demos side:
+
+```sh
+git checkout feat/tap-connect-sidecar && git fetch origin && git merge origin/main
+rg -n 'amazon-mock\.dataportrait\.app' getgather/mcp/amazon.py   # must print
+```
+
+If that prints nothing the merge took `main`'s side. The post-deploy check in the
+demos repo's `SIDECAR.md` catches the same mistake from the other end: `amazon_us
+domain` must read `amazon-mock.dataportrait.app` on all three apps.

--- a/docs/cdp-browser-retention.md
+++ b/docs/cdp-browser-retention.md
@@ -140,7 +140,74 @@ Derived: 145.4 MiB/h ÷ 432 connects/h = **0.337 MiB retained per connect**, mat
 
 ## AFTER — fix A
 
-<!-- filled in after the fix has run ≥90 min under the same 5-minute test cadence -->
+Same machine, same test suite, same 5-minute cadence. Deployed 2026-08-12 22:51 UTC,
+healthy 22:53. Measurement window 22:53–23:33 UTC.
+
+| sample (UTC) | RSS MiB | utime | stime | threads |
+| --- | --- | --- | --- | --- |
+| 22:53:47 | 142.3 | 656 | 102 | 9 |
+| 22:58:55 | 175.6 | 2728 | 164 | 10 |
+| 23:04:04 | 174.2 | 4547 | 218 | 10 |
+| 23:09:13 | 176.6 | 6920 | 284 | 10 |
+| 23:14:24 | 177.2 | 9053 | 342 | 10 |
+| 23:22:50 | 177.2 | 12719 | 432 | 10 |
+| 23:27:59 | 179.4 | 14897 | 490 | 10 |
+| 23:33:11 | 179.9 | 17202 | 555 | 10 |
+
+**Growth: 175.6 → 179.9 MiB over a measured 34.3 min = 7.5 MiB/h**, against a control
+window of comparable length (27.6 min). Warmup excluded on both arms by the same rule.
+
+Zero probe failures, so the after arm is denser than the control (8 good samples vs 5).
+
+Span rates, 5-minute buckets:
+
+| bucket (UTC) | connects | closes | hdrs | browsers | reg_max |
+| --- | --- | --- | --- | --- | --- |
+| 22:55 | 36 | 0 | 72 | 1 | 0 |
+| 23:00 | 36 | 0 | 74 | 1 | 0 |
+| 23:05 | 36 | 0 | 74 | 1 | 0 |
+| 23:10 | 36 | 0 | 74 | 1 | 0 |
+| 23:15 | 36 | 0 | 74 | 1 | 0 |
+| 23:20 | 36 | 0 | 74 | 1 | 0 |
+| 23:25 | 36 | 0 | 74 | 1 | 0 |
+| 23:30 | 36 | 0 | 74 | 1 | 0 |
+| 23:35 | 34 | 0 | 69 | 1 | 0 |
+
+`registered_instances` is **0 in every bucket** — not slowed, never taken. The last
+pre-restart bucket on the old build caught it at 315 and still incrementing.
+
+`closes` remaining 0 is expected, not a gap: fix A adds no teardown call site. Instances are
+now simply unreachable when the request drops them and are collected. Pairing connects to
+closes 1:1 only becomes meaningful under fix B, when a cached browser has a real lifetime.
+
+### Result
+
+| metric | control | fix A | change |
+| --- | --- | --- | --- |
+| **RSS growth** | **145.4 MiB/h** | **7.5 MiB/h** | **19× lower** |
+| registered_instances | 0→35/bucket, monotonic | flat 0 | leak closed |
+| cdp websocket connect | 36/bucket | 36/bucket | unchanged |
+| CDP websocket headers attached | 74/bucket | 74/bucket | unchanged |
+| browsers started | 1/bucket | 1/bucket | unchanged |
+| threads | 10 | 10 | unchanged |
+| sidecar CPU | 6.8% of one core | 7.2% | unchanged |
+
+The load columns are identical across arms, so the RSS difference is attributable to the
+fix and not to a lighter test cycle. Extrapolated to the original 6.7-hour observation:
+~975 MiB of growth becomes ~50 MiB.
+
+### Residual
+
+7.5 MiB/h is not zero, and the per-sample slope oscillated (5.8, 6.2, 4.0, 7.8, 7.5)
+rather than converging on zero, so the remainder looks like a real constant-rate effect
+rather than noise. ~7.5 MiB/h is ~180 MiB/day: no longer an operational threat on a 2 GB
+machine, but not nothing.
+
+The likely cause is allocator churn — fix A stops browsers being *retained*, but
+`get_remote_browser` still constructs 36 `zd.Browser` + `Connection` + handler sets per
+cycle, and glibc does not reliably return freed arenas to the OS. Fix B removes that churn
+at the source and is the natural candidate for the remainder. This is unconfirmed: the
+registry gauge cannot see it, and attributing it needs a different instrument.
 
 ## Scope
 

--- a/docs/cdp-browser-retention.md
+++ b/docs/cdp-browser-retention.md
@@ -141,7 +141,7 @@ Derived: 145.4 MiB/h ÷ 432 connects/h = **0.337 MiB retained per connect**, mat
 ## AFTER — fix A
 
 Same machine, same test suite, same 5-minute cadence. Deployed 2026-08-12 22:51 UTC,
-healthy 22:53. Measurement window 22:53–23:33 UTC.
+healthy 22:53. Measurement window 22:53–00:30 UTC.
 
 | sample (UTC) | RSS MiB | utime | stime | threads |
 | --- | --- | --- | --- | --- |
@@ -153,11 +153,22 @@ healthy 22:53. Measurement window 22:53–23:33 UTC.
 | 23:22:50 | 177.2 | 12719 | 432 | 10 |
 | 23:27:59 | 179.4 | 14897 | 490 | 10 |
 | 23:33:11 | 179.9 | 17202 | 555 | 10 |
+| 23:38:21 | 180.4 | 19397 | 619 | 10 |
+| 23:43:30 | 181.3 | 21517 | 668 | 10 |
+| 23:48:40 | 181.5 | 23652 | 724 | 10 |
+| 23:53:48 | 180.2 | 25639 | 774 | 10 |
+| 23:58:56 | 181.9 | 27872 | 834 | 10 |
+| 00:04:05 | 181.5 | 30022 | 890 | 10 |
+| 00:09:14 | 181.9 | 32184 | 946 | 10 |
+| 00:14:24 | 181.6 | 34288 | 993 | 10 |
+| 00:19:33 | 181.2 | 36400 | 1046 | 10 |
+| 00:24:41 | 182.4 | 38507 | 1101 | 10 |
+| 00:29:50 | 181.9 | 40638 | 1163 | 10 |
 
-**Growth: 175.6 → 179.9 MiB over a measured 34.3 min = 7.5 MiB/h**, against a control
-window of comparable length (27.6 min). Warmup excluded on both arms by the same rule.
+**Growth: 175.6 → 181.9 MiB over a measured 90.9 min = 4.16 MiB/h**, against a 27.6 min
+control. Warmup excluded on both arms by the same rule.
 
-Zero probe failures, so the after arm is denser than the control (8 good samples vs 5).
+Zero probe failures across 19 good samples, versus 5 good samples and 1 failure on the control.
 
 Span rates, 5-minute buckets:
 
@@ -173,7 +184,8 @@ Span rates, 5-minute buckets:
 | 23:30 | 36 | 0 | 74 | 1 | 0 |
 | 23:35 | 34 | 0 | 69 | 1 | 0 |
 
-`registered_instances` is **0 in every bucket** — not slowed, never taken. The last
+`registered_instances` is **0 in every bucket** — not slowed, never taken. Across the full
+window that is 0 over 16,194 records spanning 684 connects and 19 browsers. The last
 pre-restart bucket on the old build caught it at 315 and still incrementing.
 
 `closes` remaining 0 is expected, not a gap: fix A adds no teardown call site. Instances are
@@ -184,40 +196,30 @@ closes 1:1 only becomes meaningful under fix B, when a cached browser has a real
 
 | metric | control | fix A | change |
 | --- | --- | --- | --- |
-| **RSS growth** | **145.4 MiB/h** | **7.5 MiB/h** | **19× lower** |
+| **RSS growth** | **145.4 MiB/h** | **4.16 MiB/h** | **35× lower** |
 | registered_instances | 0→35/bucket, monotonic | flat 0 | leak closed |
 | cdp websocket connect | 36/bucket | 36/bucket | unchanged |
 | CDP websocket headers attached | 74/bucket | 74/bucket | unchanged |
 | browsers started | 1/bucket | 1/bucket | unchanged |
 | threads | 10 | 10 | unchanged |
-| sidecar CPU | 6.8% of one core | 7.2% | unchanged |
+| sidecar CPU | 6.8% of one core | 7.1% | unchanged |
 
 The load columns are identical across arms, so the RSS difference is attributable to the
 fix and not to a lighter test cycle. Extrapolated to the original 6.7-hour observation:
-~975 MiB of growth becomes ~50 MiB.
+~975 MiB of growth becomes ~28 MiB.
 
 ### Residual
 
-7.5 MiB/h is not zero, and the per-sample slope oscillated (5.8, 6.2, 4.0, 7.8, 7.5)
-rather than converging on zero, so the remainder looks like a real constant-rate effect
-rather than noise. ~7.5 MiB/h is ~180 MiB/day: no longer an operational threat on a 2 GB
-machine, but not nothing.
+4.16 MiB/h over the full window is not zero, but it is decaying rather than constant. The
+slope fell steadily as the window lengthened — 7.5 MiB/h at 34 min, 5.4 at 70 min, 4.16 at
+91 min — and the **last 61 minutes alone measure 2.43 MiB/h** (179.4 → 181.9 MiB), with RSS
+oscillating between 179 and 182 for the final hour and stepping down as often as up.
 
-The likely cause is allocator churn — fix A stops browsers being *retained*, but
-`get_remote_browser` still constructs 36 `zd.Browser` + `Connection` + handler sets per
-cycle, and glibc does not reliably return freed arenas to the OS. Fix B removes that churn
-at the source and is the natural candidate for the remainder. This is unconfirmed: the
-registry gauge cannot see it, and attributing it needs a different instrument.
+That revises the earlier reading: this looks like a heap settling toward a plateau, not a
+second constant-rate leak. The headline figure is therefore conservative.
 
-## Scope
-
-Fix A stops the retention only. It deliberately does **not** add an identity map to
-`get_remote_browser` (fix B), which would cut instance creation ~36× and remove 420
-redundant browser-level handshakes per hour. B is the better fix but changes lifetime
-semantics — shared `connection.handlers` and `targets` under concurrency, staleness
-invalidation, tab cleanup — and is kept separate.
-
-Order matters for measurement: B alone would leave one un-discarded instance per browser,
-~4 MiB/h at 12 browsers/h, which is below the 107–205 MiB/h noise floor of a 5-minute
-sample. Shipping B first would look like a fix while leaving a process-global set growing
-forever. A is measured by RSS slope; B is measured by span rates.
+A few MiB/h would be unsurprising regardless, since `get_remote_browser` still constructs 36
+`zd.Browser` + `Connection` + handler sets per cycle and glibc does not reliably return
+freed arenas to the OS. Fix B removes that churn at source. Unconfirmed: the registry gauge
+cannot see allocator behaviour, and confirming the plateau needs a multi-hour run that has
+not been done.

--- a/docs/cdp-browser-retention.md
+++ b/docs/cdp-browser-retention.md
@@ -1,0 +1,156 @@
+# CDP browser retention leak — before/after
+
+Measured on `tap-connect-mock-flyfleet` (Fly org `remote-browsers-dev`, machine
+`819525a9015e38`, `shared-cpu-2x:2048MB`, sjc). Sidecar is getgather under uvicorn on
+127.0.0.1:23456. Logfire project `getgather`, environment `mock-flyfleet`.
+
+Load is a test suite on a 5-minute cadence driving ~12 browsers/hour. Both arms of the
+comparison run the same suite, so the span rates below double as proof the load was
+identical and the RSS numbers are like-for-like.
+
+## Symptom
+
+Sidecar RSS grew ~140 MiB/h, perfectly linear, no flattening. Never OOM-killed — it
+thrashed the VM until `/health` timed out. At 1080 MiB RSS: 44 socket fds, 10 threads,
+zero sockets in CLOSE_WAIT, zero swap, `Private_Dirty` 1060 MiB of 1080 MiB. py-spy showed
+the event loop idle and every thread parked. So: dirty anonymous Python heap, *retained*
+rather than in-flight, and not an fd or socket leak.
+
+## Root cause
+
+`_create_browser_from_cdp_websocket` took process-lifetime ownership of every browser it
+attached to, via two independent strong references:
+
+- `util.get_registered_instances().add(instance)` — `zendriver.core.util.__registered__instances__`
+  is a module-global `Set[Browser]`. In the installed zendriver it is written at
+  `util.py:24` and read only by the accessor at `util.py:133`; **nothing in zendriver ever
+  iterates it**, and getgather was its only writer. Pure retention with no consumer.
+- `asyncio_atexit.register(browser_atexit)` — the closure captures `instance`, and the
+  registry lives for the lifetime of the event loop.
+
+Neither is removed by `terminate_remote_browser`, which only calls the ChromeFleet DELETE
+API. On the flyfleet flow `terminate_remote_browser` is not reached at all.
+
+The multiplier is that `get_remote_browser` has no identity map: it does a ChromeFleet
+existence check and then unconditionally builds a **new** `zd.Browser` + `Connection` +
+handler set for a browser_id that already has one. `dpage.py` calls it once per MCP tool
+call (`:692`, `:711`, `:766`, `:778`, `:803`), so one remote browser accumulates one local
+wrapper per tool call.
+
+Per 5-minute test cycle, 36 instances for a single browser_id:
+
+| tool call | per cycle |
+| --- | --- |
+| `get_purchase_history_with_details` | 21 |
+| `get_watch_history_with_pagination` | 8 |
+| `get_watchlist_with_pagination` | 2 |
+| `get_browsing_history` | 1 |
+| `get_prime_library` | 1 |
+| `get_browser_ip_address` | 1 |
+| `check_signin` | 1 |
+| initial `create_remote_browser` | 1 |
+| **total** | **36** |
+
+The `amazon_*`-prefixed spans are alias wrappers around the same calls — same counts, same
+trace — and must not be double-counted.
+
+This also explains the two-tier socket rate: 432/h browser-level sockets (one per
+`get_remote_browser`, redundant) plus ~444/h tab-level sockets (one per `get_new_page`,
+legitimate) = the 876/h measured header-attach rate.
+
+### Why PR #1439 did not fix it
+
+`#1439` ("always close client_ws in CDP websocket proxy relay", `dce078d`) is present in
+the measured build — verified with `git merge-base --is-ancestor dce078d HEAD`. It closes
+`client_ws` in `router.py`'s `websocket_proxy`, which is the sidecar-as-*server* relay. The
+flyfleet tenant never exercises that path: the sidecar is the CDP *client*, dialling out to
+`flyfleet-dev.flycast`. Growth was unchanged with it deployed.
+
+## Instrumentation added
+
+Teardown logging, so connects and closes can be paired 1:1. `cdp websocket close {browser_id}`
+emits from a `finally` on all three relay paths — `router.py`, `browserbase_browsers.py`,
+and `browser.py`'s `terminate_remote_browser` — carrying `browser_id`, `outcome` and
+`lifetime_ms`. The log sits in an inner `finally` so it survives a `close()` that raises,
+and `CancelledError` is caught and re-raised so cancellation is tagged rather than counted
+as a clean exit.
+
+`registered_instances=len(util.get_registered_instances())` is sampled on the connect span
+and at terminate. It is an O(1) `len()` on a set, cheap enough for 432 calls/hour, and it
+measures retention directly — which answered the question without a gc census or
+`MEMORY_XRAY` (whose tracemalloc mode cost 40% CPU under load and corrupted the measurement
+it existed to produce).
+
+## BEFORE — control
+
+Build: merge of `origin/main` into `feat/tap-connect-sidecar` (includes #1439) plus teardown
+instrumentation. Deployed 2026-08-12 22:06 UTC. Measurement window 22:08–22:45 UTC.
+
+RSS from `/proc/<pid>/stat` field 24 × 4096. PID re-discovered each sample; elapsed time
+measured, never assumed.
+
+| sample (UTC) | RSS MiB | utime | stime | threads |
+| --- | --- | --- | --- | --- |
+| 22:08:52 | 142.5 | 648 | 111 | 10 |
+| 22:14:00 | 176.9 | 2695 | 167 | 10 |
+| 22:21:02 | *probe timeout* | | | |
+| 22:26:11 | 203.8 | 7256 | 299 | 10 |
+| 22:31:19 | 213.0 | 9301 | 346 | 10 |
+| 22:36:28 | 230.6 | 11578 | 414 | 10 |
+| 22:41:36 | 243.8 | 13695 | 459 | 10 |
+
+**Growth: 176.9 → 243.8 MiB over a measured 27.6 min = 145.4 MiB/h.**
+
+The first interval (142.5 → 176.9, 402 MiB/h) is boot warmup — uvicorn mounting ~40 MCP
+bundles — and is excluded. Individual 5-minute intervals scatter 107–205 MiB/h from
+allocator and GC granularity, so only the multi-sample aggregate is meaningful.
+
+CPU: 133.9 CPU-s over 1964 s = 6.8% of one core. Threads flat at 10. Neither is the problem.
+
+Span rates, 5-minute buckets:
+
+| bucket (UTC) | connects | closes | hdrs | browsers | reg_min | reg_max |
+| --- | --- | --- | --- | --- | --- | --- |
+| 22:10 | 36 | 0 | 72 | 1 | 0 | 35 |
+| 22:15 | 36 | 0 | 74 | 1 | 36 | 71 |
+| 22:20 | 36 | 0 | 74 | 1 | 72 | 107 |
+| 22:25 | 36 | 0 | 74 | 1 | 108 | 143 |
+| 22:30 | 36 | 0 | 74 | 1 | 144 | 179 |
+| 22:35 | 36 | 0 | 74 | 1 | 180 | 215 |
+| 22:40 | 36 | 0 | 74 | 1 | 216 | 251 |
+
+`registered_instances` runs 0→35, 36→71, 72→107 … with no gap and no repeat at the bucket
+boundaries: a pure counter, +35 every bucket, **never a single decrement**. Growth is flat
+rather than accelerating, which matches the linear RSS curve and rules out anything
+quadratic. `browsers=1` per bucket confirms all 36 reconnects hit one browser_id.
+
+Derived: 145.4 MiB/h ÷ 432 connects/h = **0.337 MiB retained per connect**, matching the
+0.32 MiB/connect measured over the original 6.7-hour window.
+
+| metric | original 6.7h baseline | control |
+| --- | --- | --- |
+| RSS growth | ~140 MiB/h | 145.4 MiB/h |
+| cdp websocket connect | 432/h | 432/h |
+| CDP websocket headers attached | 888/h | 876/h |
+| browsers started | 12/h | 12/h |
+| close/teardown spans | 0 | 0 |
+| retained per connect | ~0.32 MiB | 0.337 MiB |
+| threads | 10 | 10 |
+| sidecar CPU | ~7% of one core | 6.8% |
+
+## AFTER — fix A
+
+<!-- filled in after the fix has run ≥90 min under the same 5-minute test cadence -->
+
+## Scope
+
+Fix A stops the retention only. It deliberately does **not** add an identity map to
+`get_remote_browser` (fix B), which would cut instance creation ~36× and remove 420
+redundant browser-level handshakes per hour. B is the better fix but changes lifetime
+semantics — shared `connection.handlers` and `targets` under concurrency, staleness
+invalidation, tab cleanup — and is kept separate.
+
+Order matters for measurement: B alone would leave one un-discarded instance per browser,
+~4 MiB/h at 12 browsers/h, which is below the 107–205 MiB/h noise floor of a 5-minute
+sample. Shipping B first would look like a fix while leaving a process-global set growing
+forever. A is measured by RSS slope; B is measured by span rates.

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from typing import Any, TypeVar, cast
 from urllib.parse import urlparse
 
-import asyncio_atexit
 import logfire
 import sentry_sdk
 import websockets
@@ -117,10 +116,10 @@ async def _create_browser_from_cdp_websocket(
             "cdp websocket connect {browser_id}",
             browser_id=browser_id,
             cdp_url=websocket_url,
-            # zendriver keeps every Browser in a process-global set (`util.__registered__instances__`)
-            # and nothing here removes it, so this only ever grows. Sampled on connect because it is
-            # the direct measure of retained browser graphs — if RSS tracks this, the leak is the
-            # registry, not an unclosed socket.
+            # Regression guard for the retention leak: this counts zendriver's process-global
+            # `util.__registered__instances__`, which nothing prunes. We no longer add to it, so a
+            # healthy sidecar reports a flat 0 — any upward drift means something started taking
+            # process-lifetime ownership of browsers again. O(1) len(), safe at 432 calls/hour.
             registered_instances=len(util.get_registered_instances()),
         ),
         _inject_headers_into_websockets(extra_headers=extra_headers),
@@ -171,15 +170,19 @@ async def _create_browser_from_cdp_websocket(
                 f"{settings.CHROMEFLEET_CDP_HANDSHAKE_TIMEOUT_SECONDS:g}s: "
                 f"browser_id={browser_id}"
             )
-    util.get_registered_instances().add(instance)
-
-    async def browser_atexit() -> None:
-        if not instance.stopped:
-            await instance.stop()
-        await instance._cleanup_temporary_profile()  # type: ignore[reportPrivateUsage]
-
-    asyncio_atexit.register(browser_atexit)  # type: ignore[reportUnknownMemberType]
-
+    # Deliberately NOT registered in `util.get_registered_instances()` and NOT given an
+    # asyncio_atexit hook. Both are process-lifetime strong references, and callers here
+    # abandon the instance when their request ends, so both retained every browser forever:
+    # `get_remote_browser` builds a fresh instance per MCP tool call (~36 per browser), which
+    # measured 0.34 MiB retained per connect / ~145 MiB/h. See docs/cdp-browser-retention.md.
+    #
+    # Neither is load-bearing for a *remote* attachment. Nothing in zendriver iterates the
+    # registry — it is written at util.py:24 and only read back by the accessor. And the
+    # atexit hook's work does not apply: `stop()` sends `Browser.close()`, which would tear
+    # down a fleet-owned browser this process does not own (36 times over, once per retained
+    # instance), and `_cleanup_temporary_profile()` targets a local profile dir that a remote
+    # attachment never created. Fleet browsers are reaped by the fleet's own idle teardown,
+    # and explicit teardown remains `terminate_remote_browser`.
     instance.id = browser_id  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
     instance.connected_at = time.monotonic()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
     return instance

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import random
+import time
 from collections.abc import Awaitable, Callable
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -116,6 +117,11 @@ async def _create_browser_from_cdp_websocket(
             "cdp websocket connect {browser_id}",
             browser_id=browser_id,
             cdp_url=websocket_url,
+            # zendriver keeps every Browser in a process-global set (`util.__registered__instances__`)
+            # and nothing here removes it, so this only ever grows. Sampled on connect because it is
+            # the direct measure of retained browser graphs — if RSS tracks this, the leak is the
+            # registry, not an unclosed socket.
+            registered_instances=len(util.get_registered_instances()),
         ),
         _inject_headers_into_websockets(extra_headers=extra_headers),
     ):
@@ -175,6 +181,7 @@ async def _create_browser_from_cdp_websocket(
     asyncio_atexit.register(browser_atexit)  # type: ignore[reportUnknownMemberType]
 
     instance.id = browser_id  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+    instance.connected_at = time.monotonic()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
     return instance
 
 
@@ -256,8 +263,28 @@ async def terminate_remote_browser(browser: zd.Browser) -> None:
     """Terminate an existing remote Chrome via ChromeFleet."""
     browser_id = cast(str, browser.id)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
     logger.info(f"Terminating ChromeFleet browser: {browser_id}")
-    # no need to raise for error (which would fail the whole process)
-    await call_chromefleet_api("DELETE", browser_id, timeout=1.0, retries=0, raise_for_status=False)
+    connected_at = getattr(browser, "connected_at", None)
+    try:
+        # no need to raise for error (which would fail the whole process)
+        await call_chromefleet_api(
+            "DELETE", browser_id, timeout=1.0, retries=0, raise_for_status=False
+        )
+    finally:
+        # Pairs 1:1 with the `cdp websocket connect` span. `registered_instances` is read *after*
+        # teardown on purpose: the browser is gone from the fleet by now, so a count that does not
+        # drop is the retained-object leak showing itself.
+        logfire.info(
+            "cdp websocket close {browser_id}",
+            browser_id=browser_id,
+            outcome="terminated",
+            lifetime_ms=(
+                round((time.monotonic() - connected_at) * 1000)
+                if connected_at is not None
+                else None
+            ),
+            registered_instances=len(util.get_registered_instances()),
+            relay="remote_browser",
+        )
 
 
 _CREDENTIALS_BLOCK_SCRIPT = r"""

--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import Any, Protocol, cast, runtime_checkable
 
 import httpx
+import logfire
 from fastapi import WebSocket
 from loguru import logger
 from nanoid import generate
@@ -34,12 +35,13 @@ async def get_browser_websocket_debugger_url(cdp_base_url: str) -> str:
     but no pre-baked wss connect URL: their `get_cdp_websocket_remote_url` resolves the
     cdp base URL (per browser) and then this helper does the standard /json/version probe.
     """
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        response = await client.get(f"{cdp_base_url}/json/version")
-        response.raise_for_status()
-        data: dict[str, Any] = response.json()
-        logger.debug(f"[CDP] CDP json version gives {data}")
-        return rewrite_ws_url(str(data["webSocketDebuggerUrl"]), cdp_base_url)
+    with logfire.span("[XRAY] cdp probe /json/version", cdp_host=httpx.URL(cdp_base_url).host):
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(f"{cdp_base_url}/json/version")
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            logger.debug(f"[CDP] CDP json version gives {data}")
+            return rewrite_ws_url(str(data["webSocketDebuggerUrl"]), cdp_base_url)
 
 
 async def get_page_websocket_debugger_url(cdp_base_url: str, page_id: str) -> str | None:
@@ -51,17 +53,24 @@ async def get_page_websocket_debugger_url(cdp_base_url: str, page_id: str) -> st
     browser) and then this helper does the standard /json/list probe. Returns None when the
     page id is not present in the listing (page already closed or not yet registered).
     """
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        response = await client.get(f"{cdp_base_url}/json/list")
-        response.raise_for_status()
-        raw: Any = response.json()
-        if not isinstance(raw, list):
+    with logfire.span("[XRAY] cdp probe /json/list", cdp_host=httpx.URL(cdp_base_url).host) as span:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(f"{cdp_base_url}/json/list")
+            response.raise_for_status()
+            raw: Any = response.json()
+            if not isinstance(raw, list):
+                span.set_attribute("outcome", "not-a-list")
+                return None
+            pages = cast(list[dict[str, Any]], raw)
+            span.set_attribute("page_count", len(pages))
+            for item in pages:
+                if item.get("id") == page_id:
+                    ws_url = item.get("webSocketDebuggerUrl")
+                    span.set_attribute("outcome", "found" if ws_url else "found-no-ws-url")
+                    return rewrite_ws_url(str(ws_url), cdp_base_url) if ws_url else None
+            # A miss here costs the router a full 3s retry sleep, so record it explicitly.
+            span.set_attribute("outcome", "page-id-absent")
             return None
-        for item in cast(list[dict[str, Any]], raw):
-            if item.get("id") == page_id:
-                ws_url = item.get("webSocketDebuggerUrl")
-                return rewrite_ws_url(str(ws_url), cdp_base_url) if ws_url else None
-        return None
 
 
 def new_browser_id() -> str:

--- a/getgather/browsers/browserbase_browsers.py
+++ b/getgather/browsers/browserbase_browsers.py
@@ -220,6 +220,13 @@ class BrowserbaseBackend:
         connect_url = str(data["connectUrl"])
         self._sessions[bb_id] = connect_url
         logger.info(f"Browserbase session created: id={bb_id} connectUrl={connect_url}")
+        # `timeout` is unset in the request body, so expiresAt reflects the project's
+        # defaultTimeout (300s on project d50de03f). Nothing evicts `_sessions` on expiry, so
+        # log the cache size here to watch dead entries accumulate across runs.
+        logger.info(
+            f"[BB-STATE] created id={bb_id} expiresAt={data.get('expiresAt')} "
+            f"keepAlive={data.get('keepAlive')} cached={len(self._sessions)}"
+        )
         await self._wait_until_cdp_ready(connect_url, bb_id)
         return {"browser_id": bb_id, "status": "created", "ip": None}
 
@@ -355,6 +362,7 @@ class BrowserbaseBackend:
         # clear the local id -> connectUrl mapping, regardless of whether the upstream call
         # succeeds (a 404 means the session is already gone, which is the desired state).
         self._sessions.pop(browser_id, None)
+        logger.info(f"[BB-STATE] released id={browser_id} cached={len(self._sessions)}")
         try:
             headers = {"Content-Type": "application/json", "x-bb-api-key": _api_key()}
             body = {"status": "REQUEST_RELEASE"}
@@ -375,6 +383,28 @@ class BrowserbaseBackend:
 
     async def list_browser_ids(self) -> list[str]:
         return list(self._sessions.keys())
+
+    async def log_session_state(self, browser_id: str, context: str) -> None:
+        """Log Browserbase's own view of a session. Called by the router when a probe fails; the
+        local `_sessions` map has no expiry, so only the API can say whether an id is still live.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                response = await client.get(
+                    f"{BROWSERBASE_API_URL}/{browser_id}", headers={"x-bb-api-key": _api_key()}
+                )
+            data: dict[str, Any] = response.json()
+            logger.error(
+                f"[BB-STATE] {context}: id={browser_id} http={response.status_code} "
+                f"status={data.get('status')} startedAt={data.get('startedAt')} "
+                f"endedAt={data.get('endedAt')} expiresAt={data.get('expiresAt')} "
+                f"keepAlive={data.get('keepAlive')} cached={len(self._sessions)} "
+                f"cached_ids={list(self._sessions.keys())}"
+            )
+        except Exception as e:
+            logger.warning(
+                f"[BB-STATE] {context}: id={browser_id} lookup failed: {type(e).__name__}: {e}"
+            )
 
     async def cleanup_idle(self) -> list[str]:
         return []

--- a/getgather/browsers/browserbase_browsers.py
+++ b/getgather/browsers/browserbase_browsers.py
@@ -1,9 +1,11 @@
 import asyncio
 import json
 import os
+import time
 from typing import Any
 
 import httpx
+import logfire
 import websockets
 from fastapi import WebSocket, WebSocketDisconnect
 from fastapi.websockets import WebSocketState
@@ -51,6 +53,8 @@ async def websocket_proxy_attached(
         "params": {"targetId": target_id, "flatten": True},
     })
 
+    started = time.monotonic()
+    outcome = "closed"
     try:
         async with websockets.connect(
             remote_url,
@@ -79,6 +83,7 @@ async def websocket_proxy_attached(
                     continue
                 if "error" in data:
                     err: Any = data.get("error")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+                    outcome = "attach_failed"
                     logger.error(f"[CDP] attachToTarget failed for {target_id}: {err}")
                     if client_ws.client_state == WebSocketState.CONNECTED:
                         await client_ws.close(code=4502, reason=f"attachToTarget failed: {err}")
@@ -150,15 +155,36 @@ async def websocket_proxy_attached(
                 except (asyncio.CancelledError, Exception):
                     pass
             return
+    except asyncio.CancelledError:
+        outcome = "cancelled"
+        raise
     except OSError as e:
+        outcome = "remote_unreachable"
         logger.warning(f"[CDP] Attach to {target_id} failed (OSError): {e}")
     except InvalidStatus as e:
+        outcome = "rejected"
         logger.warning(f"[CDP] Attach to {target_id} rejected with HTTP {e.response.status_code}")
     except Exception as e:
+        outcome = "error"
         logger.warning(f"[CDP] Attach to {target_id} failed ({type(e).__name__}): {e}")
-
-    if client_ws.client_state == WebSocketState.CONNECTED:
-        await client_ws.close(code=4502, reason="Remote server unreachable")
+    finally:
+        # Only the caught-exception outcomes reach the 4502 close; the success and attach_failed
+        # paths returned out of the `try` and must keep skipping it, as they did before.
+        try:
+            if (
+                outcome not in ("closed", "attach_failed", "cancelled")
+                and client_ws.client_state == WebSocketState.CONNECTED
+            ):
+                await client_ws.close(code=4502, reason="Remote server unreachable")
+        finally:
+            logfire.info(
+                "cdp websocket close {browser_id}",
+                browser_id=target_id,
+                page_id=target_id,
+                outcome=outcome,
+                lifetime_ms=round((time.monotonic() - started) * 1000),
+                relay="browserbase_attached",
+            )
 
 
 def _api_key() -> str:

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -2,6 +2,7 @@ import asyncio
 import time
 from typing import Any
 
+import logfire
 from daytona import (
     AsyncDaytona,
     AsyncSandbox,
@@ -10,6 +11,7 @@ from daytona import (
     DaytonaConflictError,
     DaytonaNotFoundError,
     ListSandboxesQuery,
+    SandboxState,
 )
 from fastapi import WebSocket
 from loguru import logger
@@ -213,11 +215,29 @@ class DaytonaBackend:
         return await self._get(_sandbox_name(browser_id)) is not None
 
     async def list_browser_ids(self) -> list[str]:
+        return await self._list_browser_ids(live_only=False)
+
+    async def list_live_browser_ids(self) -> list[str]:
+        """Only sandboxes that are actually running, for callers that intend to reach CDP.
+
+        A STOPPED or ARCHIVED sandbox has no reachable browser — its signed preview URL answers
+        HTTP 400 — so probing one costs a round-trip and an error. Archived entries are never
+        reaped (Daytona's `auto_delete_interval` counts *continuously stopped* time, and archiving
+        ends that state), so they dominate the raw list: 87 entries observed, of which 50 were
+        ARCHIVED and the oldest a week old. Kept separate from `list_browser_ids` so the
+        `GET /api/v1/browsers` listing keeps reporting every sandbox.
+        """
+        return await self._list_browser_ids(live_only=True)
+
+    async def _list_browser_ids(self, *, live_only: bool) -> list[str]:
         browser_ids: list[str] = []
         async for sandbox in self.client.list(ListSandboxesQuery(labels={LABEL_FLEET: "1"})):
             # A just-deleted sandbox lingers briefly as `DESTROYED_<name>_<ts>`; only our names count.
-            if sandbox.name and sandbox.name.startswith(BROWSER_NAME_PREFIX):
-                browser_ids.append(_browser_id_from_name(sandbox.name))
+            if not sandbox.name or not sandbox.name.startswith(BROWSER_NAME_PREFIX):
+                continue
+            if live_only and sandbox.state != SandboxState.STARTED:
+                continue
+            browser_ids.append(_browser_id_from_name(sandbox.name))
         return browser_ids
 
     async def cleanup_idle(self) -> list[str]:
@@ -226,13 +246,21 @@ class DaytonaBackend:
         return []
 
     async def get_cdp_base_url(self, browser_id: str) -> str:
-        sandbox = await self._get(_sandbox_name(browser_id))
-        if sandbox is None:
-            raise BrowserNotFound(browser_id)
-        signed = await sandbox.create_signed_preview_url(
-            CDP_PORT, expires_in_seconds=SIGNED_URL_TTL_SECONDS
-        )
-        return signed.url
+        # Two Daytona control-plane round-trips (app.daytona.io, public internet) on EVERY cdp and
+        # devtools connect. Timed separately so the tail can be attributed to the control plane vs
+        # the preview proxy.
+        with logfire.span("[XRAY] daytona resolve cdp base url", browser_id=browser_id) as span:
+            with logfire.span("[XRAY] daytona sandbox lookup", browser_id=browser_id):
+                sandbox = await self._get(_sandbox_name(browser_id))
+            if sandbox is None:
+                span.set_attribute("outcome", "not-found")
+                raise BrowserNotFound(browser_id)
+            with logfire.span("[XRAY] daytona signed preview url", browser_id=browser_id):
+                signed = await sandbox.create_signed_preview_url(
+                    CDP_PORT, expires_in_seconds=SIGNED_URL_TTL_SECONDS
+                )
+            span.set_attribute("outcome", "ok")
+            return signed.url
 
     def cdp_websocket_base(self) -> None:
         # CDP is reached per-sandbox over a signed HTTPS preview URL via get_cdp_base_url +

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -1,8 +1,11 @@
 import asyncio
 import html
 import json
+import time
 from typing import Any
+from urllib.parse import urlsplit
 
+import logfire
 import websockets
 from fastapi import APIRouter, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -64,11 +67,56 @@ async def get_page_list(browser_id: str) -> list[str]:
 
 
 async def find_browser_id(page_id: str) -> str | None:
-    for browser_id in await backend.list_browser_ids():
-        page_ids = await get_page_list(browser_id)
+    # A failing probe must not hide later entries. The pool lists sandboxes Daytona has stopped
+    # (their signed preview URL answers HTTP 400) and ones it has deleted (BrowserNotFound), so a
+    # dead entry sorting ahead of the live browser would otherwise end the scan and leave the
+    # /dpage request with no response at all. Skip the dead entry and keep scanning; returning None
+    # after a full pass lets the caller close the socket with a reason instead of hanging.
+    # `open_browser_cdp_client` connects outside `get_page_list`'s try, so a rejected upgrade
+    # (Browserbase answers HTTP 410 for an ended session) also surfaces here.
+    # Prefer the running-only listing where the backend offers one: a stopped/archived sandbox
+    # cannot host a findable page, so including it only buys a round-trip and an error.
+    list_live = getattr(backend, "list_live_browser_ids", None)
+    if list_live is not None:
+        browser_ids = await list_live()
+        scope = "live"
+    else:
+        browser_ids = await backend.list_browser_ids()
+        scope = "cached"
+    logger.info(f"[FIND] page_id={page_id} scanning {len(browser_ids)} {scope} browser(s)")
+    skipped = 0
+    for position, browser_id in enumerate(browser_ids, start=1):
+        try:
+            page_ids = await get_page_list(browser_id)
+        except Exception as e:
+            skipped += 1
+            status = getattr(getattr(e, "response", None), "status_code", None)
+            logger.warning(
+                f"[FIND] probe {position}/{len(browser_ids)} browser_id={browser_id} raised "
+                f"{type(e).__name__}"
+                + (f" HTTP {status}" if status is not None else "")
+                + f" — skipped, scan continues ({skipped} dead so far)"
+            )
+            log_state = getattr(backend, "log_session_state", None)
+            if log_state is not None:
+                await log_state(browser_id, "find_browser_id probe failed")
+            continue
+        logger.info(
+            f"[FIND] probe {position}/{len(browser_ids)} browser_id={browser_id} "
+            f"-> {len(page_ids)} page(s){' MATCH' if page_id in page_ids else ''}"
+        )
         if page_id in page_ids:
+            if skipped:
+                logger.info(
+                    f"[FIND] page_id={page_id} MATCH at probe {position} after skipping "
+                    f"{skipped} dead browser(s)"
+                )
             return browser_id
 
+    logger.info(
+        f"[FIND] page_id={page_id} not found in any of {len(browser_ids)} cached browser(s), "
+        f"{skipped} skipped as dead"
+    )
     return None
 
 
@@ -132,6 +180,7 @@ async def websocket_proxy(
     # `patch` rewrites target ids to namespace them by browser_id (local backends multiplex many
     # browsers behind one proxy). The external fleet already does this on its own /cdp proxy, so
     # when relaying to it we pass `patch=False` to avoid double-prefixing target ids.
+    handshake_started = time.monotonic()
     try:
         async with websockets.connect(
             remote_url,
@@ -140,7 +189,16 @@ async def websocket_proxy(
             close_timeout=7200,
             max_size=10 * 1024 * 1024,
         ) as remote_ws:
-            logger.info("[CDP] Connected to remote WebSocket")
+            # Timed inline rather than with a span: the connect happens on __aenter__ of the
+            # `async with`, and restructuring that to isolate it risks leaking the socket.
+            handshake_ms = (time.monotonic() - handshake_started) * 1000
+            logfire.info(
+                "[XRAY] cdp remote ws handshake",
+                browser_id=browser_id,
+                remote_host=urlsplit(remote_url).hostname,
+                handshake_ms=round(handshake_ms),
+            )
+            logger.info(f"[CDP] Connected to remote WebSocket in {handshake_ms:.0f}ms")
 
             async def client_to_remote() -> None:
                 try:
@@ -307,24 +365,33 @@ async def relay_browser_cdp(client_ws: WebSocket, browser_id: str, *, patch: boo
     # whether it came from a connectUrl, an external /cdp relay, or a /json/version probe. Both
     # `None` (not yet resolvable) and exceptions (transient /json/version failure on a boot race)
     # count as a missed attempt; the first non-None result wins.
+    # Each attempt can cost the probe's own 10s timeout plus a 3s sleep, so 10 attempts is ~130s
+    # of wall clock that the caller sees as one slow request. `attempts` is the metric that
+    # separates "one slow hop" from "many retried hops".
     remote_url: str | None = None
-    for attempt in range(10):
-        try:
-            remote_url = await backend.get_cdp_websocket_remote_url(browser_id)
-        except Exception as e:
-            logger.warning(
-                f"[CDP] Attempt {attempt + 1}/10 failed to get debugger URL from {browser_id}: {e}"
-            )
-        if remote_url is not None:
-            logger.info(f"[CDP] Got remote URL: {remote_url}")
-            break
-        if attempt < 9:
-            logger.debug("[CDP] Retrying in 3 seconds...")
-            await asyncio.sleep(3)
-    else:
-        logger.error("[CDP] All retry attempts exhausted")
-        await client_ws.close(code=4502, reason="Failed to get debugger URL")
-        return
+    with logfire.span("[XRAY] cdp resolve browser url", browser_id=browser_id) as resolve_span:
+        for attempt in range(10):
+            try:
+                remote_url = await backend.get_cdp_websocket_remote_url(browser_id)
+            except Exception as e:
+                logger.warning(
+                    f"[XRAY] cdp resolve browser attempt {attempt + 1}/10 failed for "
+                    f"{browser_id}: {type(e).__name__}: {e}"
+                )
+            if remote_url is not None:
+                resolve_span.set_attribute("attempts", attempt + 1)
+                resolve_span.set_attribute("outcome", "resolved")
+                logger.info(f"[XRAY] cdp resolved browser url after {attempt + 1} attempt(s)")
+                break
+            if attempt < 9:
+                logger.debug("[CDP] Retrying in 3 seconds...")
+                await asyncio.sleep(3)
+        else:
+            resolve_span.set_attribute("attempts", 10)
+            resolve_span.set_attribute("outcome", "exhausted")
+            logger.error("[XRAY] cdp resolve browser url exhausted all 10 attempts")
+            await client_ws.close(code=4502, reason="Failed to get debugger URL")
+            return
 
     # (3) Relay.
     logger.info(f"[CDP] Client connected, proxying to {remote_url}")
@@ -400,28 +467,37 @@ async def cdp_devtools_websocket_proxy(client_ws: WebSocket, path: str) -> None:
     # drive a single page off a multiplexed socket). Both `None` (not yet resolvable) and
     # exceptions (a transient /json/list failure on a boot race) count as a missed attempt; the
     # first non-None result wins.
+    # As with the browser-level loop: up to ~130s of wall clock hidden inside one request.
     remote_url: str | None = None
-    for attempt in range(10):
-        try:
-            remote_url = await backend.get_devtools_websocket_remote_url(
-                client_ws, browser_id, page_id
-            )
-        except Exception as e:
-            logger.warning(
-                f"[CDP] Attempt {attempt + 1}/10 failed to get page URL for "
-                f"{browser_id}/{page_id}: {e}"
-            )
-        if remote_url is not None:
-            if remote_url != "":
-                logger.info(f"[CDP] Got page remote URL: {remote_url}")
-            break
-        if attempt < 9:
-            logger.debug("[CDP] Retrying in 3 seconds...")
-            await asyncio.sleep(3)
-    else:
-        logger.error(f"[CDP] Could not get websocket URL for page {page_id}")
-        await client_ws.close(code=4502, reason="Failed to get page websocket URL")
-        return
+    with logfire.span(
+        "[XRAY] cdp resolve page url", browser_id=browser_id, page_id=page_id
+    ) as resolve_span:
+        for attempt in range(10):
+            try:
+                remote_url = await backend.get_devtools_websocket_remote_url(
+                    client_ws, browser_id, page_id
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[XRAY] cdp resolve page attempt {attempt + 1}/10 failed for "
+                    f"{browser_id}/{page_id}: {type(e).__name__}: {e}"
+                )
+            if remote_url is not None:
+                resolve_span.set_attribute("attempts", attempt + 1)
+                resolve_span.set_attribute("outcome", "resolved")
+                logger.info(f"[XRAY] cdp resolved page url after {attempt + 1} attempt(s)")
+                if remote_url != "":
+                    logger.info(f"[CDP] Got page remote URL: {remote_url}")
+                break
+            if attempt < 9:
+                logger.debug("[CDP] Retrying in 3 seconds...")
+                await asyncio.sleep(3)
+        else:
+            resolve_span.set_attribute("attempts", 10)
+            resolve_span.set_attribute("outcome", "exhausted")
+            logger.error(f"[XRAY] cdp resolve page url exhausted all 10 attempts for {page_id}")
+            await client_ws.close(code=4502, reason="Failed to get page websocket URL")
+            return
 
     # Sentinel: the backend already relayed the client socket itself (Browserbase).
     if remote_url == "":

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -173,6 +173,7 @@ async def websocket_proxy(
     # browsers behind one proxy). The external fleet already does this on its own /cdp proxy, so
     # when relaying to it we pass `patch=False` to avoid double-prefixing target ids.
     handshake_started = time.monotonic()
+    outcome = "closed"
     try:
         async with websockets.connect(
             remote_url,
@@ -235,17 +236,33 @@ async def websocket_proxy(
                 except (asyncio.CancelledError, Exception):
                     pass
 
+    except asyncio.CancelledError:
+        outcome = "cancelled"
+        raise
     except OSError as e:
+        outcome = "remote_unreachable"
         logger.error(f"[CDP] Could not connect to remote: {e}")
         if client_ws.client_state == WebSocketState.CONNECTED:
             await client_ws.close(code=4502, reason="Remote server unreachable")
     except Exception as e:
+        outcome = "error"
         logger.error(f"[CDP] Unexpected error: {type(e).__name__}: {e}")
         if client_ws.client_state == WebSocketState.CONNECTED:
             await client_ws.close(code=4500, reason="Internal proxy error")
     finally:
-        if client_ws.client_state == WebSocketState.CONNECTED:
-            await client_ws.close()
+        # Logged from an inner `finally` so the teardown record survives a close() that raises
+        # (or a cancellation landing mid-close). A close log that only fires on the happy path
+        # reads as a connection leak that isn't there.
+        try:
+            if client_ws.client_state == WebSocketState.CONNECTED:
+                await client_ws.close()
+        finally:
+            logfire.info(
+                "cdp websocket close {browser_id}",
+                browser_id=browser_id,
+                outcome=outcome,
+                lifetime_ms=round((time.monotonic() - handshake_started) * 1000),
+            )
 
 
 @router.post("/api/v1/browsers")

--- a/getgather/config.py
+++ b/getgather/config.py
@@ -23,6 +23,15 @@ class Settings(BrowserSettings, BaseSettings):
     SENTRY_DSN: str = ""
     LOGFIRE_TOKEN: str = ""
 
+    # Memory leak instrumentation (getgather/memory_xray.py). Off by default:
+    # the census and tracemalloc tiers cost real CPU, so they are opted into
+    # per-deployment rather than carried by every install.
+    MEMORY_XRAY: bool = False
+    MEMORY_XRAY_INTERVAL: int = 60
+    MEMORY_XRAY_TOP_N: int = 10
+    MEMORY_XRAY_CENSUS: bool = False
+    MEMORY_XRAY_TRACEMALLOC: bool = False
+
     @property
     def data_dir(self) -> Path:
         path = Path(self.DATA_DIR).resolve() if self.DATA_DIR else PROJECT_DIR / "data"

--- a/getgather/main.py
+++ b/getgather/main.py
@@ -19,6 +19,7 @@ from getgather.browser import create_remote_browser, terminate_remote_browser
 from getgather.browsers.router import backend, router as browsers_router
 from getgather.config import PROJECT_DIR, settings
 from getgather.logs import MCPLoggingContextMiddleware
+from getgather.memory_xray import memory_xray_loop
 from getgather.mcp.dpage import router as dpage_router
 from getgather.mcp.main import MCPDoc, create_mcp_apps, mcp_app_docs
 from getgather.pages_api_router import router as pages_router
@@ -56,6 +57,11 @@ async def lifespan(app: FastAPI):
 
     background_task = asyncio.create_task(timer_loop())
 
+    tasks = [background_task]
+    if settings.MEMORY_XRAY:
+        logger.info("[XRAY] memory sampler enabled")
+        tasks.append(asyncio.create_task(memory_xray_loop(stop_event)))
+
     try:
         async with AsyncExitStack() as stack:
             for mcp_app in mcp_apps:
@@ -63,7 +69,7 @@ async def lifespan(app: FastAPI):
             yield
 
             stop_event.set()
-            await background_task
+            await asyncio.gather(*tasks)
     finally:
         await backend.shutdown()
 

--- a/getgather/mcp/amazon.py
+++ b/getgather/mcp/amazon.py
@@ -39,7 +39,8 @@ class AmazonCountry:
 
     @property
     def base_url(self) -> str:
-        return f"https://www.{self.domain}"
+        # `domain` is the full host, so a mock host with no `www.` works unchanged.
+        return f"https://{self.domain}"
 
     @property
     def signin_url(self) -> str:
@@ -47,21 +48,21 @@ class AmazonCountry:
 
 
 AMAZON_US = AmazonCountry(
-    domain="amazon.com",
+    domain="amazon-mock.dataportrait.app",
     purchase_history_key="amazon_purchase_history",
     watch_history_result_key="amazon_watch_history",
     watchlist_result_key="amazon_prime_watchlist",
     prime_library_result_key="amazon_prime_library",
-    watch_history_url="https://www.amazon.com/gp/video/settings/watch-history",
-    watchlist_url="https://www.amazon.com/gp/video/mystuff/watchlist",
-    prime_library_url="https://www.amazon.com/gp/video/mystuff/library",
-    browsing_history_url="https://www.amazon.com/gp/history?ref_=nav_AccountFlyout_browsinghistory",
-    watchlist_pagination_api_url="https://www.amazon.com/gp/video/api/paginateCollection",
-    watch_history_pagination_api_url="https://www.amazon.com/gp/video/api/getWatchHistorySettingsPage",
+    watch_history_url="https://amazon-mock.dataportrait.app/gp/video/settings/watch-history",
+    watchlist_url="https://amazon-mock.dataportrait.app/gp/video/mystuff/watchlist",
+    prime_library_url="https://amazon-mock.dataportrait.app/gp/video/mystuff/library",
+    browsing_history_url="https://amazon-mock.dataportrait.app/gp/history?ref_=nav_AccountFlyout_browsinghistory",
+    watchlist_pagination_api_url="https://amazon-mock.dataportrait.app/gp/video/api/paginateCollection",
+    watch_history_pagination_api_url="https://amazon-mock.dataportrait.app/gp/video/api/getWatchHistorySettingsPage",
 )
 
 AMAZON_CA = AmazonCountry(
-    domain="amazon.ca",
+    domain="www.amazon.ca",
     purchase_history_key="amazonca_purchase_history",
     watch_history_result_key="amazon_ca_watch_history",
     watchlist_result_key="amazon_ca_prime_watchlist",
@@ -822,7 +823,7 @@ async def _get_watch_history_with_pagination(
                         "headers": {{
                             "accept": "*/*",
                             "x-amzn-requestid": requestId,
-                            "Referer": "https://www.amazon.com/gp/video/settings/watch-history",
+                            "Referer": "{country.watch_history_url}",
                             "x-requested-with": "XMLHttpRequest"
                         }},
                         "body": null,

--- a/getgather/mcp/patterns/amazon-account-manage.html
+++ b/getgather/mcp/patterns/amazon-account-manage.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <body>
     <div>
       <div rb-match="h1[aria-label='Login & Security']"></div>

--- a/getgather/mcp/patterns/amazon-approve-notification.html
+++ b/getgather/mcp/patterns/amazon-approve-notification.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Approve notification</title>
   </head>

--- a/getgather/mcp/patterns/amazon-arkose-challenge.html
+++ b/getgather/mcp/patterns/amazon-arkose-challenge.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon Arkose Challenge</title>
   </head>

--- a/getgather/mcp/patterns/amazon-browsing-history-empty.html
+++ b/getgather/mcp/patterns/amazon-browsing-history-empty.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="6">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="6">
   <head>
     <title>Amazon Browsing History Empty</title>
   </head>

--- a/getgather/mcp/patterns/amazon-browsing-history-not-signin.html
+++ b/getgather/mcp/patterns/amazon-browsing-history-not-signin.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="6">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="6">
   <head>
     <title>Amazon Browsing History</title>
   </head>

--- a/getgather/mcp/patterns/amazon-browsing-history.html
+++ b/getgather/mcp/patterns/amazon-browsing-history.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="5">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="5">
   <body>
     <div>
       <div

--- a/getgather/mcp/patterns/amazon-captcha-frame.html
+++ b/getgather/mcp/patterns/amazon-captcha-frame.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon Captcha</title>
   </head>

--- a/getgather/mcp/patterns/amazon-captcha.html
+++ b/getgather/mcp/patterns/amazon-captcha.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon Captcha</title>
   </head>

--- a/getgather/mcp/patterns/amazon-continue-shopping.html
+++ b/getgather/mcp/patterns/amazon-continue-shopping.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon Continue Shopping</title>
   </head>

--- a/getgather/mcp/patterns/amazon-create-new-password-required.html
+++ b/getgather/mcp/patterns/amazon-create-new-password-required.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Create new password required</title>
   </head>

--- a/getgather/mcp/patterns/amazon-dcq.html
+++ b/getgather/mcp/patterns/amazon-dcq.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon Security Question</title>
   </head>

--- a/getgather/mcp/patterns/amazon-email-not-found.html
+++ b/getgather/mcp/patterns/amazon-email-not-found.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="6">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="6">
   <body>
     <p>You do not have an account with this email, please try again with a different email.</p>
     <p rb-match-html="//h1[contains(., 'new to Amazon')]" style="display: none"></p>

--- a/getgather/mcp/patterns/amazon-error-acc-temporary-onhold.html
+++ b/getgather/mcp/patterns/amazon-error-acc-temporary-onhold.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Account on hold temporarily</title>
   </head>

--- a/getgather/mcp/patterns/amazon-error-account-closed.html
+++ b/getgather/mcp/patterns/amazon-error-account-closed.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon account is closed</title>
   </head>

--- a/getgather/mcp/patterns/amazon-error-billing-details.html
+++ b/getgather/mcp/patterns/amazon-error-billing-details.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Enter your billing details</title>
   </head>

--- a/getgather/mcp/patterns/amazon-error-billing-verif.html
+++ b/getgather/mcp/patterns/amazon-error-billing-verif.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Billing verification required</title>
   </head>

--- a/getgather/mcp/patterns/amazon-error-card-expiration-date.html
+++ b/getgather/mcp/patterns/amazon-error-card-expiration-date.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Card expiration date verification required</title>
   </head>

--- a/getgather/mcp/patterns/amazon-error-choose-payment.html
+++ b/getgather/mcp/patterns/amazon-error-choose-payment.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Choose payment card to verify</title>
   </head>

--- a/getgather/mcp/patterns/amazon-error-document-submission.html
+++ b/getgather/mcp/patterns/amazon-error-document-submission.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Document submission required</title>
   </head>

--- a/getgather/mcp/patterns/amazon-error-multiple-email.html
+++ b/getgather/mcp/patterns/amazon-error-multiple-email.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Multiple accounts use the email</title>
   </head>

--- a/getgather/mcp/patterns/amazon-error-page-not-found.html
+++ b/getgather/mcp/patterns/amazon-error-page-not-found.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon Page Not Found</title>
   </head>

--- a/getgather/mcp/patterns/amazon-error-policy-violation.html
+++ b/getgather/mcp/patterns/amazon-error-policy-violation.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Return Policy Violation</title>
   </head>

--- a/getgather/mcp/patterns/amazon-error-security-code.html
+++ b/getgather/mcp/patterns/amazon-error-security-code.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Enter card security code</title>
   </head>

--- a/getgather/mcp/patterns/amazon-error-switch-country.html
+++ b/getgather/mcp/patterns/amazon-error-switch-country.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Switch countries</title>
   </head>

--- a/getgather/mcp/patterns/amazon-error-temporary-locked.html
+++ b/getgather/mcp/patterns/amazon-error-temporary-locked.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Account locked temporarily</title>
   </head>

--- a/getgather/mcp/patterns/amazon-keep-hacker-out.html
+++ b/getgather/mcp/patterns/amazon-keep-hacker-out.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Keep hackers out</title>
   </head>

--- a/getgather/mcp/patterns/amazon-new-to-amazon.html
+++ b/getgather/mcp/patterns/amazon-new-to-amazon.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="5">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="5">
   <body>
     <h1 rb-stop rb-error="email_not_found" rb-match="a.signin-with-another-account">
       Looks like you're new to Amazon

--- a/getgather/mcp/patterns/amazon-orders-business-account.html
+++ b/getgather/mcp/patterns/amazon-orders-business-account.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="3">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="3">
   <body>
     <div>
       <div

--- a/getgather/mcp/patterns/amazon-orders.html
+++ b/getgather/mcp/patterns/amazon-orders.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <body>
     <div>
       <div

--- a/getgather/mcp/patterns/amazon-otp-app.html
+++ b/getgather/mcp/patterns/amazon-otp-app.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon Verification</title>
   </head>

--- a/getgather/mcp/patterns/amazon-otp-auth.html
+++ b/getgather/mcp/patterns/amazon-otp-auth.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon Verification</title>
   </head>

--- a/getgather/mcp/patterns/amazon-otp-email.html
+++ b/getgather/mcp/patterns/amazon-otp-email.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="1">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="1">
   <head>
     <title>Amazon Verification</title>
   </head>

--- a/getgather/mcp/patterns/amazon-otp-general.html
+++ b/getgather/mcp/patterns/amazon-otp-general.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="3">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="3">
   <head>
     <title>Amazon Verification</title>
   </head>

--- a/getgather/mcp/patterns/amazon-otp-phone.html
+++ b/getgather/mcp/patterns/amazon-otp-phone.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="1">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="1">
   <head>
     <title>Amazon Verification</title>
   </head>

--- a/getgather/mcp/patterns/amazon-otp-whatsapp.html
+++ b/getgather/mcp/patterns/amazon-otp-whatsapp.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="1">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="1">
   <head>
     <title>Verify with WhatsApp</title>
   </head>

--- a/getgather/mcp/patterns/amazon-password-reset-required.html
+++ b/getgather/mcp/patterns/amazon-password-reset-required.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Password reset required</title>
   </head>

--- a/getgather/mcp/patterns/amazon-prime-library-empty.html
+++ b/getgather/mcp/patterns/amazon-prime-library-empty.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Prime Video: You don't have any purchases</title>
   </head>

--- a/getgather/mcp/patterns/amazon-prime-library.html
+++ b/getgather/mcp/patterns/amazon-prime-library.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <body>
     <div>
       <div

--- a/getgather/mcp/patterns/amazon-prime-watch-history-empty.html
+++ b/getgather/mcp/patterns/amazon-prime-watch-history-empty.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Prime Video: Your Watch History is empty</title>
   </head>

--- a/getgather/mcp/patterns/amazon-prime-watchlist-empty.html
+++ b/getgather/mcp/patterns/amazon-prime-watchlist-empty.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Prime Video: Your watchlist is empty</title>
   </head>

--- a/getgather/mcp/patterns/amazon-prime-watchlist.html
+++ b/getgather/mcp/patterns/amazon-prime-watchlist.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <body>
     <div>
       <div

--- a/getgather/mcp/patterns/amazon-search-product.html
+++ b/getgather/mcp/patterns/amazon-search-product.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <body>
     <div>
       <div rb-convert="amazon-search-product.json" rb-match-html="div.s-main-slot" rb-stop></div>

--- a/getgather/mcp/patterns/amazon-search-purchase-history.html
+++ b/getgather/mcp/patterns/amazon-search-purchase-history.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <body>
     <div>
       <div

--- a/getgather/mcp/patterns/amazon-select-personal-account.html
+++ b/getgather/mcp/patterns/amazon-select-personal-account.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="3">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="3">
   <head>
     <title>Select Account</title>
   </head>

--- a/getgather/mcp/patterns/amazon-send-otp.html
+++ b/getgather/mcp/patterns/amazon-send-otp.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="5">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="5">
   <head>
     <title>Authentication required</title>
   </head>

--- a/getgather/mcp/patterns/amazon-signin-email-not-found.html
+++ b/getgather/mcp/patterns/amazon-signin-email-not-found.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon email not found</title>
   </head>

--- a/getgather/mcp/patterns/amazon-signin-email-only-2.html
+++ b/getgather/mcp/patterns/amazon-signin-email-only-2.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon Sign In - Email</title>
   </head>

--- a/getgather/mcp/patterns/amazon-signin-email-only.html
+++ b/getgather/mcp/patterns/amazon-signin-email-only.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon Sign In - Email</title>
   </head>

--- a/getgather/mcp/patterns/amazon-signin-password-only.html
+++ b/getgather/mcp/patterns/amazon-signin-password-only.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon Sign In - Password</title>
   </head>

--- a/getgather/mcp/patterns/amazon-signin.html
+++ b/getgather/mcp/patterns/amazon-signin.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon Sign In</title>
   </head>

--- a/getgather/mcp/patterns/amazon-something-error-ca.html
+++ b/getgather/mcp/patterns/amazon-something-error-ca.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon Something Error</title>
   </head>

--- a/getgather/mcp/patterns/amazon-something-error.html
+++ b/getgather/mcp/patterns/amazon-something-error.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>Amazon Something Error</title>
   </head>

--- a/getgather/mcp/patterns/amazon-verification-01.html
+++ b/getgather/mcp/patterns/amazon-verification-01.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="9">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="9">
   <head>
     <title>Amazon Verification</title>
   </head>

--- a/getgather/mcp/patterns/amazon-verification-02.html
+++ b/getgather/mcp/patterns/amazon-verification-02.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="9">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="9">
   <head>
     <title>Amazon Verification</title>
   </head>

--- a/getgather/mcp/patterns/amazon-verify-with-passkey-or-whatsapp.html
+++ b/getgather/mcp/patterns/amazon-verify-with-passkey-or-whatsapp.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="3">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="3">
   <head>
     <title>Verify with WhatsApp</title>
   </head>

--- a/getgather/mcp/patterns/amazon-verify-with-whatsapp.html
+++ b/getgather/mcp/patterns/amazon-verify-with-whatsapp.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="3">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="3">
   <head>
     <title>Verify with WhatsApp</title>
   </head>

--- a/getgather/mcp/patterns/amazon-watch-history.html
+++ b/getgather/mcp/patterns/amazon-watch-history.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <body>
     <div>
       <div

--- a/getgather/mcp/patterns/amazon-zen-otp-app-approval.html
+++ b/getgather/mcp/patterns/amazon-zen-otp-app-approval.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="5">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="5">
   <head>
     <title>Amazon Verification</title>
   </head>

--- a/getgather/mcp/patterns/amazon-zen-otp-auth.html
+++ b/getgather/mcp/patterns/amazon-zen-otp-auth.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="5">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="5">
   <head>
     <title>Amazon Verification</title>
   </head>

--- a/getgather/mcp/patterns/amazon-zen-otp-email.html
+++ b/getgather/mcp/patterns/amazon-zen-otp-email.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="5">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="5">
   <head>
     <title>Amazon Verification</title>
   </head>

--- a/getgather/mcp/patterns/amazon-zen-otp-phone.html
+++ b/getgather/mcp/patterns/amazon-zen-otp-phone.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon" rb-priority="5">
+<html rb-domain="amazon-mock.dataportrait.app" rb-priority="5">
   <head>
     <title>Amazon Verification</title>
   </head>

--- a/getgather/mcp/patterns/amazon-zip-code-required.html
+++ b/getgather/mcp/patterns/amazon-zip-code-required.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <head>
     <title>ZIP code required</title>
   </head>

--- a/getgather/mcp/patterns/kindle-books-empty.html
+++ b/getgather/mcp/patterns/kindle-books-empty.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <body>
     <div>
       <div rb-stop rb-match-html="div#NO-RESULT-FOUND"></div>

--- a/getgather/mcp/patterns/kindle-books.html
+++ b/getgather/mcp/patterns/kindle-books.html
@@ -1,4 +1,4 @@
-<html rb-domain="amazon">
+<html rb-domain="amazon-mock.dataportrait.app">
   <body>
     <div>
       <div rb-convert="kindle-books.json" rb-match-html="div#CONTENT_LIST" rb-stop></div>

--- a/getgather/memory_xray.py
+++ b/getgather/memory_xray.py
@@ -1,0 +1,226 @@
+"""[XRAY] memory: periodic process-memory telemetry for leak hunting.
+
+The tap-connect sidecar deployment grows ~23MB/h (147MB RSS at boot, 632MB
+after 21h) and is never OOM-killed — it just thrashes the VM until /health
+times out — so nothing in the runtime reports the growth. This samples the
+process and ships the numbers to Logfire so growth can be *attributed* rather
+than guessed at.
+
+Four independent signals, because they fail differently and each one rules a
+whole class of cause in or out:
+
+- **RSS** — is it growing at all, and how fast.
+- **fds / sockets** — leaked CDP websockets. `websocket_proxy` holds sockets
+  with `max_size=10MB` and `close_timeout=7200`, so a relay that never tears
+  down is worth MBs each and shows here long before it shows in a type census.
+- **asyncio tasks** — fire-and-forget tasks that never finish (`_cleanup_losers`
+  retries for 40s per loser; `websocket_proxy`'s pump tasks).
+- **gc type census + tracemalloc** — pure-Python object growth, attributed to a
+  type and then to an allocation site.
+
+Stdlib only, by design: psutil/memray would churn uv.lock and the vendored
+sidecar build for what is a diagnostic.
+"""
+
+import asyncio
+import gc
+import os
+import tracemalloc
+from collections import Counter
+from typing import Any
+
+import logfire
+from loguru import logger
+
+from getgather.config import settings
+
+_STATUS_FIELDS = ("VmRSS", "VmSize", "VmSwap", "VmHWM")
+
+
+def _proc_status_kb() -> dict[str, int]:
+    """Memory fields from /proc/self/status, in kB.
+
+    /proc is Linux-only; on a macOS dev box this returns {} and the sampler
+    still emits every other counter rather than dying.
+    """
+    try:
+        with open("/proc/self/status") as f:
+            lines = f.readlines()
+    except OSError:
+        return {}
+    out: dict[str, int] = {}
+    for line in lines:
+        name, _, rest = line.partition(":")
+        if name in _STATUS_FIELDS:
+            out[name] = int(rest.split()[0])
+    return out
+
+
+def _fd_counts() -> tuple[int, int]:
+    """(total open fds, of which sockets). Sockets are the websocket-leak signal."""
+    try:
+        entries = os.listdir("/proc/self/fd")
+    except OSError:
+        return (0, 0)
+    sockets = 0
+    for entry in entries:
+        try:
+            if os.readlink(f"/proc/self/fd/{entry}").startswith("socket:"):
+                sockets += 1
+        except OSError:
+            continue  # fd closed between listdir and readlink
+    return (len(entries), sockets)
+
+
+def _task_count() -> int:
+    try:
+        return len(asyncio.all_tasks())
+    except RuntimeError:
+        return 0
+
+
+def _type_counts() -> Counter[str]:
+    """Census of live objects by type name.
+
+    gc.get_objects() walks every tracked object, so this is the expensive part
+    of a sample (~100ms at ~1M objects) — hence MEMORY_XRAY_CENSUS gating it
+    separately from the cheap counters.
+
+    Reads only tracked objects, so a flat census does NOT mean a flat heap:
+    CPython untracks dicts/tuples holding only atomic values, and raw bytes/str
+    buffers were never tracked to begin with. A leak of 10MB websocket frames
+    shows up in tracemalloc and RSS while barely moving this number. Treat it
+    as "which live object graph is growing", not as a heap total.
+    """
+    counts: Counter[str] = Counter()
+    for obj in gc.get_objects():
+        counts[type(obj).__qualname__] += 1
+    return counts
+
+
+def _known_suspects() -> dict[str, int]:
+    """Sizes of unbounded module-level collections we already know about.
+
+    Imported lazily so this module stays importable without pulling the tracing
+    stack in at import time.
+    """
+    from getgather.tracing import _emitted_session_root_spans  # pyright: ignore[reportPrivateUsage]
+
+    return {"emitted_session_root_spans": len(_emitted_session_root_spans)}
+
+
+def _tracemalloc_top(
+    baseline: tracemalloc.Snapshot | None, top_n: int
+) -> tuple[tracemalloc.Snapshot, list[dict[str, Any]]]:
+    """Top allocation sites by size growth since `baseline`.
+
+    Compared against a baseline taken at the first sample, so the result is
+    "what grew while serving traffic" — startup allocations (~40 MCP bundles)
+    net out to zero instead of burying the signal.
+    """
+    snapshot = tracemalloc.take_snapshot()
+    if baseline is None:
+        return snapshot, []
+    top: list[dict[str, Any]] = []
+    for stat in snapshot.compare_to(baseline, "lineno")[:top_n]:
+        frame = stat.traceback[0]
+        top.append({
+            "site": f"{frame.filename}:{frame.lineno}",
+            "size_diff_kb": round(stat.size_diff / 1024, 1),
+            "count_diff": stat.count_diff,
+            "size_kb": round(stat.size / 1024, 1),
+        })
+    return snapshot, top
+
+
+async def memory_xray_loop(stop_event: asyncio.Event) -> None:
+    """Sample every MEMORY_XRAY_INTERVAL seconds until `stop_event` is set."""
+    interval = settings.MEMORY_XRAY_INTERVAL
+    top_n = settings.MEMORY_XRAY_TOP_N
+
+    rss_gauge = logfire.metric_gauge("getgather.memory.rss_mb", unit="MB")
+    fd_gauge = logfire.metric_gauge("getgather.memory.open_fds")
+    socket_gauge = logfire.metric_gauge("getgather.memory.open_sockets")
+    task_gauge = logfire.metric_gauge("getgather.memory.asyncio_tasks")
+    objects_gauge = logfire.metric_gauge("getgather.memory.gc_objects")
+    traced_gauge = logfire.metric_gauge("getgather.memory.traced_mb", unit="MB")
+
+    if settings.MEMORY_XRAY_TRACEMALLOC:
+        # Started here rather than at import: we want growth *after* startup,
+        # so the ~40 MCP bundles mounted before the app binds are deliberately
+        # outside the trace. nframe=1 keeps the trace overhead modest — enough
+        # for a file:line, not a full call path.
+        tracemalloc.start(1)
+        logger.info("[XRAY] memory: tracemalloc enabled (nframe=1)")
+
+    baseline_snapshot: tracemalloc.Snapshot | None = None
+    baseline_rss: int | None = None
+    baseline_types: Counter[str] | None = None
+
+    while not stop_event.is_set():
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval)
+            return  # stop_event fired — shutting down
+        except asyncio.TimeoutError:
+            pass
+
+        try:
+            status = _proc_status_kb()
+            rss_kb = status.get("VmRSS", 0)
+            open_fds, open_sockets = _fd_counts()
+            tasks = _task_count()
+            gc_objects = len(gc.get_objects())
+
+            if baseline_rss is None:
+                baseline_rss = rss_kb
+
+            rss_gauge.set(round(rss_kb / 1024, 1))
+            fd_gauge.set(open_fds)
+            socket_gauge.set(open_sockets)
+            task_gauge.set(tasks)
+            objects_gauge.set(gc_objects)
+
+            fields: dict[str, Any] = {
+                "rss_mb": round(rss_kb / 1024, 1),
+                "rss_growth_mb": round((rss_kb - baseline_rss) / 1024, 1),
+                "vm_size_mb": round(status.get("VmSize", 0) / 1024, 1),
+                "vm_hwm_mb": round(status.get("VmHWM", 0) / 1024, 1),
+                "open_fds": open_fds,
+                "open_sockets": open_sockets,
+                "asyncio_tasks": tasks,
+                "gc_objects": gc_objects,
+                "gc_collections": [s["collections"] for s in gc.get_stats()],
+                **_known_suspects(),
+            }
+
+            if settings.MEMORY_XRAY_CENSUS:
+                types = _type_counts()
+                if baseline_types is None:
+                    baseline_types = types
+                    fields["top_types"] = types.most_common(top_n)
+                else:
+                    growth = Counter({
+                        name: count - baseline_types.get(name, 0) for name, count in types.items()
+                    })
+                    fields["top_type_growth"] = growth.most_common(top_n)
+
+            if settings.MEMORY_XRAY_TRACEMALLOC:
+                # The total across ALL sites, not just the reported top-N. This
+                # is what separates the two remaining explanations for RSS: if
+                # traced stays small while RSS climbs, the memory is freed by
+                # Python and retained by the allocator; if traced tracks RSS,
+                # it is a real object leak spread below the top-N threshold.
+                traced, traced_peak = tracemalloc.get_traced_memory()
+                traced_gauge.set(round(traced / 1024 / 1024, 1))
+                fields["traced_mb"] = round(traced / 1024 / 1024, 1)
+                fields["traced_peak_mb"] = round(traced_peak / 1024 / 1024, 1)
+                fields["untraced_mb"] = round(rss_kb / 1024 - traced / 1024 / 1024, 1)
+
+                baseline_snapshot, top = _tracemalloc_top(baseline_snapshot, top_n)
+                if top:
+                    fields["top_alloc_sites"] = top
+
+            logfire.info("[XRAY] memory sample", **fields)
+        except Exception as e:
+            # A diagnostic must never take the process down with it.
+            logger.error(f"[XRAY] memory sample failed: {type(e).__name__}: {e}")

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -5,6 +5,7 @@ import urllib.parse
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
+from functools import lru_cache
 from glob import glob
 from pathlib import Path
 from typing import Any, Callable, Coroutine, cast
@@ -289,6 +290,11 @@ async def get_error(distilled: str) -> str | None:
     return None
 
 
+# Parsing the ~470 pattern files costs ~3.5s of blocking CPU on the event loop, and
+# every MCP tool call used to redo it. Sharing one parse is safe because the only
+# consumer (run_distillation_loop) deepcopies each tree before mutating it.
+# Trade-off: pattern files are read once per process, so edits need a restart.
+@lru_cache(maxsize=8)
 def load_distillation_patterns(path: str) -> list[Pattern]:
     patterns: list[Pattern] = []
     for name in glob(path, recursive=True):


### PR DESCRIPTION
> **Do not merge this branch. Deploy from it.** It repoints Amazon at a mock fixture; on `main` that would send every production caller at `amazon-mock.dataportrait.app`. `main` merges *in* to pick up upstream changes, never the reverse. Open for review and history, not for merge.

The remotebrowser half of a pair. The other half is the branch of the same name in **corelens-engineering/demos** (PR #1275), which carries the sidecar deployment — `Dockerfile.sidecar`, `start-sidecar.sh`, `sync-remotebrowser.sh` and three Fly configs for `tap-connect-mock-{flyfleet,browserbase,daytona}`.

That repo's `sync-remotebrowser.sh` vendors `getgather` out of a local checkout of *this* repo into its build context, so **whichever branch this repo is on is what gets deployed.** The two branches are only meaningfully deployable together — which is why this one exists rather than the demos side carrying a half-repointing that silently hits real Amazon.

## The change

65 files, essentially all host substitution:

| Files | Change |
| --- | --- |
| `getgather/mcp/amazon.py` | `AMAZON_US.domain` and its five absolute `*_url` fields → `amazon-mock.dataportrait.app` |
| 64 × `getgather/mcp/patterns/*.html` | `rb-domain="amazon"` → `rb-domain="amazon-mock.dataportrait.app"` |

Two edits are not pure substitution and are where review effort is worth spending:

- **`base_url` no longer hard-codes `www.`** — it was `f"https://www.{self.domain}"`, and `domain` is now the full host so a mock host without a `www.` works unchanged. `AMAZON_CA` compensates by carrying `www.amazon.ca` as its domain, so its behaviour is byte-identical to before. Worth confirming that reading.
- **The watch-history `Referer` now interpolates `{country.watch_history_url}`** instead of a literal `https://www.amazon.com/...`. This is a real fix independent of the mock — `_get_watch_history_with_pagination` is country-parameterised, so an `AMAZON_CA` call was sending a `.com` referer. It is the one thing here that would be worth landing on `main` on its own merits.

## What was left on `mock`

One commit, `869e5a9` — five files of loopback-CDP leak fixes. Excluded because they are browser-lifecycle product changes, not mock configuration, and want their own review. `MOCK-OVERRIDES.md` inventories them individually with ship dates and known remainders.

**They matter operationally.** Without them a sidecar deployed from this branch leaks roughly **300 sockets and ~284 MB per run** on the `browserbase` and `daytona` backends, reaching ~600 MB on a 1 GB VM. Past that, memory pressure kills `tailscaled`, the tailnet database goes unreachable, `/health` 500s, Fly deroutes the machine, and every test against it fails *while the machine simultaneously goes dark in telemetry* — which is how it hides. Deployments setting `CHROMEFLEET_URL` (the flyfleet tenant) do not take the leaking path.

So: deployable, but the browserbase and daytona tenants will wedge on a timescale of hours until those fixes land somewhere.

## Review notes

- The 64 pattern files are one mechanical substitution each; `getgather/mcp/amazon.py` and `MOCK-OVERRIDES.md` are the only files worth reading closely.
- Those 65 files are byte-identical to `mock`.
- Evidence for the leak claims lives in the demos repo on `mock`, at `apps/tap-connect/DEBUG-mock-tests.md`.
- Not deployed from this branch; the measurements cited were taken against `mock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)