### PR TITLE
feat(dpage): CloakBrowser humanize and reload-before-actions

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -22,6 +22,11 @@ from zendriver.core.config import Config
 from zendriver.core.connection import Connection, ProtocolException
 
 from getgather.browsers.fleet_browsers import build_chromefleet_headers, call_chromefleet_api
+from getgather.cloak_human import (
+    CloakHumanizeUnavailable,
+    human_click_element,
+    human_type_into_element,
+)
 from getgather.config import FRIENDLY_CHARS, settings
 
 _ws_extra_headers_var: ContextVar[dict[str, str] | None] = ContextVar(
@@ -477,6 +482,7 @@ class ElementConfig:
     typing_char_delay_min: float = 0.01
     typing_char_delay_max: float = 0.05
     action_delay_ms: float = 0
+    humanize: bool = False
 
 
 class Element:
@@ -633,6 +639,9 @@ class Element:
                 raise
 
     async def type_text(self, text: str) -> None:
+        if self.config.humanize:
+            await self.human_type_text(text)
+            return
         if self.config.action_delay_ms > 0:
             await asyncio.sleep(self.config.action_delay_ms / 1000)
         await self._clear_input()
@@ -641,6 +650,43 @@ class Element:
             await asyncio.sleep(
                 random.uniform(self.config.typing_char_delay_min, self.config.typing_char_delay_max)
             )
+
+    async def human_type_text(self, text: str) -> None:
+        if self.config.action_delay_ms > 0:
+            await asyncio.sleep(self.config.action_delay_ms / 1000)
+        try:
+            await human_type_into_element(
+                self.element,
+                tag=self.tag,
+                tab=self.page,
+                text=text,
+            )
+        except CloakHumanizeUnavailable as exc:
+            logger.warning(f"humanize unavailable, falling back to type_text: {exc}")
+            self.config.humanize = False
+            await self.type_text(text)
+
+    async def human_click(self) -> None:
+        if self.config.action_delay_ms > 0:
+            await asyncio.sleep(self.config.action_delay_ms / 1000)
+        try:
+            await human_click_element(
+                self.element,
+                tag=self.tag,
+                tab=self.page,
+            )
+        except CloakHumanizeUnavailable as exc:
+            logger.warning(f"humanize unavailable, falling back to mouse_click: {exc}")
+            await self.element.mouse_click()
+        await asyncio.sleep(0.25)
+
+    async def trusted_click(self) -> None:
+        """CDP-trusted click; humanized when ElementConfig.humanize is set."""
+        if self.config.humanize:
+            await self.human_click()
+        else:
+            await self.element.mouse_click()
+            await asyncio.sleep(0.25)
 
     async def css_click(self) -> None:
         if not self.css_selector:

--- a/getgather/cloak_human.py
+++ b/getgather/cloak_human.py
@@ -1,0 +1,291 @@
+"""CloakBrowser humanize algorithms over zendriver CDP (Option B).
+
+Uses ``cloakbrowser.human`` move/click/type helpers with thin zendriver adapters
+so distillation can keep zendriver while getting Bézier mouse paths and human typing.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Literal
+
+from loguru import logger
+from zendriver import cdp
+from zendriver.core.keys import KeyEvents, KeyModifiers, KeyPressEvent, SpecialKeys
+
+HumanPreset = Literal["default", "careful"]
+
+_CLOAK_CURSOR_ATTR = "_cloak_human_cursor"
+
+
+class _CursorState:
+    __slots__ = ("x", "y", "initialized")
+
+    def __init__(self) -> None:
+        self.x = 0.0
+        self.y = 0.0
+        self.initialized = False
+
+
+class CloakHumanizeUnavailable(RuntimeError):
+    """Raised when humanize is requested but the cloakbrowser package is missing."""
+
+
+def _require_cloak_human() -> Any:
+    try:
+        import cloakbrowser.human.config as human_config
+        import cloakbrowser.human.keyboard_async as keyboard_async
+        import cloakbrowser.human.mouse as mouse_sync
+        import cloakbrowser.human.mouse_async as mouse_async
+    except ImportError as exc:
+        raise CloakHumanizeUnavailable(
+            "cloakbrowser is required for humanize (install with: uv sync --extra daytona)"
+        ) from exc
+    return human_config, keyboard_async, mouse_sync, mouse_async
+
+
+def get_human_config(preset: HumanPreset = "default") -> Any:
+    human_config, _, _, _ = _require_cloak_human()
+    return human_config.resolve_config(preset)
+
+
+def position_to_box(position: Any) -> dict[str, float]:
+    return {
+        "x": float(position.x),
+        "y": float(position.y),
+        "width": float(position.width),
+        "height": float(position.height),
+    }
+
+
+def is_input_tag(tag: str) -> bool:
+    tag_lower = tag.lower()
+    return tag_lower in ("input", "textarea", "select") or tag_lower == "textarea"
+
+
+def _cursor_for_tab(tab: Any, cfg: Any) -> _CursorState:
+    # zendriver Tab is not hashable — store cursor state on the tab instance.
+    cursor = getattr(tab, _CLOAK_CURSOR_ATTR, None)
+    if cursor is None:
+        cursor = _CursorState()
+        setattr(tab, _CLOAK_CURSOR_ATTR, cursor)
+    if not cursor.initialized:
+        human_config, _, _, _ = _require_cloak_human()
+        cursor.x = human_config.rand_range(cfg.initial_cursor_x)
+        cursor.y = human_config.rand_range(cfg.initial_cursor_y)
+        cursor.initialized = True
+    return cursor
+
+
+_PLAYWRIGHT_SPECIAL: dict[str, SpecialKeys] = {
+    "Shift": SpecialKeys.SHIFT,
+    "Backspace": SpecialKeys.BACKSPACE,
+    "Control": SpecialKeys.CTRL,
+    "Meta": SpecialKeys.META,
+    "Alt": SpecialKeys.ALT,
+    "Enter": SpecialKeys.ENTER,
+    "Tab": SpecialKeys.TAB,
+    "Delete": SpecialKeys.DELETE,
+    "ArrowLeft": SpecialKeys.ARROW_LEFT,
+    "ArrowUp": SpecialKeys.ARROW_UP,
+    "ArrowRight": SpecialKeys.ARROW_RIGHT,
+    "ArrowDown": SpecialKeys.ARROW_DOWN,
+}
+
+
+async def _send_key_payload(tab: Any, payload: KeyEvents.Payload) -> None:
+    await tab.send(
+        cdp.input_.dispatch_key_event(
+            type_=payload["type_"],
+            modifiers=payload.get("modifiers") or 0,
+            text=payload.get("text"),
+            key=payload.get("key"),
+            code=payload.get("code"),
+            windows_virtual_key_code=payload.get("windows_virtual_key_code"),
+            native_virtual_key_code=payload.get("native_virtual_key_code"),
+        )
+    )
+
+
+async def _press_key(tab: Any, key: str, modifiers: KeyModifiers = KeyModifiers.Default) -> None:
+    if key in _PLAYWRIGHT_SPECIAL:
+        events = KeyEvents(_PLAYWRIGHT_SPECIAL[key]).to_cdp_events(KeyPressEvent.DOWN_AND_UP)
+    elif len(key) == 1:
+        events = KeyEvents(key, modifiers).to_cdp_events(KeyPressEvent.DOWN_AND_UP)
+    else:
+        raise ValueError(f"Unsupported key for humanize keyboard: {key!r}")
+    for payload in events:
+        await _send_key_payload(tab, payload)
+
+
+class ZendriverCdpSession:
+    """Minimal CDP session shape for cloakbrowser shift-symbol typing."""
+
+    def __init__(self, tab: Any) -> None:
+        self._tab = tab
+
+    async def send(self, method: str, params: dict[str, Any]) -> None:
+        if method != "Input.dispatchKeyEvent":
+            logger.warning(f"ZendriverCdpSession ignoring unsupported method {method!r}")
+            return
+        await self._tab.send(
+            cdp.input_.dispatch_key_event(
+                type_=str(params["type"]),
+                modifiers=params.get("modifiers"),
+                key=params.get("key"),
+                code=params.get("code"),
+                text=params.get("text"),
+                unmodified_text=params.get("unmodifiedText"),
+                windows_virtual_key_code=params.get("windowsVirtualKeyCode"),
+                native_virtual_key_code=params.get("nativeVirtualKeyCode"),
+            )
+        )
+
+
+class ZendriverRawMouse:
+    def __init__(self, tab: Any) -> None:
+        self._tab = tab
+        self._x = 0.0
+        self._y = 0.0
+
+    async def move(self, x: float, y: float) -> None:
+        self._x = float(x)
+        self._y = float(y)
+        await self._tab.send(
+            cdp.input_.dispatch_mouse_event(type_="mouseMoved", x=self._x, y=self._y)
+        )
+
+    async def down(self, click_count: int = 1) -> None:
+        await self._tab.send(
+            cdp.input_.dispatch_mouse_event(
+                type_="mousePressed",
+                x=self._x,
+                y=self._y,
+                button=cdp.input_.MouseButton("left"),
+                click_count=click_count,
+            )
+        )
+
+    async def up(self, click_count: int = 1) -> None:
+        await self._tab.send(
+            cdp.input_.dispatch_mouse_event(
+                type_="mouseReleased",
+                x=self._x,
+                y=self._y,
+                button=cdp.input_.MouseButton("left"),
+                click_count=click_count,
+            )
+        )
+
+    async def wheel(self, delta_x: float, delta_y: float) -> None:
+        await self._tab.send(
+            cdp.input_.dispatch_mouse_event(
+                type_="mouseWheel",
+                x=self._x,
+                y=self._y,
+                delta_x=float(delta_x),
+                delta_y=float(delta_y),
+            )
+        )
+
+
+def _key_event_payload(key: str, event_type: KeyPressEvent) -> KeyEvents.Payload:
+    if key in _PLAYWRIGHT_SPECIAL:
+        key_event = KeyEvents(_PLAYWRIGHT_SPECIAL[key])
+    elif len(key) == 1:
+        key_event = KeyEvents(key)
+    else:
+        raise ValueError(f"Unsupported key: {key!r}")
+    return key_event._to_basic_event(event_type)  # pyright: ignore[reportPrivateUsage]
+
+
+class ZendriverRawKeyboard:
+    def __init__(self, tab: Any) -> None:
+        self._tab = tab
+
+    async def down(self, key: str) -> None:
+        await _send_key_payload(self._tab, _key_event_payload(key, KeyPressEvent.KEY_DOWN))
+
+    async def up(self, key: str) -> None:
+        await _send_key_payload(self._tab, _key_event_payload(key, KeyPressEvent.KEY_UP))
+
+    async def type(self, text: str) -> None:
+        for ch in text:
+            await _press_key(self._tab, ch)
+
+    async def insert_text(self, text: str) -> None:
+        await self._tab.send(cdp.input_.insert_text(text))
+
+
+def reset_cursor_for_tab(tab: Any) -> None:
+    if hasattr(tab, _CLOAK_CURSOR_ATTR):
+        delattr(tab, _CLOAK_CURSOR_ATTR)
+
+
+async def human_pre_action_idle(
+    tab: Any, duration_ms: int, preset: HumanPreset = "default"
+) -> None:
+    """Drift the mouse briefly before the first interaction (Akamai warmup)."""
+    if duration_ms <= 0:
+        return
+    human_config, _, _, mouse_async = _require_cloak_human()
+    cfg = human_config.resolve_config(preset)
+    cursor = _cursor_for_tab(tab, cfg)
+    raw_mouse = ZendriverRawMouse(tab)
+    await mouse_async.async_human_idle(raw_mouse, duration_ms / 1000, cursor.x, cursor.y, cfg)
+
+
+async def human_click_element(
+    element: Any,
+    *,
+    tag: str,
+    tab: Any,
+    preset: HumanPreset = "default",
+) -> None:
+    """Humanized click on a zendriver Element (Bézier move + realistic hold)."""
+    human_config, _, mouse_sync, mouse_async = _require_cloak_human()
+    cfg = human_config.resolve_config(preset)
+
+    await element.scroll_into_view()
+    position = await element.get_position()
+    if position is None:
+        logger.warning("human_click: no position for element, skipping")
+        return
+
+    box = position_to_box(position)
+    is_input = is_input_tag(tag)
+    target = mouse_sync.click_target(box, is_input, cfg)
+
+    cursor = _cursor_for_tab(tab, cfg)
+    raw_mouse = ZendriverRawMouse(tab)
+    await mouse_async.async_human_move(raw_mouse, cursor.x, cursor.y, target.x, target.y, cfg)
+    cursor.x = target.x
+    cursor.y = target.y
+    await mouse_async.async_human_click(raw_mouse, is_input, cfg)
+
+
+async def human_type_into_element(
+    element: Any,
+    *,
+    tag: str,
+    tab: Any,
+    text: str,
+    preset: HumanPreset = "default",
+) -> None:
+    """Humanized fill: focus click, select-all clear, then cloakbrowser typing."""
+    human_config, keyboard_async, _, _ = _require_cloak_human()
+    cfg = human_config.resolve_config(preset)
+
+    await human_click_element(element, tag=tag, tab=tab, preset=preset)
+
+    await human_config.async_sleep_ms(human_config.rand(100, 250))
+
+    select_mod = KeyModifiers.Meta if sys.platform == "darwin" else KeyModifiers.Ctrl
+    await _press_key(tab, "a", select_mod)
+    await human_config.async_sleep_ms(human_config.rand(30, 80))
+    await _press_key(tab, "Backspace")
+    await human_config.async_sleep_ms(human_config.rand(50, 150))
+
+    raw_keyboard = ZendriverRawKeyboard(tab)
+    cdp_session = ZendriverCdpSession(tab)
+    await keyboard_async.async_human_type(None, raw_keyboard, text, cfg, cdp_session=cdp_session)

--- a/getgather/mcp/dpage.py
+++ b/getgather/mcp/dpage.py
@@ -29,6 +29,7 @@ from getgather.browser import (
     wait_for_ready_state,
     zen_navigate_with_retry,
 )
+from getgather.cloak_human import human_pre_action_idle, reset_cursor_for_tab
 from getgather.config import settings
 from getgather.mcp.html_renderer import DEFAULT_TITLE, render_form
 from getgather.zen_distill import (
@@ -321,6 +322,68 @@ def is_incognito_request(headers: dict[str, str]) -> bool:
     return headers.get("x-incognito", "0") == "1"
 
 
+def _html_int_attr(element: Tag | None, name: str, default: int = 0) -> int:
+    if element is None:
+        return default
+    raw = element.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(str(raw))
+    except ValueError:
+        return default
+
+
+def _pattern_reload_max(root: Tag | None) -> int:
+    """Max reloads for rb-reload-before-actions; default 1 preserves one-shot behavior."""
+    return _html_int_attr(root, "rb-reload-max", 1)
+
+
+def _pattern_html_root(patterns: list[Pattern], match_name: str) -> Tag | None:
+    pattern_item = next((item for item in patterns if item.name == match_name), None)
+    if pattern_item is None:
+        return None
+    root = pattern_item.pattern.find("html")
+    return root if isinstance(root, Tag) else None
+
+
+async def _maybe_reload_for_matched_pattern(
+    page: zd.Tab,
+    match: Match,
+    patterns: list[Pattern],
+    *,
+    current_reload_count: int = 0,
+) -> bool:
+    """Reload when the distilled pattern requests it, up to rb-reload-max (default 1)."""
+    root = _pattern_html_root(patterns, match.name)
+    if root is None:
+        return False
+    if "rb-reload-before-actions" not in root.attrs:
+        return False
+
+    reload_max = _pattern_reload_max(root)
+    if current_reload_count >= reload_max:
+        logger.info(
+            f"Reload budget exhausted for {match.name} "
+            f"({current_reload_count}/{reload_max}) — continuing without reload"
+        )
+        return False
+
+    settle_ms = _html_int_attr(root, "rb-settle-ms", 5000)
+    logger.info(
+        f"Reloading page before trusted actions for {match.name} "
+        f"(attempt {current_reload_count + 1}/{reload_max}, settle {settle_ms}ms)"
+    )
+    await page.reload()
+    reset_cursor_for_tab(page)
+    try:
+        await wait_for_ready_state(page, timeout=30)
+    except Exception as exc:
+        logger.warning(f"Ready state after reload: {exc}")
+    await asyncio.sleep(settle_ms / 1000)
+    return True
+
+
 async def distill_post_loop(
     page: zd.Tab,
     id: str,
@@ -353,6 +416,9 @@ async def distill_post_loop(
     except Exception as e:
         logger.warning(f"Error waiting for page ready state: {e}")
 
+    reload_counts: dict[str, int] = {}
+    consumed_fields: dict[str, str] = {}
+
     for iteration in range(max):
         logger.debug(f"Iteration {iteration + 1} of {max}")
         await asyncio.sleep(TICK)
@@ -376,17 +442,24 @@ async def distill_post_loop(
         inputs = document.find_all("input")
         pending_actions: list[dict[str, str]] = []
         html_element = document.find("html")
+        html_tag = html_element if isinstance(html_element, Tag) else None
         action_delay_ms = (
-            int(str(html_element.get("rb-action-delay") or 0))
-            if isinstance(html_element, Tag)
-            else 0
+            int(str(html_tag.get("rb-action-delay") or 0)) if html_tag is not None else 0
         )
         element_config = (
             ElementConfig(action_delay_ms=action_delay_ms) if action_delay_ms > 0 else None
         )
-        trusted_actions = (
-            isinstance(html_element, Tag) and "rb-trusted-actions" in html_element.attrs
-        )
+        trusted_actions = html_tag is not None and "rb-trusted-actions" in html_tag.attrs
+        pattern_humanize = html_tag is not None and "rb-humanize" in html_tag.attrs
+        use_cdp_actions = trusted_actions or pattern_humanize
+        humanize = pattern_humanize
+        if humanize:
+            element_config = ElementConfig(
+                action_delay_ms=action_delay_ms,
+                humanize=True,
+            )
+        elif use_cdp_actions and action_delay_ms > 0:
+            element_config = ElementConfig(action_delay_ms=action_delay_ms)
 
         if match.distilled == current.distilled:
             logger.info(f"Still the same: {match.name}")
@@ -397,7 +470,27 @@ async def distill_post_loop(
                 return HTMLResponse(render(str(document.find("body")), options))
             continue
 
+        pattern_reload_count = reload_counts.get(match.name, 0)
+        if await _maybe_reload_for_matched_pattern(
+            page, match, patterns, current_reload_count=pattern_reload_count
+        ):
+            reload_counts[match.name] = pattern_reload_count + 1
+            if consumed_fields:
+                fields.update(consumed_fields)
+                logger.info(
+                    f"Restored {len(consumed_fields)} field(s) after reload for {match.name}"
+                )
+            # Force re-processing of the next match (e.g. cvs-signin after bot banner clears).
+            current = Match(name="", priority=-1, distilled="")
+            continue
+
         current = match
+
+        if use_cdp_actions:
+            pre_action_ms = _html_int_attr(html_tag, "rb-pre-action-idle-ms", 0)
+            if pre_action_ms > 0:
+                logger.info(f"Pre-action idle mouse for {pre_action_ms}ms")
+                await human_pre_action_idle(page, pre_action_ms)
 
         if await terminate(distilled):
             logger.info("Finished!")
@@ -536,7 +629,7 @@ async def distill_post_loop(
                         names.append(name_str)
                         input["value"] = value
                         current.distilled = str(document)
-                        if trusted_actions and input_type not in ("checkbox", "radio"):
+                        if use_cdp_actions and input_type not in ("checkbox", "radio"):
                             text_element = await page_query_selector(
                                 page,
                                 selector if selector is not None else "",
@@ -556,6 +649,7 @@ async def distill_post_loop(
                                 "value": str(value),
                                 "action_delay_ms": str(action_delay_ms),
                             })
+                        consumed_fields[name_str] = str(value)
                         del fields[name_str]
                     else:
                         logger.info(f"No form data found for {name}")
@@ -572,17 +666,22 @@ async def distill_post_loop(
                 })
 
         should_submit = False
+        submit_delay_ms = _html_int_attr(html_tag, "rb-submit-delay-ms", 0)
+        after_submit_delay_ms = _html_int_attr(html_tag, "rb-after-submit-delay-ms", 0)
         SUBMIT_BUTTON = "button[rb-autoclick], button[gg-autoclick], button[type=submit]"
         if document.select(SUBMIT_BUTTON):
             if len(names) > 0 and expected_field_count == len(names):
                 logger.info("Submitting form, all fields are filled...")
+                if submit_delay_ms > 0:
+                    logger.info(f"Waiting {submit_delay_ms}ms before submit")
+                    await asyncio.sleep(submit_delay_ms / 1000)
                 for submit_button in document.select(SUBMIT_BUTTON):
                     submit_selector, frame_selector = get_selector(
                         str(get_match_attr(submit_button))
                     )
                     if not submit_selector:
                         continue
-                    if trusted_actions:
+                    if use_cdp_actions:
                         submit_element = await page_query_selector(
                             page,
                             submit_selector,
@@ -591,8 +690,7 @@ async def distill_post_loop(
                         )
                         if submit_element:
                             logger.info(f"Trusted CDP mouse click on {submit_selector}")
-                            await submit_element.element.mouse_click()
-                            await asyncio.sleep(0.25)
+                            await submit_element.trusted_click()
                         else:
                             logger.warning(f"Trusted submit could not find {submit_selector}")
                     else:
@@ -645,6 +743,9 @@ async def distill_post_loop(
             await asyncio.sleep(0.25)
 
         if should_submit:
+            if after_submit_delay_ms > 0:
+                logger.info(f"Waiting {after_submit_delay_ms}ms after submit")
+                await asyncio.sleep(after_submit_delay_ms / 1000)
             continue
 
     hostname_attr: str | None = getattr(page, "hostname", None)  # type: ignore[assignment]

--- a/getgather/mcp/patterns/cvs-signin-bot-detection.html
+++ b/getgather/mcp/patterns/cvs-signin-bot-detection.html
@@ -1,0 +1,14 @@
+<html
+  rb-domain="cvs"
+  rb-priority="1"
+  rb-reload-before-actions
+  rb-reload-max="3"
+  rb-settle-ms="3000"
+>
+  <head>
+    <title>CVS Bot Detection</title>
+  </head>
+  <body>
+    <div rb-stop rb-error="captcha" rb-match="div.profile-input-error h2.banner-error-text"></div>
+  </body>
+</html>

--- a/getgather/mcp/patterns/cvs-signin-confirm-submit.html
+++ b/getgather/mcp/patterns/cvs-signin-confirm-submit.html
@@ -1,4 +1,4 @@
-<html rb-domain="cvs" rb-trusted-actions>
+<html rb-domain="cvs" rb-humanize>
   <head>
     <title>Sign In to CVS</title>
   </head>

--- a/getgather/mcp/patterns/cvs-signin-confirm.html
+++ b/getgather/mcp/patterns/cvs-signin-confirm.html
@@ -1,4 +1,4 @@
-<html rb-domain="cvs" rb-trusted-actions>
+<html rb-domain="cvs" rb-after-submit-delay-ms="5000">
   <head>
     <title>Sign In to CVS</title>
   </head>
@@ -10,7 +10,7 @@
           type="radio"
           name="signin-option-radio"
           id="sms-radio"
-          data-testid="signin-method-password"
+          data-testid="signin-method-sms"
           rb-match="input[value='sms']"
           value="sms-radio"
           checked

--- a/getgather/mcp/patterns/cvs-signin-dob-confirmation.html
+++ b/getgather/mcp/patterns/cvs-signin-dob-confirmation.html
@@ -1,4 +1,4 @@
-<html rb-domain="cvs" rb-trusted-actions>
+<html rb-domain="cvs" rb-humanize rb-after-submit-delay-ms="5000">
   <head>
     <title>Sign In to CVS</title>
   </head>
@@ -14,17 +14,61 @@
 
     <div rb-optional rb-match="ps-alert-bar div[slot='heading']"></div>
 
-    <input
-      name="month"
-      type="text"
-      data-testid="month"
-      rb-match="input#month"
-      placeholder="Month"
-    />
+    <div class="dob-container">
+      <input
+        name="month"
+        type="text"
+        inputmode="numeric"
+        data-testid="month"
+        rb-match="input#month"
+        placeholder="MM"
+        maxlength="2"
+      />
+      <span class="dob-separator" aria-hidden="true">/</span>
+      <input
+        name="day"
+        type="text"
+        inputmode="numeric"
+        data-testid="day"
+        rb-match="input#day"
+        placeholder="DD"
+        maxlength="2"
+      />
+      <span class="dob-separator" aria-hidden="true">/</span>
+      <input
+        name="year"
+        type="text"
+        inputmode="numeric"
+        data-testid="year"
+        rb-match="input#year"
+        placeholder="YYYY"
+        maxlength="4"
+      />
+    </div>
 
-    <input name="day" type="text" data-testid="day" rb-match="input#day" placeholder="Day" />
+    <style>
+      .dob-container {
+        display: flex;
+        align-items: center;
+        justify-content: flex-start;
+        gap: 0.5rem;
+      }
 
-    <input name="year" type="text" data-testid="year" rb-match="input#year" placeholder="Year" />
+      .dob-container input {
+        width: 4.5rem;
+        text-align: center;
+      }
+
+      .dob-container input[name="year"] {
+        width: 5.5rem;
+      }
+
+      .dob-separator {
+        color: #6b7280;
+        font-weight: 500;
+        user-select: none;
+      }
+    </style>
 
     <button
       type="submit"

--- a/getgather/mcp/patterns/cvs-signin.html
+++ b/getgather/mcp/patterns/cvs-signin.html
@@ -1,4 +1,13 @@
-<html rb-domain="cvs" rb-trusted-actions>
+<html
+  rb-domain="cvs"
+  rb-humanize
+  rb-reload-before-actions
+  rb-settle-ms="5000"
+  rb-pre-action-idle-ms="1000"
+  rb-submit-delay-ms="2500"
+  rb-after-submit-delay-ms="1000"
+  rb-priority="2"
+>
   <head>
     <title>Sign In to CVS</title>
   </head>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # Daytona backend (BROWSER_BACKEND=daytona). Optional so podman-only installs stay unchanged.
-daytona = ["daytona>=0.183.0"]
+daytona = ["daytona>=0.183.0", "cloakbrowser>=0.5.0"]
 
 [dependency-groups]
 dev = [

--- a/tests/mcp/test_dpage_reload.py
+++ b/tests/mcp/test_dpage_reload.py
@@ -1,0 +1,25 @@
+from bs4 import BeautifulSoup, Tag
+
+from getgather.mcp.dpage import _pattern_reload_max
+
+
+def test_pattern_reload_max_default() -> None:
+    root = BeautifulSoup("<html rb-reload-before-actions></html>", "html.parser").find("html")
+    assert isinstance(root, Tag)
+    assert _pattern_reload_max(root) == 1
+
+
+def test_pattern_reload_max_custom() -> None:
+    root = BeautifulSoup(
+        '<html rb-reload-before-actions rb-reload-max="3"></html>', "html.parser"
+    ).find("html")
+    assert isinstance(root, Tag)
+    assert _pattern_reload_max(root) == 3
+
+
+def test_pattern_reload_max_invalid_falls_back_to_default() -> None:
+    root = BeautifulSoup(
+        '<html rb-reload-before-actions rb-reload-max="nope"></html>', "html.parser"
+    ).find("html")
+    assert isinstance(root, Tag)
+    assert _pattern_reload_max(root) == 1

--- a/tests/mcp/test_dpage_reload.py
+++ b/tests/mcp/test_dpage_reload.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup, Tag
 
-from getgather.mcp.dpage import _pattern_reload_max
+from getgather.mcp.dpage import _pattern_reload_max  # pyright: ignore[reportPrivateUsage]
 
 
 def test_pattern_reload_max_default() -> None:

--- a/tests/test_cloak_human.py
+++ b/tests/test_cloak_human.py
@@ -1,0 +1,161 @@
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest import MonkeyPatch
+
+from getgather import cloak_human
+
+
+def _first_range_value(r: tuple[float, float]) -> float:
+    return r[0]
+
+
+def _fake_click_target(_box: dict[str, float], _is_input: bool, _cfg: Any) -> MagicMock:
+    return MagicMock(x=50, y=10)
+
+
+def _fake_resolve_config(_preset: str) -> MagicMock:
+    return MagicMock(
+        initial_cursor_x=(1, 1),
+        initial_cursor_y=(2, 2),
+        click_input_x_range=(0.1, 0.2),
+    )
+
+
+class _FakeTab:
+    def __init__(self) -> None:
+        self.sent: list[Any] = []
+
+    async def send(self, cmd: Any) -> None:
+        self.sent.append(cmd)
+
+
+def _cmd_locals(cmd: Any) -> dict[str, Any]:
+    frame = cmd.gi_frame
+    assert frame is not None
+    return dict(frame.f_locals)
+
+
+@pytest.mark.asyncio
+async def test_zendriver_raw_mouse_move_and_click_use_last_coordinates() -> None:
+    tab = _FakeTab()
+    mouse = cloak_human.ZendriverRawMouse(tab)
+    await mouse.move(100, 200)
+    await mouse.down()
+    await mouse.up()
+
+    assert len(tab.sent) == 3
+    moved = _cmd_locals(tab.sent[0])
+    pressed = _cmd_locals(tab.sent[1])
+    released = _cmd_locals(tab.sent[2])
+    assert moved["x"] == 100 and moved["y"] == 200
+    assert pressed["x"] == 100 and pressed["y"] == 200
+    assert released["x"] == 100 and released["y"] == 200
+
+
+def test_position_to_box() -> None:
+    pos = MagicMock()
+    pos.x = 10
+    pos.y = 20
+    pos.width = 100
+    pos.height = 30
+    assert cloak_human.position_to_box(pos) == {
+        "x": 10.0,
+        "y": 20.0,
+        "width": 100.0,
+        "height": 30.0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_human_click_element_moves_before_press(monkeypatch: MonkeyPatch) -> None:
+    tab = _FakeTab()
+    element = MagicMock()
+    element.scroll_into_view = AsyncMock()
+    position = MagicMock()
+    position.x = 0
+    position.y = 0
+    position.width = 200
+    position.height = 40
+    element.get_position = AsyncMock(return_value=position)
+
+    move_calls: list[tuple[float, float, float, float]] = []
+
+    async def fake_move(
+        raw_mouse: Any, sx: float, sy: float, ex: float, ey: float, cfg: Any
+    ) -> None:
+        del cfg
+        move_calls.append((sx, sy, ex, ey))
+        await raw_mouse.move(ex, ey)
+
+    async def fake_click(raw_mouse: Any, is_input: bool, cfg: Any) -> None:
+        del is_input, cfg
+        await raw_mouse.down()
+        await raw_mouse.up()
+
+    monkeypatch.setattr(
+        cloak_human,
+        "_require_cloak_human",
+        lambda: (
+            MagicMock(
+                resolve_config=_fake_resolve_config,
+                rand_range=_first_range_value,
+            ),
+            MagicMock(),
+            MagicMock(click_target=_fake_click_target),
+            MagicMock(async_human_move=fake_move, async_human_click=fake_click),
+        ),
+    )
+
+    await cloak_human.human_click_element(element, tag="input", tab=tab)
+    assert move_calls
+    pressed = [
+        _cmd_locals(cmd) for cmd in tab.sent if _cmd_locals(cmd).get("type_") == "mousePressed"
+    ]
+    assert pressed
+
+
+@pytest.mark.asyncio
+async def test_zendriver_cdp_session_dispatches_shift_symbol_key_events() -> None:
+    tab = _FakeTab()
+    session = cloak_human.ZendriverCdpSession(tab)
+    await session.send(
+        "Input.dispatchKeyEvent",
+        {
+            "type": "keyDown",
+            "modifiers": 8,
+            "key": "@",
+            "code": "Digit2",
+            "windowsVirtualKeyCode": 50,
+            "text": "@",
+            "unmodifiedText": "@",
+        },
+    )
+    assert len(tab.sent) == 1
+
+
+def test_is_input_tag() -> None:
+    assert cloak_human.is_input_tag("input") is True
+    assert cloak_human.is_input_tag("BUTTON") is False
+
+
+def test_cursor_for_tab_works_on_unhashable_tab(monkeypatch: MonkeyPatch) -> None:
+    class _UnhashableTab:
+        pass
+
+    tab = _UnhashableTab()
+    cfg = MagicMock(initial_cursor_x=(10, 10), initial_cursor_y=(20, 20))
+    monkeypatch.setattr(
+        cloak_human,
+        "_require_cloak_human",
+        lambda: (
+            MagicMock(rand_range=_first_range_value),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        ),
+    )
+    cursor = cloak_human._cursor_for_tab(tab, cfg)  # pyright: ignore[reportPrivateUsage]
+    assert cursor.initialized is True
+    assert getattr(tab, cloak_human._CLOAK_CURSOR_ATTR) is cursor  # pyright: ignore[reportPrivateUsage]

--- a/uv.lock
+++ b/uv.lock
@@ -485,6 +485,20 @@ wheels = [
 ]
 
 [[package]]
+name = "cloakbrowser"
+version = "0.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "httpx" },
+    { name = "playwright" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/66/a0f3e06aadb89f5aa8a403864bf2bce296d2eb10e5983a13a62ce19cb493/cloakbrowser-0.5.3.tar.gz", hash = "sha256:720369cf0fce12cc895e5a09f98b18f809d9c55f17f4d5f854204d720e8133c3", size = 5644946, upload-time = "2026-07-30T01:18:58.282Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/e8/f0d86ca18b3a1e132ffd965268f621897f60c47ea8c61b1ee9a786fffb36/cloakbrowser-0.5.3-py3-none-any.whl", hash = "sha256:9082cfd2f104342fd718d9882984da7674ef6616308dd7932bff4b8bd5cf3cfe", size = 112895, upload-time = "2026-07-30T01:18:56.523Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1020,6 +1034,83 @@ name = "grapheme"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/e7/bbaab0d2a33e07c8278910c1d0d8d4f3781293dfbc70b5c38197159046bf/grapheme-0.6.0.tar.gz", hash = "sha256:44c2b9f21bbe77cfb05835fec230bd435954275267fea1858013b102f8603cca", size = 207306, upload-time = "2020-03-07T17:13:55.492Z" }
+
+[[package]]
+name = "greenlet"
+version = "3.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/74/b13368064b09053253555d3f2839cc2684d22d5aed0d2ccffbf7a6736558/greenlet-3.5.4.tar.gz", hash = "sha256:0232ae1de90a8e07867bb127d7a6ba2301e859145489f25cda8a6096dabe1d20", size = 206538, upload-time = "2026-07-22T12:47:14.468Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/16/71eefcf68267bbf06a9b6bff57d0b222e49432326e85d74348b67694b8d4/greenlet-3.5.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e883de250e299654b1f1680f72a1a9f9ba62c9bd1bce84099c90657349a8dfbb", size = 294266, upload-time = "2026-07-22T11:37:56.142Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ea/a0b19adfc35d07e10acb626e9d22a3893b95f1309c42c4a20161dec16800/greenlet-3.5.4-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32802705c2c1ff25e8237b3bdacf2594fa02be80af8a66703eb7853ea7e68686", size = 613712, upload-time = "2026-07-22T12:26:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/54/76/a121978b3337407d05a1ce5f79b4aa5998a43a9d8422f9726029b90b4471/greenlet-3.5.4-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57aa201b351f7c7c75627c60d29e4d5b97a07d37efeb62b903466fca42c097d7", size = 625582, upload-time = "2026-07-22T12:29:00.814Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4a/f301f1d85c69a86b90b5d581a73e8927bba4e79450037e6e2cbca05eb4fd/greenlet-3.5.4-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9667862a2e38ad379f11b845daeda22c8989186def44f06962c9c4c05e556da7", size = 633429, upload-time = "2026-07-22T12:43:42.073Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/080f16cf870e929e592f55767f01d6c98d2ee83bfdc36c3b892f2d0459ab/greenlet-3.5.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c3fe76c2cac86b4f7a1e92865ac0a54384deb05c92986287c1a7110d9bd53071", size = 624663, upload-time = "2026-07-22T11:51:08.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2e/26884072b0eb343a4d5fee903341bfe5171b32b7f14553886e2b6349135a/greenlet-3.5.4-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:ae53534b5dec0f4c2ec26f898f538dc8ea1ca3ef2927d597a9439e40a09da937", size = 428238, upload-time = "2026-07-22T12:39:49.973Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/bb/8f3ca88370b817369008faeceeee85970adc16c92a70a3e5fe5fea495a57/greenlet-3.5.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1e1a4a684b16c45ba324e60b32a4386a87722bcb815d2a149d2182f9b401ca72", size = 1585010, upload-time = "2026-07-22T12:25:02.539Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c2/45877154689709ebce9a0b83c2235e6ca0f31577889b02af308c8cc5f8fb/greenlet-3.5.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e849e6e139b9671adeac505f72fc05f4af7fd1921faef40295e214fc3b361b59", size = 1651283, upload-time = "2026-07-22T11:51:10.408Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7d/8711a75cb61d85246277c07ff6e1a6504621ba473d808c11ad225ffca43f/greenlet-3.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:dc418cf4c873357964d6624445ed09472e50def990c65dd4e76fc3ba8cd9cef6", size = 246434, upload-time = "2026-07-22T11:43:15.557Z" },
+    { url = "https://files.pythonhosted.org/packages/00/62/e290b3bce433da8f0324ac02da0b128d683482229f1a8b789fa47818a4cd/greenlet-3.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:c38c902a0986eba1f6e7ba1ab39ad5195926abde90f3fe080e08212db62176da", size = 244990, upload-time = "2026-07-22T11:39:22.626Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/04/81bd731d6d1e3a469d9a4c36f5eb069bcf0cbb2d5d342c9fec22245b91fc/greenlet-3.5.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3d66250e8b09f182ede05490998c818b5961f7a3640332d44c4927caec7bbfe4", size = 295909, upload-time = "2026-07-22T11:38:09.261Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/dd/f5f22903a6ae70f5ea328ed0beaec92ad903f0e3b7d2845133b354abc4b8/greenlet-3.5.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c90e930c9c192e5b3ee9fb8bcd920ea3926155e2e3ded39fc697323addecee17", size = 612011, upload-time = "2026-07-22T12:26:40.69Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/10/92a4a88d12b915d74ea5b6d288e4afefda4771647caa34442c156f7a454f/greenlet-3.5.4-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:791fdfeeb9c6e0c7b10fa151bf110d2a6974866f13dcb5b1c7efae698245893a", size = 624299, upload-time = "2026-07-22T12:29:02.089Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/f9/03e26be3487c5238e81f2b84714959a86ea8515a869828cf41f4fc54b34e/greenlet-3.5.4-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b7c895310363f310361e0fe2072af85269d2a2a285cd04c0c59e79a5e3670dcf", size = 629603, upload-time = "2026-07-22T12:43:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6d/0b14bb9db2989f32cd9fe7f76afedea01ee8bee3f87c07e69f24adfe7e63/greenlet-3.5.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f88193799d43dbf8c8a806d6405c9c52fe2af40bf75072a606357b33cc336c7f", size = 621541, upload-time = "2026-07-22T11:51:09.464Z" },
+    { url = "https://files.pythonhosted.org/packages/57/6b/7c55ca72ef80d57c16c4a55210f82582622462dc4485799a30f4ec6f3372/greenlet-3.5.4-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:13b980043cb1b3134e81ea469da1250ddcc6bfe6d245bbaa59168d9cdc8f228f", size = 432554, upload-time = "2026-07-22T12:39:51.379Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3d/25e9a2d9eb6b2e8b7ca4e80a3a26cb887cce6c8e0a87c921164f11bc5574/greenlet-3.5.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7a5f095767c4493afcd06067f2bb3b8716e3f3f9e92b99c88e7e99f885b3d4d", size = 1581444, upload-time = "2026-07-22T12:25:03.818Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/96/4c9bf2e2c408dcc0556edce69efa9f802e82223573c53240136a086821f1/greenlet-3.5.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:42afdc1ab5f66da8c586c32af9224a74a706b4f0ea0dc3a4188a0860a09c65c9", size = 1645842, upload-time = "2026-07-22T11:51:12.295Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/41/303ecb26a3a56122c0f4d4073ee078881847bd6b6f463ae0ec57ec20223b/greenlet-3.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:60149df8f462d1b230038e6590c23c3b4768bb5d6c022b3b6e82532b34b0b8a3", size = 247169, upload-time = "2026-07-22T11:38:19.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e3/ef56864b4c35fcb3eb3b41b869f6cc46f4cd3f5e2c68e74acde8ac433951/greenlet-3.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:77d6ce04fed0d9aeed42e0f37923cc43eba9b027bdd9c34546bb4ccd143d0fe0", size = 245565, upload-time = "2026-07-22T11:38:27.061Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/9a/e51225dcd58713f16ccbdcc501a8da21098ea14515b7870f1f94459e5ff5/greenlet-3.5.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:24e61b88cb7e1b1d794b32a10cc346ac779681d6d74ff137a3e0a444d2bf1f02", size = 294831, upload-time = "2026-07-22T11:38:53.389Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ea/de50a50fadf979713ab18b46f22ad5ff5f2dcfc637a3ebdecf669801e1a5/greenlet-3.5.4-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:870d730fec833f5a06906a32596cc099b9161594642a92a520b7a88911c95356", size = 614619, upload-time = "2026-07-22T12:26:42.282Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c7/2aae27fea41205b8650294c301f042a2a4bb6155eea48c995b890a92f2c1/greenlet-3.5.4-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ec5ff0d1878df6af3bf9b638a5a92a7d5693291de77c91bff10fa48519c604ef", size = 627021, upload-time = "2026-07-22T12:29:03.445Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/80/fb4d4788bbc8e54761f1fc88533af9523a6e86299fa113d6e8a8503ed9fc/greenlet-3.5.4-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:07bd44616608d873d06735b63ef1a88191d6ca57c8d291d6559c71bc14c0893c", size = 632845, upload-time = "2026-07-22T12:43:45.19Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/79fd826f9ccaae0b84e1b4ef68dabba5e105bb044ffcd448a0b782fcba9a/greenlet-3.5.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d84d993f6e575c950d91a23c1345d18fe1a4310d447bf630849d7809196b52f0", size = 624002, upload-time = "2026-07-22T11:51:11.391Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e3/6086fa578ebb72772722cdc4bcd628459814b42e0c2db1e3cbd6552b3271/greenlet-3.5.4-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:3529a8a933582ad19e224792cac7372489526576b75b4c124e8e4f29948f4861", size = 435053, upload-time = "2026-07-22T12:39:52.715Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/27319f97e731298513dcba1a2e91b63e9d8811d9de22130f960b129b1bf1/greenlet-3.5.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:58023945f421093de5e6fa108c0985a8659d43f49e0216da25099369a121bcbd", size = 1581533, upload-time = "2026-07-22T12:25:05.322Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/6d/24240bf562e9786dd2799ee0a4a4dadb4ded22510f41b20245099159ac8c/greenlet-3.5.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bae2728e1897aa8df8cb1af38cd48b3a743aefe29372de7b8b7a9f532501e69f", size = 1645781, upload-time = "2026-07-22T11:51:14.805Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/5a/442ab1a9ef7ca6bf7210e5397a95972206a91a31033a03c8900866a10039/greenlet-3.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:ca5726c0b08ca35ae873557266a78b2c3f3b2b7d7401aa5ff886c2045dd0111c", size = 247133, upload-time = "2026-07-22T11:39:20.661Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/e6/9160210222386b1a378ff94db846b9508ca24a121cf684991561fdb69280/greenlet-3.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:7c1303791d603080cac6fc3b34df51c3b75b723739c282c8029e48a0d241672f", size = 245500, upload-time = "2026-07-22T11:40:22.185Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a7/6ab1d4f9cd548d15ab90da29947f2076100130bb179b0bde59f795a459e3/greenlet-3.5.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:7e8afa5eac028f8140ceafe5ceec66e6aa127ddcb21452d2a564dcd2900b5f22", size = 295410, upload-time = "2026-07-22T11:40:35.747Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7a/422f63b4715cbc0b24385305407adf38b48f6bb68b3e6b04090e994d0f5a/greenlet-3.5.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73b37afe369021423ea53dd3123e04bffa7e93ac64429b9f50835b2e4fcae7cf", size = 661286, upload-time = "2026-07-22T12:26:43.8Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/31/5a1cac663bf5582190c5a714ef81364f03cde232227f39748f8ae4c11da5/greenlet-3.5.4-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3ef964f56dfcb6f9bbef2a190d9126795eac408716aeae47b5e7c73c32aafca9", size = 673517, upload-time = "2026-07-22T12:29:04.815Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/bf/250c2921c7b585dde12f5239e313ca2dcbc464d161ecca36e4e6ef21762d/greenlet-3.5.4-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cef589bc65fae02d10bca2ac341191c5b33acc2967892ebf4fcbd10eabb7a74c", size = 677968, upload-time = "2026-07-22T12:43:46.788Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4a/2a82a1e3f8aaca020853ac8d12211280ca2b231aa08ea39f636f1060c319/greenlet-3.5.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c53ff01a5c53a40f2c16820ebc56d7c61a77f5fbe009dadd96292d5682f80f8", size = 670917, upload-time = "2026-07-22T11:51:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/18/40/10bfcf6513558d82f7b95dd728001c63bd388259fe27d3e30ae01f103430/greenlet-3.5.4-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:dfc41ae893d9ceaf22c824f2153a88b30651b20e8758c2cd9ac143f23640563c", size = 480643, upload-time = "2026-07-22T12:39:54.149Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b0/e379a152b17bfdfa95795af4049e37c0fd1b4d81f020d426db104ed07c77/greenlet-3.5.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecca4d80d55a01ad6b23b33262662956149fbb7b2c6be2910f1705921958cbf3", size = 1628478, upload-time = "2026-07-22T12:25:06.678Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/43/bffdfa64f7317f954c5c1230b5dd5922676ce198689a68c1ac1ed4b1b1a5/greenlet-3.5.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ffbc533e0eaf8e80d8471411646ab88fe58f641d508c0b02b24494479f4d9ec", size = 1692021, upload-time = "2026-07-22T11:51:17.008Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/11/f799f9637e2c6e9b0b716015e339040598b058cf7654dfc0d67468b177ed/greenlet-3.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:305f69e6c4523d7f6979ed001cff4e5853c063e5da04880296603aa0227e544c", size = 248031, upload-time = "2026-07-22T11:40:11.007Z" },
+    { url = "https://files.pythonhosted.org/packages/05/75/625bcdd74d5e6b2dca1ecba3c3ac77bcf8a026c21a649a46cef23e421f97/greenlet-3.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:f260930bbbbcf9caee661211235a5111c86dfe5832fdf6ae4570da1e0995320f", size = 246892, upload-time = "2026-07-22T11:40:27.357Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/69/35c62ed49c320cb4d98e14698ccca5467d3bfe683984172be9cb564d9ce3/greenlet-3.5.4-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:41ddab54e4b238f4a6c323f39b4e59e176affd5a94d461a9fb7583dac74240a3", size = 305571, upload-time = "2026-07-22T11:40:31.659Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6c/64d60216b3640dcb0b62d913dd9e0d80030c09115bb2e4ba70c95d10ca45/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3dabe3e2809013052c68bdf0b7fa5f5f2859c43a80803131ad61af9cabd7867", size = 672568, upload-time = "2026-07-22T12:26:45.298Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/de/ba3ab0a96292e53039530333b0d2ae18d9e508f3a325cd7bf15f8172944c/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:27d3f00718634d4520a3a150154ac5da36f257869d41321953375b90bfbbc72c", size = 680076, upload-time = "2026-07-22T12:29:06.125Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/db/24a10af12bf8e639cec46c38b9ce1a282543ba42ff4fb0b31a970f1ab603/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:39169a11d87a6a263afda3e9a27d1df16d0f919d40a4837cc73986c9884c0dd8", size = 681690, upload-time = "2026-07-22T12:43:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/aeada79083c6f1c15f45d77a332f9c441af263ee298e3eb17522cd337d22/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbd60b5763c6543c1827e48faaf14ea9bfbad245f52b1a4d76a2a2d8884c6c66", size = 676733, upload-time = "2026-07-22T11:51:16.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/60/44a2eca7b9fd71ae0fae7ff184da1cd3169d176652b97aa1cffcbb0ef961/greenlet-3.5.4-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:bd3d1145f603b2db19feb9078c2e6855eb7c67e15580c010ed815cee519b86fd", size = 510263, upload-time = "2026-07-22T12:39:55.678Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/10/2392fc3a98948652ef5fd1e7275c04f861dd13f74b78a2b4309f4ee4d090/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f00f910f0e7b35416c63b23ad78b769aeccfc1775f712b43c4ee525624a2eef7", size = 1637327, upload-time = "2026-07-22T12:25:07.879Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c6/e7237a3dfa1f205ed0d9ea1e46d70bd2811b32d516266399fb59d28ab90a/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:91c26423753b92caf41ab3f98fd547d7374d4d9fc2d85be041886c1579d9255e", size = 1697493, upload-time = "2026-07-22T11:51:19.214Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e3/4ba8154ba2a3d43729e499f72471b4b5c993f3826d3e24da81d5f06d6572/greenlet-3.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:ee032b91fd8ec29ec6c4cea2b8c561b178435134bd0752c7334b94e9c736c132", size = 251637, upload-time = "2026-07-22T11:40:37.44Z" },
+    { url = "https://files.pythonhosted.org/packages/90/03/e3f96dfc100261a29545ddc8270cafe58f9195b6651466910e820910de77/greenlet-3.5.4-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:178111881dd7a6c946471fda85485ec796e1043c2b939f694b096e2ecf986809", size = 296076, upload-time = "2026-07-22T11:39:38.364Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/da52d208e5c977bce8667e784729e584e38b5785f4c1ec0f4c836e9a1c42/greenlet-3.5.4-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d92df08dd65fede97fc37aad36c2e9dcda3b31c467f8e0c2c096456cb818e927", size = 666870, upload-time = "2026-07-22T12:26:46.691Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/8a/7e6dee25cb8a8cf9b362c8e597cc269593378bd916f16c736c059a52e85a/greenlet-3.5.4-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:99e8f8c4ebc4fd80aa26c1280ae9ad43a0976e786349703a181cf0bae60413e5", size = 677678, upload-time = "2026-07-22T12:29:07.508Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a7/dafc7415d430b0a43a16396eb49ecb3b62fd720877fb259cc4dcfaf5f31e/greenlet-3.5.4-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1f17e362d78e37559e0506c5a7d066bdd45073c36a0127a543e8a0df27242ff3", size = 681428, upload-time = "2026-07-22T12:43:49.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/21/5a38699fa45de749e3857d93b8f07e4c20489e77c2d35d915a2e1c456606/greenlet-3.5.4-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:394de08dad5ffcb1f50c2159d93e398d9d2da3ed437645eaa54771fa720db9f0", size = 676067, upload-time = "2026-07-22T11:51:18.163Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d9/6298f3432de301d4718766cf934bd73c418c73f81fbb77247319364b0d96/greenlet-3.5.4-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:cd320d998cbaa032932830448e39abf3c6a12901295e386e8114db926e10cffb", size = 487446, upload-time = "2026-07-22T12:39:57.044Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ba/863116ab8ff1ca7a729e327800268939d182db47aa433db70e216e7d9194/greenlet-3.5.4-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:c883d61f2282d72c767a14936641b3efcbde9d82f1080712aaea0b1d3126cb88", size = 1633489, upload-time = "2026-07-22T12:25:09.605Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/06/7466ced82818d6132462d7f26b3f83c66ea15d2b193a6c0088d558ed7d95/greenlet-3.5.4-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:2a924f15d17957e252a810acefcb5942f5ca712298e8b6fcaed9a307d357522c", size = 1696584, upload-time = "2026-07-22T11:51:21.304Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/4d/55b638489260065de9ffce606c8b5d04507bef705de4b212a0c3d6a1a0df/greenlet-3.5.4-cp315-cp315-win_amd64.whl", hash = "sha256:ed17e5f3420360d5b459de8462efb52060399a5326a613d4cde31cef63ef95da", size = 248297, upload-time = "2026-07-22T11:42:04.055Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/08/9dd4ae635da93d41dc268bc34bd62a9d711ed8b8825c5d22ac910c7d6e6d/greenlet-3.5.4-cp315-cp315-win_arm64.whl", hash = "sha256:f908898d6fa484ce4b6f447ce70ea99b52c503fee419e53cf74d60a16bc9e667", size = 247423, upload-time = "2026-07-22T11:44:00.764Z" },
+    { url = "https://files.pythonhosted.org/packages/19/66/7c87ed9cdbf1d49c2c6cd1c7b9dd4d16c33b24235ca03972293a1876b30c/greenlet-3.5.4-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:1833637f17d5e7472548a48575c394fe39f1b1890d676d162d86593610f44d8c", size = 306487, upload-time = "2026-07-22T11:41:25.118Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/05/0a4201e7c0054866eefc05da234f236dd4c950d0fbf9ca0517141f01b269/greenlet-3.5.4-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12cda9122e03341f1cb6b8207a19d7a9d375e52f1b4e9243918375f40fd7b4b9", size = 676479, upload-time = "2026-07-22T12:26:48.129Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c0/4b6b8c5a3aec70f0649cd89662d120fdd6421e2bdc8e3b15c3ab5ec568d8/greenlet-3.5.4-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d83ae0e32d14957ab7170785a20f582635c8474deab1bfbb552b17e769a6ce25", size = 684321, upload-time = "2026-07-22T12:29:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/88/15/0b167aeea95285b0e654ddce651922f666c089363c2ec528ca8b9a9ba74f/greenlet-3.5.4-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:123aa379c962ed5fe90a880327e0c3066124ac64ec99e12a238be9fd8eb3db3d", size = 685995, upload-time = "2026-07-22T12:43:50.993Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c9/b49c31c9a972eee91e260445770e922244a7efc542697f51a012ec046d0f/greenlet-3.5.4-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f1467de1bb767f75db0aa34c195e3a496d8d1278c796e70c24ce205d3e99cde", size = 681293, upload-time = "2026-07-22T11:51:20.43Z" },
+    { url = "https://files.pythonhosted.org/packages/de/90/c023ec337f32ff505be7db759c80d98f0532bb94d0c6fa13645efe9bee2e/greenlet-3.5.4-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:adf2244d7f69409925a8f22ed22cc5f93cdfe5c9dc87ff3476be2c2aaae61a05", size = 516928, upload-time = "2026-07-22T12:39:58.359Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6f/7f2d4653770500eee667866016d42d7a68e3d3462f80df6b8e3fcd48a0eb/greenlet-3.5.4-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0fa53040b78b578120eecdc0265e3f1051487cc425d11a2b7c761daadf4feaa8", size = 1642474, upload-time = "2026-07-22T12:25:10.819Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/d8/8cba31036a4caae448087ba5d150660ab03b4a0f54d9150f6495a3be7262/greenlet-3.5.4-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:60e0bc961d367df506660e9ac0177a76bc6d81305300704b0977d1634f76efe2", size = 1701012, upload-time = "2026-07-22T11:51:23.17Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cd/3f77a4cce3bae631b08eb52f53a82a976669600337e21dfdba811cb50267/greenlet-3.5.4-cp315-cp315t-win_amd64.whl", hash = "sha256:f680e549edb3eaf21eea4e7fe101e15ec180c74b7879ab46adc080f22d4015d2", size = 251977, upload-time = "2026-07-22T11:41:38.125Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e8/65e8707d00fe2a49bf12f609a9b2b39ba6dd23c2810eacad877c4fc94bfe/greenlet-3.5.4-cp315-cp315t-win_arm64.whl", hash = "sha256:08fc36de8442d5c3e95b044550dbea9bf144d31ec0cc58e36fb241cb6ef6a994", size = 250538, upload-time = "2026-07-22T11:40:17.985Z" },
+]
 
 [[package]]
 name = "h11"
@@ -1900,6 +1991,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.62.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5b/ca2abcf3aa69f9fb510215e3064f30b57fe57657c8d04ede45bb966d5606/playwright-1.62.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d8da938f3748841a8754f2e1f0216902c1c8f8ae3720de8b32ccf8e6913a7c4f", size = 43732091, upload-time = "2026-07-31T17:00:44.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/0bfbe9904350961f4dbb713f04342e40d548c5fc26c8157bd13617c81492/playwright-1.62.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:db755ab27db21a04186f1fe8169888e42356086e439b1059b923ef417f0b6034", size = 42510842, upload-time = "2026-07-31T17:00:48.596Z" },
+    { url = "https://files.pythonhosted.org/packages/66/dc/c0486b407ad0699a250f6bbe3066fca95344009a99ca66e88ca175c69dc1/playwright-1.62.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:5108bd5b3e87169ddf269feee097da5893af7f8aea4634dfc840518d64c1f1da", size = 43732093, upload-time = "2026-07-31T17:00:52.218Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6b/b24aebc2b04bffcb342bccf96e287c78b363e1615bed5cea97500cc0393a/playwright-1.62.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:ba33bae6a13b3d9d354c751cb618af357d20fe1d57767cbcce52079bbef17ad3", size = 47748926, upload-time = "2026-07-31T17:00:56.438Z" },
+    { url = "https://files.pythonhosted.org/packages/36/43/b4b18bdc87e1949568fffdcde3ff9a0456266b2d0c6d4432cc34d89ea6eb/playwright-1.62.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db2d76613a57ad844362ce42f7d0c2fa26b19a4f7a46d4f76b891c631e6e5aff", size = 47441423, upload-time = "2026-07-31T17:01:00.404Z" },
+    { url = "https://files.pythonhosted.org/packages/81/22/af5d926fc2c32a339eec00a443644bc40ab9db1dd2dd9017873c59773c0c/playwright-1.62.0-py3-none-win32.whl", hash = "sha256:e5614fa89355d7081457680324bb219f79f69c423c5cb6fa250e30b0d8aebf1c", size = 38164450, upload-time = "2026-07-31T17:01:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a9/4160c1033c07af98bf841ad079457dd78408a5ee0dd56cbfe50b8b6a1c22/playwright-1.62.0-py3-none-win_amd64.whl", hash = "sha256:92c0d98ed04eb35af557b709875edba415b1f548bdb22ddb5bb3e1e6c835c2f1", size = 38164458, upload-time = "2026-07-31T17:01:08.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ec/06b55d619a7082a766aa04f2c6bb31435c87f02930087d8a0517119408fa/playwright-1.62.0-py3-none-win_arm64.whl", hash = "sha256:ea8d3055aa9d5a9f1832ac82517bd8b42c78fac7ebcbebb0107116735c8cb6a1", size = 34208868, upload-time = "2026-07-31T17:01:11.818Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2152,6 +2262,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee", size = 172583, upload-time = "2025-06-24T13:26:46.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796", size = 45235, upload-time = "2025-06-24T13:26:45.485Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -2449,6 +2571,7 @@ dependencies = [
 
 [package.optional-dependencies]
 daytona = [
+    { name = "cloakbrowser" },
     { name = "daytona" },
 ]
 
@@ -2474,6 +2597,7 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "async-lru", specifier = ">=2.0" },
     { name = "beautifulsoup4", specifier = ">=4.13.4" },
+    { name = "cloakbrowser", marker = "extra == 'daytona'", specifier = ">=0.5.0" },
     { name = "daytona", specifier = ">=0.183.0" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.183.0" },
     { name = "fastapi", specifier = ">=0.115.12" },


### PR DESCRIPTION
## Summary
- Add CloakBrowser humanize adapters (`cloak_human.py`) and per-pattern `rb-humanize` typing/clicks
- Support `rb-reload-before-actions`, settle/idle/submit delay attrs in the dpage loop
- Depend on `cloakbrowser>=0.5.0` via the daytona extra

Stacked under: CVS bot-detection will target this branch.

## Test plan
- [ ] `uv run pytest tests/test_cloak_human.py tests/mcp/test_dpage_reload.py`
- [ ] `make check`
- [ ] Confirm no CVS pattern files are in this PR