### PR TITLE
fix(cdp): namespace targetId in Target.getTargets/getTargetInfo/attachedToTarget

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -194,7 +194,14 @@ def find_browser_tab(browser: zd.Browser, target_id: str) -> zd.Tab | None:
     ``browser.targets`` so subsequent lookups return the ``Tab`` as well.
     """
     for idx, target in enumerate(browser.targets):
-        if target.target_id != target_id:
+        # target.target_id comes back namespaced as `browser_id@raw_id` when zendriver
+        # discovers it via the self-proxied /cdp/{browser_id} connection (see
+        # patch_cdp_target); target_id here is always the bare form, so strip before
+        # comparing (mirrors the same split done in safe_close_page below).
+        bare_target_id = (
+            target.target_id.split("@", 1)[-1] if target.target_id else target.target_id
+        )
+        if bare_target_id != target_id:
             continue
         if isinstance(target, zd.Tab):
             return target

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -193,15 +193,18 @@ def find_browser_tab(browser: zd.Browser, target_id: str) -> zd.Tab | None:
     ``_handle_target_update`` does for newly created targets) and replace it in
     ``browser.targets`` so subsequent lookups return the ``Tab`` as well.
     """
+    # target.target_id comes back namespaced as `browser_id@raw_id` when zendriver discovers
+    # it via the self-proxied /cdp/{browser_id} connection (see patch_cdp_target). Callers are
+    # inconsistent about which form they pass in — dpage.py round-trips the namespaced
+    # `page.target_id` it got from us, pages_api_router strips to bare first — so normalize
+    # both sides to bare before comparing (mirrors the same split done in safe_close_page
+    # below).
+    bare_query_id = target_id.split("@", 1)[-1] if target_id else target_id
     for idx, target in enumerate(browser.targets):
-        # target.target_id comes back namespaced as `browser_id@raw_id` when zendriver
-        # discovers it via the self-proxied /cdp/{browser_id} connection (see
-        # patch_cdp_target); target_id here is always the bare form, so strip before
-        # comparing (mirrors the same split done in safe_close_page below).
         bare_target_id = (
             target.target_id.split("@", 1)[-1] if target.target_id else target.target_id
         )
-        if bare_target_id != target_id:
+        if bare_target_id != bare_query_id:
             continue
         if isinstance(target, zd.Tab):
             return target

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -100,6 +100,13 @@ CDP_TARGET_METHODS_STRIP_ID = (
     "Target.getTargetInfo",
 )
 
+# CDP events carrying a single params.targetInfo.targetId to namespace by browser_id.
+CDP_TARGET_EVENTS_WITH_TARGET_INFO = (
+    "Target.targetCreated",
+    "Target.targetInfoChanged",
+    "Target.attachedToTarget",
+)
+
 
 def patch_cdp_target(message: str, browser_id: str) -> str:
     if "targetId" not in message:
@@ -111,7 +118,7 @@ def patch_cdp_target(message: str, browser_id: str) -> str:
         return message
 
     if isinstance(data, dict):
-        if data.get("method") == "Target.targetCreated":  # pyright: ignore[reportUnknownMemberType]
+        if data.get("method") in CDP_TARGET_EVENTS_WITH_TARGET_INFO:  # pyright: ignore[reportUnknownMemberType]
             params: Any = data.get("params")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
             if isinstance(params, dict):
                 target_info: Any = params.get("targetInfo")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
@@ -134,6 +141,32 @@ def patch_cdp_target(message: str, browser_id: str) -> str:
                     browser_id,
                 )
                 return json.dumps(data)
+            if isinstance(result, dict) and "targetInfo" in result:
+                target_info = result.get("targetInfo")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+                if isinstance(target_info, dict) and "targetId" in target_info:
+                    target_info["targetId"] = prepend_browser_id_to_target_id(
+                        str(target_info["targetId"]),  # pyright: ignore[reportUnknownArgumentType]
+                        browser_id,
+                    )
+                    return json.dumps(data)
+            if isinstance(result, dict) and "targetInfos" in result:
+                # Target.getTargets response: a list of targetInfo objects, each with its own
+                # targetId. zendriver uses this to discover pages outside of targetCreated
+                # events (e.g. enumerating existing tabs), so an unpatched id here sends the
+                # client a raw page_id, forcing the expensive find_browser_id fleet scan when it
+                # later opens a /devtools socket for that page.
+                target_infos: Any = result.get("targetInfos")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+                if isinstance(target_infos, list):
+                    patched = False
+                    for info in target_infos:  # pyright: ignore[reportUnknownVariableType]
+                        if isinstance(info, dict) and "targetId" in info:
+                            info["targetId"] = prepend_browser_id_to_target_id(
+                                str(info["targetId"]),  # pyright: ignore[reportUnknownArgumentType]
+                                browser_id,
+                            )
+                            patched = True
+                    if patched:
+                        return json.dumps(data)
 
     return message
 

