### PR TITLE
feat(browsers): proxy best-of-N racing for Daytona sticky proxies

### DIFF
--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -1,4 +1,5 @@
 import asyncio
+import shlex
 import time
 from typing import Any
 
@@ -23,7 +24,14 @@ from getgather.browsers.backend import (
     get_browser_websocket_debugger_url,
     get_page_websocket_debugger_url,
 )
-from getgather.browsers.residential_proxy import get_proxy_config
+from getgather.browsers.proxy_best_of_n import (
+    candidate_session_ids,
+    effective_proxy_best_of_n,
+    parse_ttfb,
+    pick_fastest_session,
+    proxy_probe_url,
+)
+from getgather.browsers.residential_proxy import ProxyConfig, get_proxy_config
 from getgather.config import settings
 
 CDP_PORT = 9222
@@ -92,6 +100,49 @@ async def _configure_sandbox_proxy(sandbox: AsyncSandbox, proxy_url: str) -> boo
     return True
 
 
+async def _probe_proxy_ttfb(sandbox: AsyncSandbox, proxy_url: str, probe_url: str) -> float | None:
+    """Measure TTFB through `proxy_url` to `probe_url` without touching tinyproxy."""
+    cmd = (
+        "curl -s -o /dev/null -w '%{time_starttransfer}' "
+        f"--max-time 10 -x {shlex.quote(proxy_url)} {shlex.quote(probe_url)}"
+    )
+    try:
+        response = await sandbox.process.exec(cmd)
+    except Exception as e:
+        logger.debug(f"Proxy TTFB probe failed on {sandbox.name}: {type(e).__name__}: {e}")
+        return None
+    if response.exit_code != 0:
+        logger.debug(
+            f"Proxy TTFB probe exit={response.exit_code} on {sandbox.name}: {response.result!r}"
+        )
+        return None
+    return parse_ttfb(response.result or "")
+
+
+async def _select_proxy_session_id(
+    sandbox: AsyncSandbox,
+    proxy_config: ProxyConfig,
+    browser_id: str,
+    target_domain: str | None,
+) -> str:
+    n = effective_proxy_best_of_n(settings.BROWSER_PROXY_BEST_OF_N)
+    if n == 1:
+        return browser_id
+
+    probe_url = proxy_probe_url(target_domain)
+    sessions = candidate_session_ids(browser_id, n)
+    logger.info(f"Best-of-{n} proxy race on {sandbox.name}: sessions={sessions} probe={probe_url}")
+
+    async def _one(session_id: str) -> tuple[str, float | None]:
+        url = proxy_config.get_proxy_url(session_id)
+        return session_id, await _probe_proxy_ttfb(sandbox, url, probe_url)
+
+    results = await asyncio.gather(*[_one(s) for s in sessions])
+    winner = pick_fastest_session(list(results))
+    logger.info(f"Best-of-N proxy winner on {sandbox.name}: {winner}")
+    return winner
+
+
 async def _get_sandbox_public_ip(
     sandbox: AsyncSandbox, *, retries: int = 5, retry_delay: float = 2.0
 ) -> str | None:
