### PR TITLE
fix(ci): install the wheel test against uv.lock

### DIFF
--- a/.github/workflows/browser-api-e2e-test.yml
+++ b/.github/workflows/browser-api-e2e-test.yml
@@ -117,8 +117,16 @@ jobs:
       - name: List the wheel contents
         run: unzip -l dist/*.whl
 
+      - name: Export uv.lock as constraints
+        # uvx resolves the wheel's dependencies fresh from PyPI and never reads uv.lock, so without
+        # this the wheel legs run a different dependency set than every other job — daytona 0.204.0
+        # and zendriver 0.15.5 rather than the locked 0.184.0 and 0.14.2.
+        run: uv export --format requirements-txt --no-hashes --no-dev --no-emit-project --extra daytona -o /tmp/constraints.txt
+
       - name: Execute the wheel
         # The daytona backend needs the optional SDK (lazy-imported); add it for that variant only.
+        env:
+          UV_CONSTRAINT: /tmp/constraints.txt
         run: |
           if [ "${{ matrix.browser_backend }}" = daytona ]; then
             uvx --with daytona ./dist/*.whl &

--- a/.github/workflows/extraction-test.yml
+++ b/.github/workflows/extraction-test.yml
@@ -120,8 +120,16 @@ jobs:
       - name: List the wheel contents
         run: unzip -l dist/*.whl
 
+      - name: Export uv.lock as constraints
+        # uvx resolves the wheel's dependencies fresh from PyPI and never reads uv.lock, so without
+        # this the wheel legs run a different dependency set than every other job — daytona 0.204.0
+        # and zendriver 0.15.5 rather than the locked 0.184.0 and 0.14.2.
+        run: uv export --format requirements-txt --no-hashes --no-dev --no-emit-project --extra daytona -o /tmp/constraints.txt
+
       - name: Execute the wheel
         # The daytona backend needs the optional SDK (lazy-imported); add it for that variant only.
+        env:
+          UV_CONSTRAINT: /tmp/constraints.txt
         run: |
           if [ "${{ matrix.browser_backend }}" = daytona ]; then
             uvx --with daytona ./dist/*.whl &


### PR DESCRIPTION
## The failure

`extraction-tests-wheel (daytona)` and `browser-api-e2e-tests-wheel (daytona)` had both been failing on `main` for at least three runs:

```
FAILED tests/test_extractions.py::test_acme_login_email_password - httpx.ReadTimeout: timed out
assert 500 == 200   # GET /api/v1/browsers
```

## The cause

`uvx ./dist/*.whl` builds an ephemeral environment and resolves the wheel's dependencies fresh from PyPI. It never reads `uv.lock`. So the wheel legs were running an entirely unlocked dependency set:

| package | `uv.lock` (every other job) | `uvx` resolved (wheel legs) |
|---|---|---|
| daytona | 0.184.0 | 0.204.0 |
| zendriver | 0.14.2 | 0.15.5 |

## The fix

Export `uv.lock` as a requirements file and hand it to uvx via `UV_CONSTRAINT`, so the wheel legs install exactly what the lock resolves.