### PR TITLE
fix(browsers): delete sandbox/container on egress IP verification failure

### DIFF
--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -189,7 +189,14 @@ class DaytonaBackend:
             sandbox = await self._ensure(browser_id, browser_type)
             # Proxy is mandatory when configured: let ProxyVerificationError propagate (the endpoint
             # maps it to 500) so the client can retry rather than get an unproxied browser.
-            await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+            try:
+                await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+            except ProxyVerificationError:
+                # A sandbox that fails proxy verification is unusable (wrong/no egress IP) and
+                # would otherwise sit around until Daytona's auto_stop/auto_delete TTL. Delete now.
+                logger.warning(f"Deleting sandbox {sandbox.name} after proxy verification failure")
+                await sandbox.delete()
+                raise
             return await self._get_info(sandbox)
 
     async def get_browser(

--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -349,7 +349,16 @@ class PodmanBackend:
     ) -> dict[str, Any]:
         container_name = f"{BROWSER_NAME_PREFIX}{browser_id}"
         await launch_container(settings.CONTAINER_IMAGE, container_name)
-        ip = await configure_remote_browser(browser_id, container_name, origin_ip, target_domain)
+        try:
+            ip = await configure_remote_browser(
+                browser_id, container_name, origin_ip, target_domain
+            )
+        except ProxyVerificationError:
+            # A container that fails proxy verification is unusable (wrong/no egress IP) and
+            # would otherwise sit around until manually reaped. Delete it immediately.
+            logger.warning(f"Deleting {container_name} after proxy verification failure")
+            await kill_container(container_name)
+            raise
         return {"container_name": container_name, "status": "created", "ip": ip}
 
     async def get_browser(

--- a/tests/test_podman_browsers.py
+++ b/tests/test_podman_browsers.py
@@ -113,17 +113,26 @@ async def test_get_browser_never_reconfigures_proxy(monkeypatch: MonkeyPatch) ->
 async def test_create_browser_propagates_proxy_verification_error(monkeypatch: MonkeyPatch) -> None:
     # create_browser must let ProxyVerificationError propagate (the endpoint maps it to 500) so the
     # client can retry rather than get an unproxied browser; best-of-N relies on this to fail a loser.
+    # It must also kill the now-unusable container rather than leaking it.
     async def fake_launch(image: str, name: str) -> str:
         return "container-id"
 
     async def fake_configure(*args: Any, **kwargs: Any) -> str | None:
         raise ProxyVerificationError("IP unchanged after proxy")
 
+    killed: list[str] = []
+
+    async def fake_kill(container_name: str) -> None:
+        killed.append(container_name)
+
     monkeypatch.setattr(podman_browsers, "launch_container", fake_launch)
     monkeypatch.setattr(podman_browsers, "configure_remote_browser", fake_configure)
+    monkeypatch.setattr(podman_browsers, "kill_container", fake_kill)
 
     with pytest.raises(ProxyVerificationError, match="IP unchanged"):
         await PodmanBackend().create_browser("b0", "1.2.3.4", "amazon.com", None)
+
+    assert killed == ["chromium-b0"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Daytona `create_browser` and Podman `create_browser` left orphaned sandboxes/containers running whenever egress IP verification failed (`ProxyVerificationError`), relying on Daytona TTL cleanup (podman had none at all).
- Both now delete the machine immediately on that failure before re-raising, so the client's retry doesn't leave broken infra behind.

## Test plan
- [x] `uv run pytest tests/test_daytona_browsers.py tests/test_podman_browsers.py -q` — 22 passed
- [x] `make check-backend-format`, `uv run pyright` on changed files