### PR TITLE
feat(daytona): pass Logfire env into sandbox create

### DIFF
--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -14,6 +14,7 @@ from daytona import (
 )
 from fastapi import WebSocket
 from loguru import logger
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from getgather.browsers.backend import (
     BROWSER_NAME_PREFIX,
@@ -384,12 +385,20 @@ class DaytonaBackend:
         # boot (chrome-live). Driven by the per-request `browser_type` (x-browser-type header); Chrome
         # is the default. Only set the env for a non-Chrome pick: Chrome is the snapshot default, so
         # a None env_vars keeps the create call identical to a Chrome-only snapshot (older Daytona
-        # backends reject env_vars they don't expect).
-        env_vars = (
-            {ACTIVE_BROWSER_ENV: browser_type}
-            if browser_type and browser_type != "chrome"
-            else None
-        )
+        # backends reject env_vars they don't expect) — unless Logfire/browser-trace needs env too.
+        sandbox_env: dict[str, str] = {}
+        if browser_type and browser_type != "chrome":
+            sandbox_env[ACTIVE_BROWSER_ENV] = browser_type
+        # chrome-live browser-trace + tinyproxy-log read these (see spiteful-hedgehog browser-trace).
+        if settings.LOGFIRE_TOKEN:
+            sandbox_env["LOGFIRE_TOKEN"] = settings.LOGFIRE_TOKEN
+            sandbox_env["ENVIRONMENT"] = settings.ENVIRONMENT
+            sandbox_env["LOG_LEVEL"] = settings.LOG_LEVEL
+            carrier: dict[str, str] = {}
+            TraceContextTextMapPropagator().inject(carrier)
+            if traceparent := carrier.get("traceparent"):
+                sandbox_env["LOGFIRE_TRACEPARENT"] = traceparent
+        env_vars = sandbox_env or None
         params = CreateSandboxFromSnapshotParams(
             snapshot=self.snapshot,
             name=name,

--- a/tests/test_daytona_browsers.py
+++ b/tests/test_daytona_browsers.py
@@ -206,6 +206,7 @@ async def _capture_create_params(monkeypatch: MonkeyPatch, backend: DaytonaBacke
 async def test_create_sets_active_browser_env_for_cloak(monkeypatch: MonkeyPatch) -> None:
     # browser_type="cloak" (x-browser-type header) selects CloakBrowser via the ACTIVE_BROWSER env.
     backend = _backend()
+    monkeypatch.setattr(daytona_browsers.settings, "LOGFIRE_TOKEN", "")
     captured = await _capture_create_params(monkeypatch, backend)
     await backend._create("chromium-test", "cloak")  # pyright: ignore[reportPrivateUsage]
     assert captured[0].env_vars == {"ACTIVE_BROWSER": "cloak"}
@@ -214,8 +215,9 @@ async def test_create_sets_active_browser_env_for_cloak(monkeypatch: MonkeyPatch
 @pytest.mark.asyncio
 async def test_create_omits_env_for_chrome(monkeypatch: MonkeyPatch) -> None:
     # Chrome is the default: send no env_vars so the create call is identical to a Chrome-only
-    # snapshot (older Daytona backends reject unexpected env_vars).
+    # snapshot (older Daytona backends reject unexpected env_vars), when Logfire is unset.
     backend = _backend()
+    monkeypatch.setattr(daytona_browsers.settings, "LOGFIRE_TOKEN", "")
     captured = await _capture_create_params(monkeypatch, backend)
     await backend._create("chromium-test", "chrome")  # pyright: ignore[reportPrivateUsage]
     assert captured[0].env_vars is None
@@ -223,11 +225,43 @@ async def test_create_omits_env_for_chrome(monkeypatch: MonkeyPatch) -> None:
 
 @pytest.mark.asyncio
 async def test_create_omits_env_when_browser_type_none(monkeypatch: MonkeyPatch) -> None:
-    # No x-browser-type header -> browser_type None -> default Chrome, no env_vars.
+    # No x-browser-type header -> browser_type None -> default Chrome, no env_vars (no Logfire).
     backend = _backend()
+    monkeypatch.setattr(daytona_browsers.settings, "LOGFIRE_TOKEN", "")
     captured = await _capture_create_params(monkeypatch, backend)
     await backend._create("chromium-test", None)  # pyright: ignore[reportPrivateUsage]
     assert captured[0].env_vars is None
+
+
+@pytest.mark.asyncio
+async def test_create_passes_logfire_env_for_chrome(monkeypatch: MonkeyPatch) -> None:
+    # chrome-live browser-trace needs LOGFIRE_TOKEN even for the default Chrome browser.
+    backend = _backend()
+    monkeypatch.setattr(daytona_browsers.settings, "LOGFIRE_TOKEN", "lf_test_token")
+    monkeypatch.setattr(daytona_browsers.settings, "ENVIRONMENT", "test")
+    monkeypatch.setattr(daytona_browsers.settings, "LOG_LEVEL", "DEBUG")
+    captured = await _capture_create_params(monkeypatch, backend)
+    await backend._create("chromium-test", "chrome")  # pyright: ignore[reportPrivateUsage]
+    env = captured[0].env_vars
+    assert env["LOGFIRE_TOKEN"] == "lf_test_token"
+    assert env["ENVIRONMENT"] == "test"
+    assert env["LOG_LEVEL"] == "DEBUG"
+    assert "ACTIVE_BROWSER" not in env
+
+
+@pytest.mark.asyncio
+async def test_create_passes_logfire_env_with_cloak(monkeypatch: MonkeyPatch) -> None:
+    backend = _backend()
+    monkeypatch.setattr(daytona_browsers.settings, "LOGFIRE_TOKEN", "lf_test_token")
+    monkeypatch.setattr(daytona_browsers.settings, "ENVIRONMENT", "prod")
+    monkeypatch.setattr(daytona_browsers.settings, "LOG_LEVEL", "INFO")
+    captured = await _capture_create_params(monkeypatch, backend)
+    await backend._create("chromium-test", "cloak")  # pyright: ignore[reportPrivateUsage]
+    env = captured[0].env_vars
+    assert env["ACTIVE_BROWSER"] == "cloak"
+    assert env["LOGFIRE_TOKEN"] == "lf_test_token"
+    assert env["ENVIRONMENT"] == "prod"
+    assert env["LOG_LEVEL"] == "INFO"
 
 
 def test_create_browser_auto_uses_backend_default_when_env_unset(monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- chrome-live browser-trace needs LOGFIRE_TOKEN, ENVIRONMENT, LOG_LEVEL (and LOGFIRE_TRACEPARENT) to emit CDP/proxy telemetry from Daytona sandboxes.
- Re-implemented commit 611a3e4 against current `daytona_browsers.py`, which diverged (no CloakBrowser seat/license logic on this branch).

## Test plan
- [x] `uv run pytest tests/test_daytona_browsers.py -q` (15 passed)
- [x] `make check-backend-format`
- [x] `make typecheck`