### PR TITLE
feat(safeway): add signin-locked pattern for too-many-attempts error

### DIFF
--- a/getgather/mcp/patterns/safeway-signin-locked.html
+++ b/getgather/mcp/patterns/safeway-signin-locked.html
@@ -1,0 +1,12 @@
+<html rb-domain="safeway" rb-priority="-2">
+  <head>
+    <title>Safeway Sign In - Too Many Attempts</title>
+  </head>
+  <body>
+    <div
+      rb-stop
+      rb-error="too_many_attempts"
+      rb-match="//div[contains(@class, 'styles_content__') and contains(., 'Too many incorrect attempts')]"
+    ></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- **`getgather/mcp/patterns/safeway-signin-locked.html`** — New: terminal error pattern for Safeway's "Too many incorrect attempts. Try again after 5 minutes." lockout state, mirrors `signin-error.html` structure with `rb-stop` + `rb-error="too_many_attempts"`.