### PR TITLE
fix(browser): add 30s timeout to get_remote_browser chromefleet check

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -221,7 +221,7 @@ async def get_remote_browser_cdp_url(browser_id: str) -> str:
 async def get_remote_browser(browser_id: str) -> zd.Browser | None:
     logger.debug(f"Finding the ChromeFleet browser: {browser_id}")
     try:
-        await call_chromefleet_api("GET", browser_id)
+        await call_chromefleet_api("GET", browser_id, timeout=30.0)
     except Exception:
         return None
 


### PR DESCRIPTION
## Problem
`get_remote_browser` calls `call_chromefleet_api("GET", browser_id)` with no timeout override, so it falls back to the default 120s x 3 retries. Traced a live incident (`/dpage/{id}` POST) where this stalled the request until the caller's own undici `headersTimeout` (300s) fired first, surfacing as a bare `Headers Timeout Error` with no useful error attached.

Sibling `get_remote_browser_cdp_url` already passes `timeout=20.0` — this one was missed.

## Fix
Pass `timeout=30.0` explicitly, bounding the worst case well under the caller's 300s budget.

## Test plan
- [x] `make check-backend-format`
- [x] `make typecheck`