### PR TITLE
fix(browsers): always close client_ws in CDP websocket proxy relay

### DIFF
--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -137,7 +137,7 @@ async def websocket_proxy(
             remote_url,
             ping_interval=60,
             ping_timeout=30,
-            close_timeout=7200,
+            close_timeout=10,
             max_size=10 * 1024 * 1024,
         ) as remote_ws:
             logger.info("[CDP] Connected to remote WebSocket")
@@ -193,6 +193,9 @@ async def websocket_proxy(
         logger.error(f"[CDP] Unexpected error: {type(e).__name__}: {e}")
         if client_ws.client_state == WebSocketState.CONNECTED:
             await client_ws.close(code=4500, reason="Internal proxy error")
+    finally:
+        if client_ws.client_state == WebSocketState.CONNECTED:
+            await client_ws.close()
 
 
 @router.post("/api/v1/browsers")


### PR DESCRIPTION
## Summary
- `websocket_proxy()` only closed `client_ws` on the two exception branches; normal relay-end (remote hangs up, client never sends close) fell through the `async with` and returned without closing. Matches load-test symptom: Fly per-machine concurrency stayed pinned nonzero for 4+ min after traffic stopped, while Logfire showed balanced Entered/exiting counts.
- Moved the close into a `finally` so it runs on every exit path.
- Cut remote-leg `close_timeout` 7200s -> 10s  so a slow/unresponsive proxy ack can't hold a concurrency slot for hours.

## Test plan
- [x] `make check-backend-format` passes
- [x] Re-run the ~5-concurrent Amazon-sync load burst against `remotebrowser-dev`; confirm Fly "App Concurrency" decays to ~0 within seconds of last client disconnect instead of staying pinned



## Test Result

Run 5 concurrent test.

| Before (~161 connection) | After (~45 connection) |
| --- | --- |
| Test end at 16:50, but the conection still stale until 2 hour   |  After test end, the connection drop     |  
| <img width="809" height="878" alt="Screenshot 2026-08-12 at 16 54 57" src="https://github.com/user-attachments/assets/90c72888-66eb-42db-8189-2c2f71cac35a" />  | <img width="324" height="440" alt="Screenshot 2026-08-12 at 17 02 50" src="https://github.com/user-attachments/assets/d4acf5c4-fce7-495e-9e0e-b3ce73e69e39" />   |


<img width="1493" height="799" alt="Screenshot 2026-08-12 at 17 06 17" src="https://github.com/user-attachments/assets/fc8b0ff8-6192-40b3-8939-8e5e252f0198" />

