### PR TITLE
fix(cdp): scan only running sandboxes when locating a page

### DIFF
--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Protocol, cast, runtime_checkable
+from typing import Any, Literal, Protocol, cast, runtime_checkable
 
 import httpx
 from fastapi import WebSocket
@@ -11,6 +11,10 @@ from getgather.config import FRIENDLY_CHARS, settings
 # Shared name prefix: a browser with id `abc` is a podman container / Daytona sandbox named
 # `chromium-abc`. Both local backends derive names and parse ids from this single prefix.
 BROWSER_NAME_PREFIX = "chromium-"
+
+# Which browsers a listing should include. `all` is the full inventory, including ones a
+# backend can resume on demand; `live` is only those able to serve CDP right now.
+BROWSER_SCOPE = Literal["all", "live"]
 
 
 def rewrite_ws_url(ws_url: str, cdp_base_url: str) -> str:
@@ -216,7 +220,15 @@ class Backend(Protocol):
 
     async def delete_browser(self, browser_id: str) -> dict[str, Any]: ...
 
-    async def list_browser_ids(self) -> list[str]: ...
+    async def list_browser_ids(self, scope: BROWSER_SCOPE = "all") -> list[str]:
+        """Every browser this backend knows about.
+
+        Pass `"live"` when you intend to reach one (page lookup, CDP relay) rather than
+        report inventory. Backends whose listing already holds only reachable browsers
+        return the same ids either way; the distinction matters for Daytona, which keeps
+        stopped and archived sandboxes in its listing.
+        """
+        ...
 
     async def browser_exists(self, browser_id: str) -> bool: ...
 

--- a/getgather/browsers/browserbase_browsers.py
+++ b/getgather/browsers/browserbase_browsers.py
@@ -10,7 +10,7 @@ from fastapi.websockets import WebSocketState
 from loguru import logger
 from websockets.exceptions import ConnectionClosed, InvalidStatus
 
-from getgather.browsers.backend import BrowserNotFound
+from getgather.browsers.backend import BROWSER_SCOPE, BrowserNotFound
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
 
@@ -373,7 +373,7 @@ class BrowserbaseBackend:
     async def browser_exists(self, browser_id: str) -> bool:
         return browser_id in self._sessions
 
-    async def list_browser_ids(self) -> list[str]:
+    async def list_browser_ids(self, scope: BROWSER_SCOPE = "all") -> list[str]:
         return list(self._sessions.keys())
 
     async def cleanup_idle(self) -> list[str]:

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -10,12 +10,14 @@ from daytona import (
     DaytonaConflictError,
     DaytonaNotFoundError,
     ListSandboxesQuery,
+    SandboxState,
 )
 from fastapi import WebSocket
 from loguru import logger
 
 from getgather.browsers.backend import (
     BROWSER_NAME_PREFIX,
+    BROWSER_SCOPE,
     BrowserNotFound,
     ProxyVerificationError,
     get_browser_websocket_debugger_url,
@@ -219,9 +221,25 @@ class DaytonaBackend:
     async def browser_exists(self, browser_id: str) -> bool:
         return await self._get(_sandbox_name(browser_id)) is not None
 
-    async def list_browser_ids(self) -> list[str]:
+    async def list_browser_ids(self, scope: BROWSER_SCOPE = "all") -> list[str]:
+        """Sandboxes carrying our fleet label; `"live"` keeps only the running ones.
+
+        Stopped and archived sandboxes stay in the default listing because `_ensure`
+        resumes them on demand, so they are still usable browsers. They cannot serve CDP
+        as they are, though — a stopped sandbox's signed preview URL answers HTTP 400 — so
+        callers hunting for a live page must pass `"live"`. Archived sandboxes accumulate
+        (`auto_delete_interval` counts *continuously stopped* time, and archiving ends that
+        state) and were observed reaching 50 of 87 entries, so the distinction matters.
+
+        The state filter is applied server-side, so the unusable majority is never fetched.
+        STARTING is excluded along with STOPPED/ARCHIVED: its CDP endpoint is not up yet.
+        """
+        query = ListSandboxesQuery(
+            labels={LABEL_FLEET: "1"},
+            states=[SandboxState.STARTED] if scope == "live" else None,
+        )
         browser_ids: list[str] = []
-        async for sandbox in self.client.list(ListSandboxesQuery(labels={LABEL_FLEET: "1"})):
+        async for sandbox in self.client.list(query):
             # A just-deleted sandbox lingers briefly as `DESTROYED_<name>_<ts>`; only our names count.
             if sandbox.name and sandbox.name.startswith(BROWSER_NAME_PREFIX):
                 browser_ids.append(_browser_id_from_name(sandbox.name))

--- a/getgather/browsers/fleet_browsers.py
+++ b/getgather/browsers/fleet_browsers.py
@@ -5,7 +5,7 @@ from fastapi import WebSocket
 from fastmcp.server.dependencies import get_http_headers
 from httpx_retries import Retry, RetryTransport
 
-from getgather.browsers.backend import BrowserNotFound
+from getgather.browsers.backend import BROWSER_SCOPE, BrowserNotFound
 from getgather.client_ip import client_ip_var
 from getgather.config import settings
 
@@ -138,7 +138,7 @@ class FleetBackend:
         )
         return response is not None and response.status_code == 200
 