@@ -122,10 +173,11 @@ async def _configure_remote_sandbox(
     this raises ProxyVerificationError. If no proxy is configured, this is a no-op (proxy is not
     required). Callers let the error propagate; best-of-N treats a raising candidate as failed."""
     proxy_config = await get_proxy_config(origin_ip, target_domain, settings)
-    proxy_url = proxy_config.get_proxy_url(browser_id) if proxy_config else None
-
-    if not proxy_url:
+    if not proxy_config:
         return  # no proxy configured; proxy is not required for this browser
+
+    session_id = await _select_proxy_session_id(sandbox, proxy_config, browser_id, target_domain)
+    proxy_url = proxy_config.get_proxy_url(session_id)
 
     ip_before = await _get_sandbox_public_ip(sandbox)
     logger.debug(f"Sandbox {sandbox.name} IP before proxy: {ip_before}")

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -42,7 +42,7 @@ VNC_PORT = 8080
 # selected browser — no post-start swap. See chrome-live chromium/run.
 ACTIVE_BROWSER_ENV = "ACTIVE_BROWSER"
 
-DEFAULT_BEST_OF_N = 3
+DEFAULT_BEST_OF_N = 1
 
 # Chrome stores last_visit_time as microseconds since 1601-01-01; this offset converts to unix epoch.
 CHROMIUM_EPOCH_OFFSET_SECONDS = 11644473600

--- a/getgather/browsers/proxy_best_of_n.py
+++ b/getgather/browsers/proxy_best_of_n.py
@@ -1,4 +1,3 @@
-# getgather/browsers/proxy_best_of_n.py
 from getgather.browsers.backend import ProxyVerificationError
 
 FALLBACK_PROBE_URL = "https://ip.fly.dev"

--- a/getgather/browsers/proxy_best_of_n.py
+++ b/getgather/browsers/proxy_best_of_n.py
@@ -1,0 +1,39 @@
+# getgather/browsers/proxy_best_of_n.py
+from getgather.browsers.backend import ProxyVerificationError
+
+FALLBACK_PROBE_URL = "https://ip.fly.dev"
+DEFAULT_PROXY_BEST_OF_N = 3
+
+
+def effective_proxy_best_of_n(explicit: int | None) -> int:
+    return max(1, explicit if explicit is not None else DEFAULT_PROXY_BEST_OF_N)
+
+
+def proxy_probe_url(target_domain: str | None) -> str:
+    if not target_domain or not target_domain.strip():
+        return FALLBACK_PROBE_URL
+    first = target_domain.split(",")[0].strip()
+    if not first:
+        return FALLBACK_PROBE_URL
+    return f"https://{first}/"
+
+
+def candidate_session_ids(browser_id: str, n: int) -> list[str]:
+    return [f"{browser_id}-p{i}" for i in range(n)]
+
+
+def parse_ttfb(stdout: str) -> float | None:
+    text = stdout.strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def pick_fastest_session(results: list[tuple[str, float | None]]) -> str:
+    successes = [(sid, ttfb) for sid, ttfb in results if ttfb is not None]
+    if not successes:
+        raise ProxyVerificationError("Best-of-N proxy: no proxy candidate succeeded")
+    return min(successes, key=lambda item: item[1])[0]

--- a/getgather/browsers/settings.py
+++ b/getgather/browsers/settings.py
@@ -65,6 +65,11 @@ class BrowserSettings(BaseSettings):
     # (see `Backend.default_best_of_n`): Podman=5, Daytona=3, Fleet=1.
     BROWSER_BEST_OF_N: int | None = None
 
+    # Daytona-only: race this many sticky proxy sessions (same provider) and keep the
+    # lowest TTFB to the target domain (or ip.fly.dev fallback). When unset, default is 3.
+    # Set to 1 to disable the race and use a single session id (= browser_id).
+    BROWSER_PROXY_BEST_OF_N: int | None = None
+
     @property
     def effective_chromefleet_url(self) -> str:
         """Returns CHROMEFLEET_URL if set, otherwise falls back to the local backend."""

--- a/tests/test_daytona_browsers.py
+++ b/tests/test_daytona_browsers.py
@@ -15,6 +15,9 @@ def _backend() -> DaytonaBackend:
 
 def _patch_proxy(monkeypatch: MonkeyPatch, *, ips: list[str | None], proxy_ok: bool = True) -> None:
     """Force a configured proxy and drive _get_sandbox_public_ip's return sequence."""
+    from getgather.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "BROWSER_PROXY_BEST_OF_N", 1)
 
     class _Cfg:
         def get_proxy_url(self, browser_id: str) -> str:
