### PR TITLE
perf(distill): cache parsed distillation patterns

### DIFF
--- a/getgather/patterns_api_router.py
+++ b/getgather/patterns_api_router.py
@@ -6,6 +6,8 @@ from fastapi.responses import JSONResponse, PlainTextResponse
 from loguru import logger
 from pydantic import BaseModel
 
+from getgather.zen_distill import load_distillation_patterns
+
 router = APIRouter()
 
 PATTERNS_DIR = os.path.join(os.path.dirname(__file__), "mcp", "patterns")
@@ -82,6 +84,7 @@ async def upsert_pattern(
     try:
         with open(path, "w", encoding="utf-8") as f:
             f.write(body.content)
+        load_distillation_patterns.cache_clear()
         action = "updated" if exists else "created"
         logger.info(f"Pattern {pattern_name!r} {action}.")
         return {"pattern_name": pattern_name, "status": action}
@@ -100,6 +103,7 @@ async def delete_pattern(pattern_name: str, ext: str = Query("html")) -> dict[st
         raise HTTPException(status_code=404, detail=f"Pattern {pattern_name!r} not found")
     try:
         os.remove(path)
+        load_distillation_patterns.cache_clear()
         logger.info(f"Pattern {pattern_name!r} deleted.")
         return {"pattern_name": pattern_name, "status": "deleted"}
     except Exception as e:

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -290,12 +290,6 @@ async def get_error(distilled: str) -> str | None:
     return None
 
 
-# Re-parsing the 470 pattern files costs ~0.22s of blocking CPU per call, 86% of it
-# BeautifulSoup tree-building, and every MCP tool call redid it. On a CPU-throttled
-# host the same work stretches to seconds of wall time, which is how it first showed
-# up. Sharing one parse is safe: distill() deepcopies each tree before mutating it
-# and nothing mutates the returned list.
-# Trade-off: pattern files are read once per process, so edits need a restart.
 @lru_cache(maxsize=8)
 def load_distillation_patterns(path: str) -> list[Pattern]:
     patterns: list[Pattern] = []

--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -5,6 +5,7 @@ import urllib.parse
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
+from functools import lru_cache
 from glob import glob
 from pathlib import Path
 from typing import Any, Callable, Coroutine, cast
@@ -289,6 +290,13 @@ async def get_error(distilled: str) -> str | None:
     return None
 
 
+# Re-parsing the 470 pattern files costs ~0.22s of blocking CPU per call, 86% of it
+# BeautifulSoup tree-building, and every MCP tool call redid it. On a CPU-throttled
+# host the same work stretches to seconds of wall time, which is how it first showed
+# up. Sharing one parse is safe: distill() deepcopies each tree before mutating it
+# and nothing mutates the returned list.
+# Trade-off: pattern files are read once per process, so edits need a restart.
+@lru_cache(maxsize=8)
 def load_distillation_patterns(path: str) -> list[Pattern]:
     patterns: list[Pattern] = []
     for name in glob(path, recursive=True):


### PR DESCRIPTION
## What

Adds `@lru_cache(maxsize=8)` to `load_distillation_patterns`, which re-read and re-parsed all **470** pattern files on every call. Every MCP tool call went through it.

## Measured

On the `tap-connect-mock-flyfleet` sidecar (`shared-cpu-2x`, Fly `sjc`), both arms run back-to-back in one process against the same files. Arm A calls `.__wrapped__` — the undecorated function — so it is the genuine pre-cache path. `process_time` is used rather than wall clock because it is unaffected by host CPU steal.

| arm | CPU per call |
|---|---|
| uncached | 0.2174 / 0.2170 / 0.2162 / 0.2192 s |
| `lru_cache` | 0.0000 s (4 hits, 1 miss) |

`py-spy` at 200 Hz, 1570 samples inside the function:

| share | where |
|---|---|
| 55.9% | bs4 tree build |
| 29.9% | `html.parser` tokenize |
| 9.0% | `glob` + file read |

So ~86% of the cost is BeautifulSoup parsing, and the cache eliminates it entirely after the first call.

## Why it is safe

- `Pattern.pattern` is read in exactly one place repo-wide — `distill()` — and it `deepcopy`s the tree before mutating it.
- Nothing mutates the returned list in place (no `append`/`sort`/`pop` outside the constructor loop), which matters because `lru_cache` shares the list object too, not just the trees.
- `path` is a `str`, so it is hashable.
- `maxsize=8` covers the distinct globs in use: `mcp/patterns/**`, the dpage patterns, `main.py`'s single `ip-fly.html`, and the test fixtures.