### PR TITLE
fix(cdp): return empty list when a browser is unreachable instead of raises

### DIFF
--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -58,7 +58,6 @@ async def get_page_list(browser_id: str) -> list[str]:
         # for an ended session). In every case the browser has no reachable pages.
         logger.info(f"[CDP] browser {browser_id} unreachable: {type(e).__name__}")
         return []
-    client = await open_browser_cdp_client(browser_id)
     if client is None:
         return []
     try:

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -3,6 +3,7 @@ import html
 import json
 from typing import Any
 
+import httpx
 import websockets
 from fastapi import APIRouter, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -49,6 +50,14 @@ async def get_page_list(browser_id: str) -> list[str]:
     # works uniformly for every backend that exposes a browser-level socket (Browserbase via
     # connectUrl, Podman/Daytona via /json/version discovery); Fleet relays /devtools to its
     # own proxy and never reaches this path, so open_browser_cdp_client returns None there.
+    try:
+        client = await open_browser_cdp_client(browser_id)
+    except (BrowserNotFound, httpx.HTTPStatusError) as e:
+        # A Daytona sandbox that is stopped or archived answers 400/404 on its signed
+        # preview URL, and a deleted one raises BrowserNotFound (Browserbase answers 410
+        # for an ended session). In every case the browser has no reachable pages.
+        logger.info(f"[CDP] browser {browser_id} unreachable: {type(e).__name__}")
+        return []
     client = await open_browser_cdp_client(browser_id)
     if client is None:
         return []


### PR DESCRIPTION
## Problem
`get_page_list` opens its CDP client **outside** its own `try`, so an unreachable browser raises instead of returning `[]`. `find_browser_id` re-raises, so one dead browser aborts the whole scan and hides every later entry — including the live one.

Two exception types, both meaning "this browser is gone":

| Exception | Raised from | Cause |
| --- | --- | --- |
| `httpx.HTTPStatusError` | `raise_for_status()` on `/json/version` | sandbox STOPPED or ARCHIVED — its signed preview URL answers **400** (**404** also seen) |
| `BrowserNotFound` | `get_cdp_base_url` when `_get()` returns `None` | sandbox deleted |

Observed three times in ~50 minutes, every one at probe 1 of N:

```
[FIND] probe 1/76 B92dfhdrt raised BrowserNotFound      — 75 later entries never probed
[FIND] probe 1/72 Biw2w8tng raised HTTPStatusError 400  — 71 later entries never probed
[FIND] probe 1/73 Bg66hvxep raised HTTPStatusError 400  — 72 later entries never probed
```

The page is then never found, so `/dpage` dies without a response and the caller blocks on undici's default 300s `headersTimeout` — past the client's own 180s budget, so the run surfaces a bare timeout with no error attached.

## Fix

`get_page_list` already returns `[]` when page enumeration fails; this makes it do so consistently, including when the connection itself fails.

## Verification

Deployed as an equivalent skip-and-continue. Two runs hit dead sandboxes at probes 6/9/10/11 and still matched the live browser at probe 13 — both would have aborted and hung under the current behaviour:

```
probe 11/95 Bk98vd3cn raised BrowserNotFound — skipped MATCH at probe 13 after skipping 1 dead browser(s)
```

Zero scan aborts and zero 300s `/dpage` failures in the ~5 hours since.