### PR TITLE
feat(proxy): x-country header for residential proxy country selection

### DIFF
--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -106,6 +106,7 @@ class _BestOfNBackend(_CleanupBackend, Protocol):
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,
+        country: str | None,
     ) -> dict[str, Any]: ...
 
 
@@ -115,6 +116,7 @@ async def best_of_n(
     origin_ip: str | None,
     target_domain: str | None,
     browser_type: str | None,
+    country: str | None,
 ) -> tuple[str, dict[str, Any]]:
     """Race `n` cold-create candidates; keep the first that fully succeeds, delete the rest.
 
@@ -129,7 +131,9 @@ async def best_of_n(
     logger.info(f"Best-of-{n} browser race: {ids}")
 
     async def _candidate(bid: str) -> tuple[str, dict[str, Any]]:
-        return bid, await backend.create_browser(bid, origin_ip, target_domain, browser_type)
+        return bid, await backend.create_browser(
+            bid, origin_ip, target_domain, browser_type, country
+        )
 
     tasks = [asyncio.create_task(_candidate(b)) for b in ids]
     winner: tuple[str, dict[str, Any]] | None = None
@@ -212,10 +216,15 @@ class Backend(Protocol):
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,
+        country: str | None,
     ) -> dict[str, Any]: ...
 
     async def get_browser(
-        self, browser_id: str, origin_ip: str | None, target_domain: str | None
+        self,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        country: str | None,
     ) -> dict[str, Any]: ...
 
     async def delete_browser(self, browser_id: str) -> dict[str, Any]: ...

--- a/getgather/browsers/browserbase_browsers.py
+++ b/getgather/browsers/browserbase_browsers.py
@@ -197,6 +197,7 @@ class BrowserbaseBackend:
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,  # not supported by Browserbase; always their hosted Chrome
+        country: str | None,
     ) -> dict[str, Any]:
         del browser_type  # not supported by Browserbase; always their hosted Chrome
         headers = {"Content-Type": "application/json", "x-bb-api-key": _api_key()}
@@ -204,7 +205,7 @@ class BrowserbaseBackend:
         # Without it, Browserbase ends the session the moment the first WS drops, and any
         # subsequent connect to the same signingKey returns HTTP 410 Gone.
         body: dict[str, Any] = {"keepAlive": True}
-        proxy_config = await get_proxy_config(origin_ip, target_domain, settings)
+        proxy_config = await get_proxy_config(origin_ip, target_domain, settings, country)
         if proxy_config:
             proxy_url = proxy_config.get_proxy_url(browser_id)
             body["proxies"] = [{"type": "external", "server": proxy_url}]
@@ -342,7 +343,11 @@ class BrowserbaseBackend:
         return ""  # self-relayed; sentinel tells the router to skip websocket_proxy
 
     async def get_browser(
-        self, browser_id: str, origin_ip: str | None, target_domain: str | None
+        self,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        country: str | None,
     ) -> dict[str, Any]:
         if browser_id not in self._sessions:
             raise BrowserNotFound(browser_id)

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -115,13 +115,14 @@ async def _configure_remote_sandbox(
     browser_id: str,
     origin_ip: str | None,
     target_domain: str | None,
+    country: str | None,
 ) -> None:
     """Apply the residential proxy to the sandbox and verify egress IP changed.
 
     The proxy is mandatory: if one is configured it MUST apply and change the egress IP, otherwise
     this raises ProxyVerificationError. If no proxy is configured, this is a no-op (proxy is not
     required). Callers let the error propagate; best-of-N treats a raising candidate as failed."""
-    proxy_config = await get_proxy_config(origin_ip, target_domain, settings)
+    proxy_config = await get_proxy_config(origin_ip, target_domain, settings, country)
     proxy_url = proxy_config.get_proxy_url(browser_id) if proxy_config else None
 
     if not proxy_url:
@@ -185,6 +186,7 @@ class DaytonaBackend:
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,
+        country: str | None,
     ) -> dict[str, Any]:
         lock = self._locks.setdefault(browser_id, asyncio.Lock())
         async with lock:
@@ -192,7 +194,9 @@ class DaytonaBackend:
             # Proxy is mandatory when configured: let ProxyVerificationError propagate (the endpoint
             # maps it to 500) so the client can retry rather than get an unproxied browser.
             try:
-                await _configure_remote_sandbox(sandbox, browser_id, origin_ip, target_domain)
+                await _configure_remote_sandbox(
+                    sandbox, browser_id, origin_ip, target_domain, country
+                )
             except ProxyVerificationError:
                 # A sandbox that fails proxy verification is unusable (wrong/no egress IP) and
                 # would otherwise sit around until Daytona's auto_stop/auto_delete TTL. Delete now.
@@ -202,7 +206,11 @@ class DaytonaBackend:
             return await self._get_info(sandbox)
 
     async def get_browser(
-        self, browser_id: str, origin_ip: str | None, target_domain: str | None
+        self,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        country: str | None,
     ) -> dict[str, Any]:
         sandbox = await self._get(_sandbox_name(browser_id))
         if sandbox is None:

--- a/getgather/browsers/fleet_browsers.py
+++ b/getgather/browsers/fleet_browsers.py
@@ -26,6 +26,7 @@ def build_chromefleet_headers(*, target_domain: str | None = None) -> dict[str, 
         "x-origin-id": mcp_headers.get("x-origin-id", None),
         "x-origin-ua": mcp_headers.get("x-origin-ua", None),
         "x-browser-type": mcp_headers.get("x-browser-type", None),
+        "x-country": mcp_headers.get("x-country", None),
         "x-target-domains": target_domain,
     }
     return {k: v for k, v in headers.items() if v is not None}
@@ -109,17 +110,26 @@ class FleetBackend:
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,
+        country: str | None,
     ) -> dict[str, Any]:
         headers = {"x-origin-ip": origin_ip} if origin_ip else {}
         if browser_type:
             headers["x-browser-type"] = browser_type
+        if country:
+            headers["x-country"] = country
         response = _require(await call_chromefleet_api("POST", browser_id, headers=headers))
         return response.json()
 
     async def get_browser(
-        self, browser_id: str, origin_ip: str | None, target_domain: str | None
+        self,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        country: str | None,
     ) -> dict[str, Any]:
         headers = {"x-origin-ip": origin_ip} if origin_ip else {}
+        if country:
+            headers["x-country"] = country
         response = _require(
             await call_chromefleet_api("GET", browser_id, headers=headers, raise_for_status=False)
         )

--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -291,6 +291,7 @@ async def configure_remote_browser(
     container_name: str,
     origin_ip: str | None,
     target_domain: str | None,
+    country: str | None,
 ) -> str | None:
     """Apply the residential proxy to the container and verify the egress IP changed.
 