--- a/getgather/cdp_client.py
+++ b/getgather/cdp_client.py
@@ -143,10 +143,15 @@ class CDPClient:
 
     async def find_page_target(self, page_id: str) -> dict[str, Any]:
         """Return the TargetInfo dict for the given page_id, or raise PageNotFoundError."""
+        # Deferred import: getgather.browsers.router imports this module at load time, so a
+        # top-level import here would be circular.
+        from getgather.browsers.router import strip_browser_id_from_target_id
+
         result = await self.send("Target.getTargets")
         target_infos: list[dict[str, Any]] = result.get("targetInfos", [])  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
         for info in target_infos:
-            if info.get("targetId") == page_id and info.get("type") == "page":
+            info_target_id = strip_browser_id_from_target_id(str(info.get("targetId", "")))
+            if info_target_id == page_id and info.get("type") == "page":
                 return info
         raise PageNotFoundError(f"Page {page_id} not found in browser")
 

--- a/getgather/pages_api_router.py
+++ b/getgather/pages_api_router.py
@@ -40,7 +40,11 @@ async def list_pages(browser_id: str) -> JSONResponse:
         await client.aclose()
 
     target_infos: list[dict[str, Any]] = result.get("targetInfos", [])  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
-    page_ids = [str(info["targetId"]) for info in target_infos if info.get("type") == "page"]
+    page_ids = [
+        strip_browser_id_from_target_id(str(info["targetId"]))
+        for info in target_infos
+        if info.get("type") == "page"
+    ]
     return JSONResponse(page_ids)
 
 


### PR DESCRIPTION
## Problem

`patch_cdp_target` only rewrote `targetId` on `Target.targetCreated` events and a bare top-level `result.targetId`. It missed:

- `Target.getTargets` result — `result.targetInfos[]` (array, plural)
- `Target.getTargetInfo` result — `result.targetInfo` (singular, nested)
- `Target.attachedToTarget` / `Target.targetInfoChanged` events — `params.targetInfo`

zendriver's `update_targets()` discovers pages via `Target.getTargets`, then builds the devtools URL directly from the returned `target_id`:

```python
f"ws://{self.config.host}:{self.config.port}/devtools/page/{t.target_id}"
```

Since that response wasn't namespaced, zendriver ended up connecting to `/devtools/page/<raw_id>` instead of `/devtools/page/<browser_id>@<raw_id>`. The devtools websocket route only recognizes a page by its bare id when the `@` form is absent, so it falls back to `find_browser_id`, which scans every cached browser's CDP endpoint (`/json/version`) looking for the page. If one sandbox in that scan is slow/unresponsive, the whole lookup stalls until that probe's timeout fires.

Traced from a real incident: a `/devtools` connection stuck ~15s because the fallback scan hit a sandbox that timed out on `/json/version` (`httpx.ReadTimeout`), even though the caller had already resolved `browser_id` one call earlier (`GET /api/v1/browsers/{browser_id}`) — it just never reached the WS layer.

## Fix

Extend `patch_cdp_target` to also namespace `targetId` inside `Target.getTargets` (`targetInfos[]`), `Target.getTargetInfo` (`targetInfo`), and `Target.attachedToTarget`/`Target.targetInfoChanged` (`params.targetInfo`). This lets zendriver receive already-namespaced ids from every code path that can produce a `target_id`, so the devtools route takes the direct `browser_id@page_id` branch and skips the fleet scan entirely for this case.

## Verification

- `ruff check` / `ruff format --check` / `pyright` clean on the changed file.
- Manual unit check of `patch_cdp_target` against all three new payload shapes (`Target.getTargets` result, `Target.getTargetInfo` result, `Target.attachedToTarget` event) — each correctly gets `browser_id@` prepended to `targetId`.

## Test plan

- [ ] Open a page via the local (Podman/Daytona) backend, trigger tab/page discovery (e.g. a link opening a new tab) that goes through `Target.getTargets`, then confirm the resulting `/devtools` websocket connection uses the namespaced path and does not hit `find_browser_id`.
- [ ] Confirm existing `Target.targetCreated`/strip-id behavior is unaffected (no regression for direct tab creation flows).