@@ -66,6 +69,149 @@ async def test_configure_remote_sandbox_raises_when_ip_unchanged(monkeypatch: Mo
     _patch_proxy(monkeypatch, ips=["1.1.1.1", "1.1.1.1"])
     with pytest.raises(ProxyVerificationError, match="IP unchanged"):
         await daytona_browsers._configure_remote_sandbox(_fake_sandbox(), "b0", None, None)  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_configure_remote_sandbox_picks_fastest_proxy_session(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    from getgather.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "BROWSER_PROXY_BEST_OF_N", 3)
+
+    applied: list[str] = []
+
+    class _Cfg:
+        def get_proxy_url(self, session_id: str) -> str:
+            return f"http://user-sess-{session_id}:pass@proxy.example:9999"
+
+    async def fake_get_proxy_config(*args: Any, **kwargs: Any):
+        return _Cfg()
+
+    async def fake_configure_sandbox_proxy(sandbox: Any, proxy_url: str) -> bool:
+        applied.append(proxy_url)
+        return True
+
+    ips = iter(["1.1.1.1", "9.9.9.9"])
+
+    async def fake_public_ip(*args: Any, **kwargs: Any):
+        return next(ips)
+
+    class _ExecResult:
+        def __init__(self, exit_code: int, result: str) -> None:
+            self.exit_code = exit_code
+            self.result = result
+
+    class _Process:
+        async def exec(self, cmd: str) -> _ExecResult:
+            assert "https://amazon.com/" in cmd
+            if "b0-p0" in cmd:
+                return _ExecResult(0, "0.50")
+            if "b0-p1" in cmd:
+                return _ExecResult(0, "0.10")
+            if "b0-p2" in cmd:
+                return _ExecResult(28, "")
+            return _ExecResult(1, "")
+
+    class _RaceSandbox:
+        name = "chromium-test"
+        process = _Process()
+
+    monkeypatch.setattr(daytona_browsers, "get_proxy_config", fake_get_proxy_config)
+    monkeypatch.setattr(daytona_browsers, "_configure_sandbox_proxy", fake_configure_sandbox_proxy)
+    monkeypatch.setattr(daytona_browsers, "_get_sandbox_public_ip", fake_public_ip)
+
+    await daytona_browsers._configure_remote_sandbox(  # pyright: ignore[reportPrivateUsage]
+        cast("daytona_browsers.AsyncSandbox", _RaceSandbox()),
+        "b0",
+        "1.2.3.4",
+        "amazon.com",
+    )
+    assert applied == ["http://user-sess-b0-p1:pass@proxy.example:9999"]
+
+
+@pytest.mark.asyncio
+async def test_configure_remote_sandbox_all_proxy_probes_fail(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    from getgather.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "BROWSER_PROXY_BEST_OF_N", 2)
+
+    class _Cfg:
+        def get_proxy_url(self, session_id: str) -> str:
+            return f"http://user-sess-{session_id}:pass@proxy.example:9999"
+
+    async def fake_get_proxy_config(*args: Any, **kwargs: Any):
+        return _Cfg()
+
+    class _ExecResult:
+        exit_code = 28
+        result = ""
+
+    class _Process:
+        async def exec(self, cmd: str) -> _ExecResult:
+            return _ExecResult()
+
+    class _RaceSandbox:
+        name = "chromium-test"
+        process = _Process()
+
+    monkeypatch.setattr(daytona_browsers, "get_proxy_config", fake_get_proxy_config)
+
+    with pytest.raises(ProxyVerificationError, match="no proxy candidate"):
+        await daytona_browsers._configure_remote_sandbox(  # pyright: ignore[reportPrivateUsage]
+            cast("daytona_browsers.AsyncSandbox", _RaceSandbox()),
+            "b0",
+            "1.2.3.4",
+            "amazon.com",
+        )
+
+
+@pytest.mark.asyncio
+async def test_configure_remote_sandbox_n1_uses_browser_id_session(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    from getgather.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "BROWSER_PROXY_BEST_OF_N", 1)
+    applied: list[str] = []
+
+    class _Cfg:
+        def get_proxy_url(self, session_id: str) -> str:
+            return f"http://sess-{session_id}@proxy.example:9999"
+
+    async def fake_get_proxy_config(*args: Any, **kwargs: Any):
+        return _Cfg()
+
+    async def fake_configure_sandbox_proxy(sandbox: Any, proxy_url: str) -> bool:
+        applied.append(proxy_url)
+        return True
+
+    ips = iter([None, "9.9.9.9"])
+
+    async def fake_public_ip(*args: Any, **kwargs: Any):
+        return next(ips)
+
+    class _RaceSandbox:
+        name = "chromium-test"
+
+        class process:
+            @staticmethod
+            async def exec(cmd: str) -> Any:
+                raise AssertionError(f"probe should not run for N=1: {cmd}")
+
+    monkeypatch.setattr(daytona_browsers, "get_proxy_config", fake_get_proxy_config)
+    monkeypatch.setattr(daytona_browsers, "_configure_sandbox_proxy", fake_configure_sandbox_proxy)
+    monkeypatch.setattr(daytona_browsers, "_get_sandbox_public_ip", fake_public_ip)
+
+    await daytona_browsers._configure_remote_sandbox(  # pyright: ignore[reportPrivateUsage]
+        cast("daytona_browsers.AsyncSandbox", _RaceSandbox()),
+        "b0",
+        "1.2.3.4",
+        None,
+    )
+    assert applied == ["http://sess-b0@proxy.example:9999"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_daytona_browsers.py
+++ b/tests/test_daytona_browsers.py
@@ -378,7 +378,7 @@ async def test_create_omits_env_when_browser_type_none(monkeypatch: MonkeyPatch)
 
 def test_create_browser_auto_uses_backend_default_when_env_unset(monkeypatch: MonkeyPatch) -> None:
     # When BROWSER_BEST_OF_N is unset (None), the router falls back to the backend's own default
-    # (DaytonaBackend.default_best_of_n == 3) instead of hard-coding 1.
+    # (DaytonaBackend.default_best_of_n == 1) and short-circuits the race like explicit N=1.
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
 
@@ -387,19 +387,29 @@ def test_create_browser_auto_uses_backend_default_when_env_unset(monkeypatch: Mo
     monkeypatch.setattr(router_module.settings, "BROWSER_BEST_OF_N", None)
     monkeypatch.setattr(router_module, "backend", _backend())
 
-    invoked: dict[str, Any] = {}
+    ids = iter(["solo"])
 
-    async def fake_best_of_n(
-        backend: Any,
-        n: int,
+    def fake_new_id() -> str:
+        return next(ids)
+
+    called: dict[str, Any] = {}
+
+    async def fake_create_browser(
+        self: Any,
+        browser_id: str,
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,
-    ) -> tuple[str, dict[str, str]]:
-        invoked["n"] = n
-        return "winner", {"id": "winner"}
+    ) -> dict[str, str]:
+        called["browser_id"] = browser_id
+        return {"id": browser_id}
 
-    monkeypatch.setattr(router_module, "best_of_n", fake_best_of_n)
+    async def fail_best_of_n(*args: Any, **kwargs: Any) -> tuple[str, dict[str, Any]]:
+        raise AssertionError("best_of_n should not run when backend default N=1")
+
+    monkeypatch.setattr(router_module, "new_browser_id", fake_new_id)
+    monkeypatch.setattr(DaytonaBackend, "create_browser", fake_create_browser)
+    monkeypatch.setattr(router_module, "best_of_n", fail_best_of_n)
 
     app = FastAPI()
     app.include_router(router_module.router)
@@ -407,14 +417,15 @@ def test_create_browser_auto_uses_backend_default_when_env_unset(monkeypatch: Mo
 
     response = client.post("/api/v1/browsers")
     assert response.status_code == 200
-    assert invoked["n"] == 3
+    assert response.json() == {"browser_id": "solo", "id": "solo"}
+    assert called["browser_id"] == "solo"
 
 
 @pytest.mark.parametrize(
     ("module_name", "expected"),
     [
         ("getgather.browsers.podman_browsers", 5),
-        ("getgather.browsers.daytona_browsers", 3),
+        ("getgather.browsers.daytona_browsers", 1),
         ("getgather.browsers.fleet_browsers", 1),
     ],
 )

--- a/tests/test_proxy_best_of_n.py
+++ b/tests/test_proxy_best_of_n.py
@@ -1,4 +1,3 @@
-# tests/test_proxy_best_of_n.py
 import pytest
 
 from getgather.browsers.backend import ProxyVerificationError

--- a/tests/test_proxy_best_of_n.py
+++ b/tests/test_proxy_best_of_n.py
@@ -41,8 +41,8 @@ def test_candidate_session_ids() -> None:
 
 
 def test_parse_ttfb_ok() -> None:
-    assert parse_ttfb("0.321") == pytest.approx(0.321)
-    assert parse_ttfb(" 1.5\n") == pytest.approx(1.5)
+    assert parse_ttfb("0.321") == 0.321
+    assert parse_ttfb(" 1.5\n") == 1.5
 
 
 def test_parse_ttfb_invalid() -> None:

--- a/tests/test_proxy_best_of_n.py
+++ b/tests/test_proxy_best_of_n.py
@@ -52,9 +52,7 @@ def test_parse_ttfb_invalid() -> None:
 
 
 def test_pick_fastest_session_picks_lowest_ttfb() -> None:
-    winner = pick_fastest_session(
-        [("b0-p0", 0.40), ("b0-p1", 0.12), ("b0-p2", None)]
-    )
+    winner = pick_fastest_session([("b0-p0", 0.40), ("b0-p1", 0.12), ("b0-p2", None)])
     assert winner == "b0-p1"
 
 

--- a/tests/test_proxy_best_of_n.py
+++ b/tests/test_proxy_best_of_n.py
@@ -1,0 +1,63 @@
+# tests/test_proxy_best_of_n.py
+import pytest
+
+from getgather.browsers.backend import ProxyVerificationError
+from getgather.browsers.proxy_best_of_n import (
+    DEFAULT_PROXY_BEST_OF_N,
+    FALLBACK_PROBE_URL,
+    candidate_session_ids,
+    effective_proxy_best_of_n,
+    parse_ttfb,
+    pick_fastest_session,
+    proxy_probe_url,
+)
+
+
+def test_effective_n_default_is_three() -> None:
+    assert effective_proxy_best_of_n(None) == DEFAULT_PROXY_BEST_OF_N == 3
+
+
+def test_effective_n_explicit() -> None:
+    assert effective_proxy_best_of_n(1) == 1
+    assert effective_proxy_best_of_n(5) == 5
+    assert effective_proxy_best_of_n(0) == 1  # floor at 1
+
+
+def test_probe_url_from_target_domain() -> None:
+    assert proxy_probe_url("amazon.com") == "https://amazon.com/"
+
+
+def test_probe_url_uses_first_comma_separated_token() -> None:
+    assert proxy_probe_url(" amazon.com , cvs.com ") == "https://amazon.com/"
+
+
+def test_probe_url_fallback_when_missing() -> None:
+    assert proxy_probe_url(None) == FALLBACK_PROBE_URL
+    assert proxy_probe_url("") == FALLBACK_PROBE_URL
+    assert proxy_probe_url("   ") == FALLBACK_PROBE_URL
+
+
+def test_candidate_session_ids() -> None:
+    assert candidate_session_ids("b0", 3) == ["b0-p0", "b0-p1", "b0-p2"]
+
+
+def test_parse_ttfb_ok() -> None:
+    assert parse_ttfb("0.321") == pytest.approx(0.321)
+    assert parse_ttfb(" 1.5\n") == pytest.approx(1.5)
+
+
+def test_parse_ttfb_invalid() -> None:
+    assert parse_ttfb("") is None
+    assert parse_ttfb("curl: (28) timed out") is None
+
+
+def test_pick_fastest_session_picks_lowest_ttfb() -> None:
+    winner = pick_fastest_session(
+        [("b0-p0", 0.40), ("b0-p1", 0.12), ("b0-p2", None)]
+    )
+    assert winner == "b0-p1"
+
+
+def test_pick_fastest_session_all_fail() -> None:
+    with pytest.raises(ProxyVerificationError, match="no proxy candidate"):
+        pick_fastest_session([("b0-p0", None), ("b0-p1", None)])


### PR DESCRIPTION
## Summary
- Add pure helpers (`proxy_best_of_n.py`) for picking effective N, building probe URLs, candidate session IDs, TTFB parsing, and fastest-session selection.
- Add `BROWSER_PROXY_BEST_OF_N` setting.
- Race N sticky Daytona proxy sessions on browser create, keep the one with fastest TTFB.
- Keep machine-tier `DEFAULT_BEST_OF_N` at 1 (no racing for machine browsers).
- Fix pyright strict violation on `pytest.approx` in the new tests (plain equality instead, since inputs parse exactly).

## Test plan
- [x] `make check` (ruff, yamlfix, prettier, ty, pyright, pattern testids) — all pass
- [x] `uv run pytest tests/test_proxy_best_of_n.py tests/test_daytona_browsers.py -q` — 26 passed