@@ -299,7 +300,7 @@ async def configure_remote_browser(
     treats the raising candidate as a loser, so the client can retry rather than get an unproxied
     browser). If no proxy is configured, this is a no-op (proxy is not required) and the current
     egress IP is returned. Mirrors `daytona_browsers._configure_remote_sandbox`."""
-    proxy_config = await get_proxy_config(origin_ip, target_domain, settings)
+    proxy_config = await get_proxy_config(origin_ip, target_domain, settings, country)
     proxy_url = proxy_config.get_proxy_url(browser_id) if proxy_config else None
 
     ip_before = await get_container_public_ip(container_name)
@@ -347,12 +348,13 @@ class PodmanBackend:
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,  # not supported by the podman backend; always Chrome
+        country: str | None,
     ) -> dict[str, Any]:
         container_name = f"{BROWSER_NAME_PREFIX}{browser_id}"
         await launch_container(settings.CONTAINER_IMAGE, container_name)
         try:
             ip = await configure_remote_browser(
-                browser_id, container_name, origin_ip, target_domain
+                browser_id, container_name, origin_ip, target_domain, country
             )
         except ProxyVerificationError:
             # A container that fails proxy verification is unusable (wrong/no egress IP) and
@@ -363,7 +365,11 @@ class PodmanBackend:
         return {"container_name": container_name, "status": "created", "ip": ip}
 
     async def get_browser(
-        self, browser_id: str, origin_ip: str | None, target_domain: str | None
+        self,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        country: str | None,
     ) -> dict[str, Any]:
         # GET is a cheap read: proxy is configured+verified once on create (see create_browser),
         # never on get, even when x-origin-ip is present. Otherwise every GET would restart tinyproxy

--- a/getgather/browsers/residential_proxy.py
+++ b/getgather/browsers/residential_proxy.py
@@ -163,23 +163,35 @@ async def get_proxy_config(
     origin_ip: str | None,
     target_domain: str | None,
     settings: "BrowserSettings",
+    country: str | None = None,
 ) -> "OxylabsProxyConfig | MassiveProxyConfig | None":
-    if not origin_ip:
-        logger.info("No origin IP provided — skipping proxy selection")
-        return None
+    location: GeoLocation | None = None
 
-    if not settings.MAXMIND_ENABLED:
-        logger.info(
-            f"x-origin-ip={origin_ip} provided but MaxMind not configured — skipping proxy selection"
+    if country:
+        # x-country wins when present — no MaxMind call, even if origin_ip is also set. An
+        # invalid code is treated as absent (skip proxy), not a fallback to MaxMind.
+        try:
+            location = GeoLocation(country=country)
+        except ValueError:
+            logger.info(f"Invalid x-country={country!r} — skipping proxy selection")
+            return None
+    else:
+        if not origin_ip:
+            logger.info("No origin IP provided — skipping proxy selection")
+            return None
+
+        if not settings.MAXMIND_ENABLED:
+            logger.info(
+                f"x-origin-ip={origin_ip} provided but MaxMind not configured — skipping proxy selection"
+            )
+            return None
+
+        location = await get_location(
+            origin_ip, settings.MAXMIND_ACCOUNT_ID, settings.MAXMIND_LICENSE_KEY
         )
-        return None
-
-    location = await get_location(
-        origin_ip, settings.MAXMIND_ACCOUNT_ID, settings.MAXMIND_LICENSE_KEY
-    )
-    if not location:
-        logger.info(f"Could not resolve location for {origin_ip} — skipping proxy selection")
-        return None
+        if not location:
+            logger.info(f"Could not resolve location for {origin_ip} — skipping proxy selection")
+            return None
 
     proxies: dict[Literal["oxylabs", "massive"], OxylabsProxyConfig | MassiveProxyConfig] = {}
     if settings.OXYLABS_PROXY_ENABLED:

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -222,15 +222,18 @@ async def create_browser_auto_endpoint(request: Request) -> dict[str, Any]:
         origin_ip = request.headers.get("x-origin-ip")
         target_domain = request.headers.get("x-target-domains")
         browser_type = request.headers.get("x-browser-type")
+        country = request.headers.get("x-country") or None
         explicit = settings.BROWSER_BEST_OF_N
         n = max(1, explicit if explicit is not None else backend.default_best_of_n)
         if n == 1:
             browser_id = new_browser_id()
             result = await backend.create_browser(
-                browser_id, origin_ip, target_domain, browser_type
+                browser_id, origin_ip, target_domain, browser_type, country
             )
         else:
-            browser_id, result = await best_of_n(backend, n, origin_ip, target_domain, browser_type)
+            browser_id, result = await best_of_n(
+                backend, n, origin_ip, target_domain, browser_type, country
+            )
         logger.info(f"Browser {browser_id} is started.")
         return {"browser_id": browser_id, **result}
     except Exception as e:
@@ -246,7 +249,10 @@ async def create_browser(browser_id: str, request: Request) -> dict[str, Any]:
         origin_ip = request.headers.get("x-origin-ip")
         target_domain = request.headers.get("x-target-domains")
         browser_type = request.headers.get("x-browser-type")
-        result = await backend.create_browser(browser_id, origin_ip, target_domain, browser_type)
+        country = request.headers.get("x-country") or None
+        result = await backend.create_browser(
+            browser_id, origin_ip, target_domain, browser_type, country
+        )
         logger.info(f"Browser {browser_id} is started.")
         return {"browser_id": browser_id, **result}
     except Exception as e:
@@ -277,8 +283,9 @@ async def get_browser(browser_id: str, request: Request) -> dict[str, Any]:
     logger.info(f"Querying browser {browser_id}...")
     origin_ip = request.headers.get("x-origin-ip")
     target_domain = request.headers.get("x-target-domains")
+    country = request.headers.get("x-country") or None
     try:
-        return await backend.get_browser(browser_id, origin_ip, target_domain)
+        return await backend.get_browser(browser_id, origin_ip, target_domain, country)
     except BrowserNotFound:
         detail = f"Browser {browser_id} not found!"
         logger.warning(detail)
@@ -310,7 +317,10 @@ async def relay_browser_cdp(client_ws: WebSocket, browser_id: str, *, patch: boo
             origin_ip = client_ws.headers.get("x-origin-ip")
             target_domain = client_ws.headers.get("x-target-domains")
             browser_type = client_ws.headers.get("x-browser-type")
-            await backend.create_browser(browser_id, origin_ip, target_domain, browser_type)
+            country = client_ws.headers.get("x-country") or None
+            await backend.create_browser(
+                browser_id, origin_ip, target_domain, browser_type, country
+            )
             logger.info(f"[CDP] Browser {browser_id} started")
         except Exception as e:
             logger.error(f"[CDP] Failed to auto-start browser {browser_id}: {e}")

--- a/tests/test_best_of_n.py
+++ b/tests/test_best_of_n.py
@@ -30,6 +30,7 @@ class _FakeBackend:
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,
+        country: str | None,
     ) -> dict[str, Any]:
         delay = self.delays.get(browser_id, 0.0)
         if delay:
@@ -73,7 +74,7 @@ async def test_best_of_n_picks_first_to_complete(monkeypatch: MonkeyPatch) -> No
     backend.delays = {"b0": 0.02, "b1": 0.01, "b2": 0.05}
     backend.create_outcomes = {"b1": ProxyVerificationError("proxy unchanged")}
 
-    winner_id, info = await best_of_n(backend, 3, None, None, None)
+    winner_id, info = await best_of_n(backend, 3, None, None, None, None)
     await asyncio.sleep(0)  # let the fire-and-forget cleanup task schedule
 
     assert winner_id == "b0"
@@ -90,7 +91,7 @@ async def test_best_of_n_raises_when_all_candidates_fail(monkeypatch: MonkeyPatc
     }
 
     with pytest.raises(ProxyVerificationError, match="no browser candidate started"):
-        await best_of_n(backend, 2, None, None, None)
+        await best_of_n(backend, 2, None, None, None, None)
 
 
 @pytest.mark.asyncio
@@ -100,7 +101,7 @@ async def test_best_of_n_winner_is_not_deleted(monkeypatch: MonkeyPatch) -> None
     backend = _FakeBackend()
     backend.delays = {"w": 0.01, "l1": 0.05, "l2": 0.05}
 
-    winner_id, _ = await best_of_n(backend, 3, None, None, None)
+    winner_id, _ = await best_of_n(backend, 3, None, None, None, None)
     assert winner_id == "w"
     assert "w" not in backend.deleted
 
@@ -154,11 +155,11 @@ async def test_cleanup_losers_waits_for_materialization(monkeypatch: MonkeyPatch
 
 
 @pytest.mark.asyncio
-async def test_best_of_n_passes_origin_ip_target_domain_and_browser_type(
+async def test_best_of_n_passes_origin_ip_target_domain_browser_type_and_country(
     monkeypatch: MonkeyPatch,
 ) -> None:
     _patch_ids(monkeypatch, ["b0", "b1"])
-    seen: list[tuple[str, str | None, str | None, str | None]] = []
+    seen: list[tuple[str, str | None, str | None, str | None, str | None]] = []
 
     class _Tracking(_FakeBackend):
         async def create_browser(
@@ -167,13 +168,14 @@ async def test_best_of_n_passes_origin_ip_target_domain_and_browser_type(
             origin_ip: str | None,
             target_domain: str | None,
             browser_type: str | None,
+            country: str | None,
         ) -> dict[str, Any]:
-            seen.append((browser_id, origin_ip, target_domain, browser_type))
+            seen.append((browser_id, origin_ip, target_domain, browser_type, country))
             self.existing.add(browser_id)
             return {"id": browser_id}
 
-    await best_of_n(_Tracking(), 2, "1.2.3.4", "amazon.com", "cloak")
+    await best_of_n(_Tracking(), 2, "1.2.3.4", "amazon.com", "cloak", "de")
     assert set(seen) == {
-        ("b0", "1.2.3.4", "amazon.com", "cloak"),
-        ("b1", "1.2.3.4", "amazon.com", "cloak"),
+        ("b0", "1.2.3.4", "amazon.com", "cloak", "de"),
+        ("b1", "1.2.3.4", "amazon.com", "cloak", "de"),
     }

--- a/tests/test_browser_backend.py
+++ b/tests/test_browser_backend.py
@@ -54,6 +54,7 @@ def test_create_browser_auto_name_starts_with_b(monkeypatch: MonkeyPatch) -> Non
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,
+        country: str | None,
     ):
         return {
             "container_name": f"chromium-{browser_id}",

--- a/tests/test_browserbase_backend.py
+++ b/tests/test_browserbase_backend.py
@@ -125,7 +125,7 @@ async def test_browserbase_create_browser_stores_connect_url_mapping(
 
     backend = BrowserbaseBackend()
     # The caller-supplied id is ignored; Browserbase mints its own session id.
-    result = await backend.create_browser("ignored-id", None, None, None)
+    result = await backend.create_browser("ignored-id", None, None, None, None)
 
     assert result == {"browser_id": SESSION_ID, "status": "created", "ip": None}
 
@@ -171,7 +171,7 @@ async def test_browserbase_create_browser_attaches_residential_proxy(
     monkeypatch.setattr(browserbase_browsers, "get_proxy_config", fake_get_proxy_config)
 
     backend = BrowserbaseBackend()
-    result = await backend.create_browser("bid", "1.2.3.4", "amazon.com", None)
+    result = await backend.create_browser("bid", "1.2.3.4", "amazon.com", None, None)
 
     assert result == {"browser_id": SESSION_ID, "status": "created", "ip": None}
     assert fake_client.create_call["json"] == {
@@ -197,7 +197,7 @@ async def test_browserbase_create_browser_omits_proxies_without_proxy(
     monkeypatch.setattr(browserbase_browsers, "get_proxy_config", fake_get_proxy_config)
 
     backend = BrowserbaseBackend()
-    await backend.create_browser("bid", "1.2.3.4", "amazon.com", None)
+    await backend.create_browser("bid", "1.2.3.4", "amazon.com", None, None)
     assert fake_client.create_call["json"] == {"keepAlive": True}
 
 
@@ -223,7 +223,7 @@ async def test_browserbase_cdp_proxy_single_attempt_on_410(
     monkeypatch.setattr(httpx, "AsyncClient", factory)
 
     backend = BrowserbaseBackend()
-    await backend.create_browser("ignored", None, None, None)
+    await backend.create_browser("ignored", None, None, None, None)
     monkeypatch.setattr(browsers_router, "backend", backend)
 
     connect_calls: list[int] = []
@@ -262,7 +262,7 @@ async def test_browserbase_delete_browser_releases_session_via_post(
     monkeypatch.setattr(httpx, "AsyncClient", factory)
 
     backend = BrowserbaseBackend()
-    await backend.create_browser("ignored", None, None, None)
+    await backend.create_browser("ignored", None, None, None, None)
     assert await backend.get_cdp_websocket_remote_url(SESSION_ID) == CONNECT_URL
 
     result = await backend.delete_browser(SESSION_ID)
@@ -286,7 +286,7 @@ async def test_browserbase_delete_browser_swallows_404(monkeypatch: MonkeyPatch)
     monkeypatch.setattr(httpx, "AsyncClient", factory)
 
     backend = BrowserbaseBackend()
-    await backend.create_browser("ignored", None, None, None)
+    await backend.create_browser("ignored", None, None, None, None)
 
     result = await backend.delete_browser(SESSION_ID)
     assert result == {"browser_id": SESSION_ID, "status": "deleted"}
@@ -350,7 +350,7 @@ async def test_browserbase_create_browser_waits_until_cdp_ready(
     monkeypatch.setattr(websockets, "connect", fake_connect)
 
     backend = BrowserbaseBackend()
-    result = await backend.create_browser("ignored", None, None, None)
+    result = await backend.create_browser("ignored", None, None, None, None)
 
     assert result == {"browser_id": SESSION_ID, "status": "created", "ip": None}
     # Exactly one probe was sent (Target.getTargets with id=-2) and it succeeded first try.
@@ -389,7 +389,7 @@ async def test_browserbase_create_browser_never_ready_releases_and_raises(
     monkeypatch.setattr(asyncio, "sleep", _no_sleep)
 
     with pytest.raises(RuntimeError, match="never became CDP-ready"):
-        await backend.create_browser("ignored", None, None, None)
+        await backend.create_browser("ignored", None, None, None, None)
 
     # Cleanup released the upstream session and dropped the dead id from the local mapping.
     assert fake_client.release_call["url"] == f"{BROWSERBASE_SESSIONS_URL}/{SESSION_ID}"

--- a/tests/test_daytona_browsers.py
+++ b/tests/test_daytona_browsers.py
@@ -48,7 +48,7 @@ def _fake_sandbox() -> "daytona_browsers.AsyncSandbox":
 async def test_configure_remote_sandbox_ok_when_ip_before_missing(monkeypatch: MonkeyPatch) -> None:
     # Regression: a failed ip_before measurement (None) must NOT fail a working proxy.
     _patch_proxy(monkeypatch, ips=[None, "9.9.9.9"])
-    await daytona_browsers._configure_remote_sandbox(_fake_sandbox(), "b0", None, None)  # pyright: ignore[reportPrivateUsage]
+    await daytona_browsers._configure_remote_sandbox(_fake_sandbox(), "b0", None, None, None)  # pyright: ignore[reportPrivateUsage]
 
 
 @pytest.mark.asyncio
@@ -58,14 +58,14 @@ async def test_configure_remote_sandbox_raises_on_ip_check_failure(
     # ip_after is None (curl/exec timeout): distinct, accurate error, not "IP unchanged".
     _patch_proxy(monkeypatch, ips=["1.1.1.1", None])
     with pytest.raises(ProxyVerificationError, match="IP check failed"):
-        await daytona_browsers._configure_remote_sandbox(_fake_sandbox(), "b0", None, None)  # pyright: ignore[reportPrivateUsage]
+        await daytona_browsers._configure_remote_sandbox(_fake_sandbox(), "b0", None, None, None)  # pyright: ignore[reportPrivateUsage]
 
 
 @pytest.mark.asyncio
 async def test_configure_remote_sandbox_raises_when_ip_unchanged(monkeypatch: MonkeyPatch) -> None:
     _patch_proxy(monkeypatch, ips=["1.1.1.1", "1.1.1.1"])
     with pytest.raises(ProxyVerificationError, match="IP unchanged"):
-        await daytona_browsers._configure_remote_sandbox(_fake_sandbox(), "b0", None, None)  # pyright: ignore[reportPrivateUsage]
+        await daytona_browsers._configure_remote_sandbox(_fake_sandbox(), "b0", None, None, None)  # pyright: ignore[reportPrivateUsage]
 
 
 @pytest.mark.asyncio
@@ -88,7 +88,9 @@ async def test_get_browser_never_reconfigures_proxy(monkeypatch: MonkeyPatch) ->
     monkeypatch.setattr(DaytonaBackend, "_get", fake_get)
     monkeypatch.setattr(DaytonaBackend, "_get_info", fake_info)
 
-    info = await _backend().get_browser("b0", origin_ip="1.2.3.4", target_domain="amazon.com")
+    info = await _backend().get_browser(
+        "b0", origin_ip="1.2.3.4", target_domain="amazon.com", country=None
+    )
     assert info == {"id": "b0"}
     assert configured is False
 
@@ -117,6 +119,7 @@ def test_create_browser_n1_short_circuits_best_of_n(monkeypatch: MonkeyPatch) ->
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,
+        country: str | None,
     ) -> dict[str, str]:
         called["browser_id"] = browser_id
         called["browser_type"] = browser_type
@@ -159,6 +162,7 @@ def test_create_browser_auto_n_gt1_invokes_best_of_n(monkeypatch: MonkeyPatch) -
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,
+        country: str | None,
     ) -> tuple[str, dict[str, str]]:
         invoked["n"] = n
         invoked["origin_ip"] = origin_ip
@@ -249,6 +253,7 @@ def test_create_browser_auto_uses_backend_default_when_env_unset(monkeypatch: Mo
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,
+        country: str | None,
     ) -> tuple[str, dict[str, str]]:
         invoked["n"] = n
         return "winner", {"id": "winner"}

--- a/tests/test_podman_browsers.py
+++ b/tests/test_podman_browsers.py
@@ -35,7 +35,7 @@ def _patch_proxy(monkeypatch: MonkeyPatch, *, ips: list[str | None], proxy_ok: b
 async def test_configure_remote_browser_ok_when_ip_before_missing(monkeypatch: MonkeyPatch) -> None:
     # Regression: a failed ip_before measurement (None) must NOT fail a working proxy.
     _patch_proxy(monkeypatch, ips=[None, "9.9.9.9"])
-    ip = await podman_browsers.configure_remote_browser("b0", "chromium-b0", None, None)
+    ip = await podman_browsers.configure_remote_browser("b0", "chromium-b0", None, None, None)
     assert ip == "9.9.9.9"
 
 
@@ -43,7 +43,7 @@ async def test_configure_remote_browser_ok_when_ip_before_missing(monkeypatch: M
 async def test_configure_remote_browser_raises_on_apply_failure(monkeypatch: MonkeyPatch) -> None:
     _patch_proxy(monkeypatch, ips=["1.1.1.1"], proxy_ok=False)
     with pytest.raises(ProxyVerificationError, match="Proxy failed to apply"):
-        await podman_browsers.configure_remote_browser("b0", "chromium-b0", None, None)
+        await podman_browsers.configure_remote_browser("b0", "chromium-b0", None, None, None)
 
 
 @pytest.mark.asyncio
@@ -53,14 +53,14 @@ async def test_configure_remote_browser_raises_on_ip_check_failure(
     # ip_after is None (curl/exec timeout): distinct, accurate error, not "IP unchanged".
     _patch_proxy(monkeypatch, ips=["1.1.1.1", None])
     with pytest.raises(ProxyVerificationError, match="IP check failed"):
-        await podman_browsers.configure_remote_browser("b0", "chromium-b0", None, None)
+        await podman_browsers.configure_remote_browser("b0", "chromium-b0", None, None, None)
 
 
 @pytest.mark.asyncio
 async def test_configure_remote_browser_raises_when_ip_unchanged(monkeypatch: MonkeyPatch) -> None:
     _patch_proxy(monkeypatch, ips=["1.1.1.1", "1.1.1.1"])
     with pytest.raises(ProxyVerificationError, match="IP unchanged"):
-        await podman_browsers.configure_remote_browser("b0", "chromium-b0", None, None)
+        await podman_browsers.configure_remote_browser("b0", "chromium-b0", None, None, None)
 
 
 @pytest.mark.asyncio
@@ -75,7 +75,7 @@ async def test_configure_remote_browser_noop_without_proxy(monkeypatch: MonkeyPa
     monkeypatch.setattr(podman_browsers, "get_proxy_config", fake_get_proxy_config)
     monkeypatch.setattr(podman_browsers, "get_container_public_ip", fake_public_ip)
 
-    ip = await podman_browsers.configure_remote_browser("b0", "chromium-b0", None, None)
+    ip = await podman_browsers.configure_remote_browser("b0", "chromium-b0", None, None, None)
     assert ip == "1.1.1.1"
 
 
@@ -104,7 +104,9 @@ async def test_get_browser_never_reconfigures_proxy(monkeypatch: MonkeyPatch) ->
     monkeypatch.setattr(podman_browsers, "get_container_last_activity", fake_last_activity)
     monkeypatch.setattr(podman_browsers, "get_container_public_ip", fake_public_ip)
 
-    info = await PodmanBackend().get_browser("b0", origin_ip="1.2.3.4", target_domain="amazon.com")
+    info = await PodmanBackend().get_browser(
+        "b0", origin_ip="1.2.3.4", target_domain="amazon.com", country=None
+    )
     assert info == {"last_activity_timestamp": 1.0, "ip": "9.9.9.9"}
     assert configured is False
 
@@ -130,7 +132,7 @@ async def test_create_browser_propagates_proxy_verification_error(monkeypatch: M
     monkeypatch.setattr(podman_browsers, "kill_container", fake_kill)
 
     with pytest.raises(ProxyVerificationError, match="IP unchanged"):
-        await PodmanBackend().create_browser("b0", "1.2.3.4", "amazon.com", None)
+        await PodmanBackend().create_browser("b0", "1.2.3.4", "amazon.com", None, None)
 
     assert killed == ["chromium-b0"]
 
@@ -160,6 +162,7 @@ async def test_best_of_n_treats_proxy_failure_as_loser(monkeypatch: MonkeyPatch)
             origin_ip: str | None,
             target_domain: str | None,
             browser_type: str | None,
+            country: str | None,
         ) -> dict[str, Any]:
             if browser_id == "b0":
                 raise ProxyVerificationError("IP unchanged after proxy")
@@ -176,6 +179,6 @@ async def test_best_of_n_treats_proxy_failure_as_loser(monkeypatch: MonkeyPatch)
     ids = iter(["b0", "b1"])
     monkeypatch.setattr(backend_module, "new_browser_id", lambda: next(ids))
 
-    winner_id, info = await best_of_n(_Backend(), 2, "1.2.3.4", "amazon.com", None)
+    winner_id, info = await best_of_n(_Backend(), 2, "1.2.3.4", "amazon.com", None, None)
     assert winner_id == "b1"
     assert info == {"id": "b1"}

--- a/tests/test_residential_proxy.py
+++ b/tests/test_residential_proxy.py
@@ -282,3 +282,72 @@ async def test_get_proxy_config_no_provider_returns_none() -> None:
     ):
         result = await get_proxy_config("1.2.3.4", None, s)
     assert result is None
+
+
+# --- get_proxy_config: x-country ---
+
+
+@pytest.mark.asyncio
+async def test_get_proxy_config_country_wins_without_maxmind_call() -> None:
+    # x-country present -> no MaxMind call at all, even with an origin_ip set.
+    s = _settings(
+        MASSIVE_PROXY_USERNAME="mu",
+        MASSIVE_PROXY_PASSWORD="mp",
+        MAXMIND_ACCOUNT_ID=1,
+        MAXMIND_LICENSE_KEY="k",
+        DEFAULT_PROXY_TYPE="massive",
+    )
+    get_location_mock = AsyncMock(side_effect=AssertionError("MaxMind must not be called"))
+    with patch("getgather.browsers.residential_proxy.get_location", new=get_location_mock):
+        result = await get_proxy_config("1.2.3.4", None, s, "de")
+    assert result is not None
+    assert "country-de" in result.get_proxy_url("sess")
+    get_location_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_proxy_config_country_without_origin_ip() -> None:
+    # Country alone is enough to build the proxy; MaxMind is not required.
+    s = _settings(
+        MASSIVE_PROXY_USERNAME="mu",
+        MASSIVE_PROXY_PASSWORD="mp",
+        DEFAULT_PROXY_TYPE="massive",
+    )
+    result = await get_proxy_config(None, None, s, "US")
+    assert result is not None
+    assert "country-us" in result.get_proxy_url("sess")
+
+
+@pytest.mark.asyncio
+async def test_get_proxy_config_invalid_country_skips_proxy_not_maxmind() -> None:
+    # An invalid x-country is treated as absent/miss: skip proxy, do not fall back to MaxMind.
+    s = _settings(
+        MASSIVE_PROXY_USERNAME="mu",
+        MASSIVE_PROXY_PASSWORD="mp",
+        MAXMIND_ACCOUNT_ID=1,
+        MAXMIND_LICENSE_KEY="k",
+    )
+    get_location_mock = AsyncMock(side_effect=AssertionError("MaxMind must not be called"))
+    with patch("getgather.browsers.residential_proxy.get_location", new=get_location_mock):
+        result = await get_proxy_config("1.2.3.4", None, s, "xyz")
+    assert result is None
+    get_location_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_proxy_config_empty_country_falls_back_to_maxmind() -> None:
+    # An empty string country is falsy -> same as absent, so MaxMind is used as usual.
+    s = _settings(
+        MASSIVE_PROXY_USERNAME="mu",
+        MASSIVE_PROXY_PASSWORD="mp",
+        MAXMIND_ACCOUNT_ID=1,
+        MAXMIND_LICENSE_KEY="k",
+        DEFAULT_PROXY_TYPE="massive",
+    )
+    loc = _us_location()
+    with patch(
+        "getgather.browsers.residential_proxy.get_location", new=AsyncMock(return_value=loc)
+    ):
+        result = await get_proxy_config("1.2.3.4", None, s, "")
+    assert result is not None
+    assert "country-us" in result.get_proxy_url("sess")


### PR DESCRIPTION
## Summary
- Add optional `x-country` header (same plumbing as `x-origin-ip`/`x-browser-type`/`x-target-domains`) that picks the residential-proxy country directly — no MaxMind call when present.
- `get_proxy_config` now takes `country`: valid `x-country` wins over MaxMind; invalid/empty is treated as absent (skip proxy, still create the browser, no 400); MaxMind from `x-origin-ip` remains the fallback and still does not default to US on a miss.
- `x-country` threaded through `router.py`, `Backend` protocol, `best_of_n`, and all four backends (Fleet, Daytona, Podman, Browserbase).
- Fleet backend reads/forwards `x-country` on both create and GET; local backends (Daytona/Podman/Browserbase) only use it on create — GET never re-applies the proxy, unchanged.
- `build_chromefleet_headers` (MCP → Fleet path) forwards `x-country` when present.

Design: `docs/superpowers/specs/2026-08-14-x-country-proxy-design.md`

## Test plan
- [x] `uv run pytest -m "not api and not webui and not mcp and not distill"` — 136 passed
- [x] `make typecheck` — pyright strict + ty clean
- [x] `make check-backend-format` — ruff clean
- [x] New unit tests cover: country wins without MaxMind call, country-only (no origin_ip), invalid country skips proxy without falling to MaxMind, empty country falls back to MaxMind