-    async def list_browser_ids(self) -> list[str]:
+    async def list_browser_ids(self, scope: BROWSER_SCOPE = "all") -> list[str]:
         response = _require(await call_chromefleet_api("GET"))
         data: Any = response.json()
         if not isinstance(data, list):

--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from getgather.browsers.backend import (
     BROWSER_NAME_PREFIX,
+    BROWSER_SCOPE,
     BrowserNotFound,
     ProxyVerificationError,
     get_browser_websocket_debugger_url,
@@ -383,7 +384,7 @@ class PodmanBackend:
     async def browser_exists(self, browser_id: str) -> bool:
         return await container_exists(f"{BROWSER_NAME_PREFIX}{browser_id}")
 
-    async def list_browser_ids(self) -> list[str]:
+    async def list_browser_ids(self, scope: BROWSER_SCOPE = "all") -> list[str]:
         containers = await list_containers()
         return [
             c[len(BROWSER_NAME_PREFIX) :] for c in containers if c.startswith(BROWSER_NAME_PREFIX)

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -64,7 +64,11 @@ async def get_page_list(browser_id: str) -> list[str]:
 
 
 async def find_browser_id(page_id: str) -> str | None:
-    for browser_id in await backend.list_browser_ids():
+    # Live-only: a stopped or archived browser cannot host the page, so probing it would only
+    # buy a round-trip and an error.
+    browser_ids = await backend.list_browser_ids("live")
+    logger.debug(f"[CDP] scanning {len(browser_ids)} browser(s) for page_id={page_id}")
+    for browser_id in browser_ids:
         page_ids = await get_page_list(browser_id)
         if page_id in page_ids:
             return browser_id


### PR DESCRIPTION
## Problem

`find_browser_id` probes every cached browser to find which one holds a given page. On Daytona that listing includes sandboxes that cannot serve CDP:

- **STOPPED / ARCHIVED** — the signed preview URL answers HTTP 400 - deleted — `get_cdp_base_url` raises `BrowserNotFound`

Each one costs two Daytona control-plane calls plus a proxy round-trip before the scan reaches a live browser. A live sample held **87 sandboxes — 24 STARTED, 13 STOPPED, 50 ARCHIVED**: 72%.

## Change

`list_browser_ids` takes a scope:

```python
BROWSER_SCOPE = Literal["all", "live"]

async def list_browser_ids(self, scope: BROWSER_SCOPE = "all") -> list[str]: ...
```

- **`"all"` (default)** — full inventory, unchanged behaviour for `GET /api/v1/browsers`. Stopped sandboxes belong here: `_ensure` resumes them on demand, so they are cold but still usable browsers.
- **`"live"`** — `find_browser_id` passes this. Daytona turns it into a server-side `states=[STARTED]` filter, so the unusable majority is never fetched. STARTING is excluded as well: its CDP endpoint is not up yet.

Fleet, Podman and Browserbase ignore the scope — their listings only ever contain reachable browsers, so both scopes return the same ids.

## Verification

Against the live Daytona API, through `DaytonaBackend`:

```
list_browser_ids()        ->   2  ['B292g3f9v', 'B7ss5s2wx']
list_browser_ids("live")  ->   1  ['B292g3f9v']
live is a subset of all   : True
ground truth states       : {'STARTED': 1, 'STOPPED': 1}
STARTED per ground truth  : 1  == live count 1
```

Measured effect when deployed.

| | before | after |
| --- | --- | --- |
| scan size | 87–94 | 27–28 |
| `/dpage` p50 | 17,591 ms | 11,232 ms |
| sign-in step p50 | 42,146 ms | 21,632 ms |