### PR TITLE
fix(cdp): treat ReadTimeout on /json/version probe as unreachable browser

### DIFF
--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -52,10 +52,12 @@ async def get_page_list(browser_id: str) -> list[str]:
     # own proxy and never reaches this path, so open_browser_cdp_client returns None there.
     try:
         client = await open_browser_cdp_client(browser_id)
-    except (BrowserNotFound, httpx.HTTPStatusError) as e:
+    except (BrowserNotFound, httpx.HTTPStatusError, httpx.TimeoutException) as e:
         # A Daytona sandbox that is stopped or archived answers 400/404 on its signed
         # preview URL, and a deleted one raises BrowserNotFound (Browserbase answers 410
-        # for an ended session). In every case the browser has no reachable pages.
+        # for an ended session). A sandbox that is up but unresponsive times out on the
+        # /json/version probe (httpx.TimeoutException). In every case the browser has no
+        # reachable pages, so skip it and let find_browser_id keep scanning the rest.
         logger.info(f"[CDP] browser {browser_id} unreachable: {type(e).__name__}")
         return []
     if client is None:


### PR DESCRIPTION
## Summary
- Logfire trace `ac70e6d4dafe43f62f5862d4ab4b8c45` showed `httpx.ReadTimeout` escaping `get_page_list` (`getgather/browsers/router.py`) when probing a dead Daytona sandbox's `/json/version` endpoint.
- `get_page_list` only caught `(BrowserNotFound, httpx.HTTPStatusError)` — a timeout wasn't handled, so it raised out of `find_browser_id`'s scan loop and 500'd the whole `/devtools` websocket proxy request instead of skipping that browser and continuing the scan.
- Added `httpx.TimeoutException` to the caught exceptions so an unresponsive sandbox is treated the same as a stopped/deleted one (no reachable pages).

## Test plan
- [ ] `make check`
- [ ] Manually verify a stale/unreachable browser_id no longer 500s the devtools proxy route