### PR TITLE
feat(patterns): auto-close Target health data consent modal

### DIFF
--- a/getgather/mcp/patterns/target-health-consent.html
+++ b/getgather/mcp/patterns/target-health-consent.html
@@ -1,0 +1,8 @@
+<html rb-domain="target">
+  <head>
+    <title>Target Health Data Consent</title>
+  </head>
+  <body>
+    <div rb-autoclick rb-match="button[class*='hiddenCloseButton']"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- New: **`getgather/mcp/patterns/target-health-consent.html`** — autoclicks Target's health data consent modal via hidden close button (`button[class*='hiddenCloseButton']`), dismissing without accepting the consent text.