### PR TITLE
fix(browser): remove local-browser cleanup from remote CDP attachments

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from typing import Any, TypeVar, cast
 from urllib.parse import urlparse
 
-import asyncio_atexit
 import logfire
 import sentry_sdk
 import websockets
@@ -16,7 +15,6 @@ import zendriver as zd
 from loguru import logger
 from nanoid import generate
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
-from zendriver.core import util
 from zendriver.core._contradict import ContraDict
 from zendriver.core.config import Config
 from zendriver.core.connection import Connection, ProtocolException
@@ -165,15 +163,6 @@ async def _create_browser_from_cdp_websocket(
                 f"{settings.CHROMEFLEET_CDP_HANDSHAKE_TIMEOUT_SECONDS:g}s: "
                 f"browser_id={browser_id}"
             )
-    util.get_registered_instances().add(instance)
-
-    async def browser_atexit() -> None:
-        if not instance.stopped:
-            await instance.stop()
-        await instance._cleanup_temporary_profile()  # type: ignore[reportPrivateUsage]
-
-    asyncio_atexit.register(browser_atexit)  # type: ignore[reportUnknownMemberType]
-
     instance.id = browser_id  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
     return instance
 


### PR DESCRIPTION
## Problem

The getgather sidecar on `tap-connect-mock-flyfleet` grew **~145 MiB/h of RSS, perfectly linear, with no flattening**. 

## Cause

`_create_browser_from_cdp_websocket` took **process-lifetime ownership** of every browser it attached to, through two independent strong references:

- `util.get_registered_instances().add(instance)` — `zendriver.core.util.__registered__instances__` is a module-global `Set[Browser]`.
- `asyncio_atexit.register(browser_atexit)` — the closure captures `instance`, and the registry lives as long as the event loop.

## Why this is safe

### `browser_atexit` is not appropriate for a CDP attachment, because we do not own the browser

The deleted block is a near-verbatim copy of zendriver's own `Browser.create()` (`zendriver/core/browser.py:105-112`), down to the function name, paired with the registry `add` that `start()` performs at `:379`.

In zendriver those lines are correct, because `start()` **launches a local Chrome**: it resolves `browser_executable_path`, asserts the binary exists (`:341`), and spawns it via `util._start_process(exe, params, is_posix)` (`:375`), keeping the handle in `self._process`. Every part of the cleanup follows from that ownership — kill the child process we spawned, delete the temp profile dir we created, track the instances we own.

`_create_browser_from_cdp_websocket` owns none of that. It never calls `start()`; it hand-builds the instance (`zd.Browser(config)`, then assigns `.info` and `.connection` directly) specifically to bypass process launch. `_process` stays `None`, and the config states it outright:

```python
config = Config(host=host, port=port, browser_executable_path="remote")
```

`"remote"` is a sentinel, not a path — `start()` would fail its `exists()` check on it immediately. The browser lives in ChromeFleet / Browserbase / Daytona. So each cleanup step inverts:

### The registry has no consumer

`__registered__instances__` is written at `zendriver/core/util.py:24` and read only by the accessor at `:133`. Nothing inside zendriver ever iterates it, and getgather was its only writer. Removing the write removes an entry in a set nobody reads.

## Before / after

Measured on `tap-connect-mock-flyfleet` (`shared-cpu-2x:2048MB`, sjc), same test suite on a 5-minute cadence driving ~12 browsers/hour on both arms. RSS read from `/proc/<pid>/stat` field 24; PID re-discovered each sample and elapsed time measured, never assumed. Boot warmup excluded on both arms by the same rule.

<img width="763" height="199" alt="image" src="https://github.com/user-attachments/assets/606439d5-7e8d-4de8-986c-929e3da8c3f2" />
