### PR TITLE
fix(ci): cap daytona, remove daytona from dependency, and use wheel metadata to install daytona

### DIFF
--- a/.github/workflows/browser-api-e2e-test.yml
+++ b/.github/workflows/browser-api-e2e-test.yml
@@ -120,7 +120,15 @@ jobs:
       - name: Execute the wheel
         # uvx resolves fresh from PyPI and never reads uv.lock — this leg deliberately tests what
         # `uvx remotebrowser` gives a real user, so the version caps live in pyproject.toml.
-        run: uvx ./dist/*.whl &
+        # The daytona SDK is an extra (lazy-imported), so request it via the wheel's own extra
+        # rather than `--with daytona`, which would resolve the SDK uncapped.
+        run: |
+          wheel=$(ls dist/*.whl)
+          if [ "${{ matrix.browser_backend }}" = daytona ]; then
+            uvx --from "remotebrowser[daytona] @ file://$PWD/$wheel" remotebrowser &
+          else
+            uvx "$wheel" &
+          fi
 
       - name: Run the health check validation
         run: while ! curl -s 'http://localhost:23456/health' | grep 'OK'; do sleep 1; done

--- a/.github/workflows/browser-api-e2e-test.yml
+++ b/.github/workflows/browser-api-e2e-test.yml
@@ -117,22 +117,10 @@ jobs:
       - name: List the wheel contents
         run: unzip -l dist/*.whl
 
-      - name: Export uv.lock as constraints
-        # uvx resolves the wheel's dependencies fresh from PyPI and never reads uv.lock, so without
-        # this the wheel legs run a different dependency set than every other job — daytona 0.204.0
-        # and zendriver 0.15.5 rather than the locked 0.184.0 and 0.14.2.
-        run: uv export --format requirements-txt --no-hashes --no-dev --no-emit-project --extra daytona -o /tmp/constraints.txt
-
       - name: Execute the wheel
-        # The daytona backend needs the optional SDK (lazy-imported); add it for that variant only.
-        env:
-          UV_CONSTRAINT: /tmp/constraints.txt
-        run: |
-          if [ "${{ matrix.browser_backend }}" = daytona ]; then
-            uvx --with daytona ./dist/*.whl &
-          else
-            uvx ./dist/*.whl &
-          fi
+        # uvx resolves fresh from PyPI and never reads uv.lock — this leg deliberately tests what
+        # `uvx remotebrowser` gives a real user, so the version caps live in pyproject.toml.
+        run: uvx ./dist/*.whl &
 
       - name: Run the health check validation
         run: while ! curl -s 'http://localhost:23456/health' | grep 'OK'; do sleep 1; done

--- a/.github/workflows/browser-api-e2e-test.yml
+++ b/.github/workflows/browser-api-e2e-test.yml
@@ -118,10 +118,6 @@ jobs:
         run: unzip -l dist/*.whl
 
       - name: Execute the wheel
-        # uvx resolves fresh from PyPI and never reads uv.lock — this leg deliberately tests what
-        # `uvx remotebrowser` gives a real user, so the version caps live in pyproject.toml.
-        # The daytona SDK is an extra (lazy-imported), so request it via the wheel's own extra
-        # rather than `--with daytona`, which would resolve the SDK uncapped.
         run: |
           wheel=$(ls dist/*.whl)
           if [ "${{ matrix.browser_backend }}" = daytona ]; then

--- a/.github/workflows/extraction-test.yml
+++ b/.github/workflows/extraction-test.yml
@@ -121,10 +121,6 @@ jobs:
         run: unzip -l dist/*.whl
 
       - name: Execute the wheel
-        # uvx resolves fresh from PyPI and never reads uv.lock — this leg deliberately tests what
-        # `uvx remotebrowser` gives a real user, so the version caps live in pyproject.toml.
-        # The daytona SDK is an extra (lazy-imported), so request it via the wheel's own extra
-        # rather than `--with daytona`, which would resolve the SDK uncapped.
         run: |
           wheel=$(ls dist/*.whl)
           if [ "${{ matrix.browser_backend }}" = daytona ]; then

--- a/.github/workflows/extraction-test.yml
+++ b/.github/workflows/extraction-test.yml
@@ -120,22 +120,10 @@ jobs:
       - name: List the wheel contents
         run: unzip -l dist/*.whl
 
-      - name: Export uv.lock as constraints
-        # uvx resolves the wheel's dependencies fresh from PyPI and never reads uv.lock, so without
-        # this the wheel legs run a different dependency set than every other job — daytona 0.204.0
-        # and zendriver 0.15.5 rather than the locked 0.184.0 and 0.14.2.
-        run: uv export --format requirements-txt --no-hashes --no-dev --no-emit-project --extra daytona -o /tmp/constraints.txt
-
       - name: Execute the wheel
-        # The daytona backend needs the optional SDK (lazy-imported); add it for that variant only.
-        env:
-          UV_CONSTRAINT: /tmp/constraints.txt
-        run: |
-          if [ "${{ matrix.browser_backend }}" = daytona ]; then
-            uvx --with daytona ./dist/*.whl &
-          else
-            uvx ./dist/*.whl &
-          fi
+        # uvx resolves fresh from PyPI and never reads uv.lock — this leg deliberately tests what
+        # `uvx remotebrowser` gives a real user, so the version caps live in pyproject.toml.
+        run: uvx ./dist/*.whl &
 
       - name: Run the health check validation
         run: while ! curl -s 'http://localhost:23456/health' | grep 'OK'; do sleep 1; done

--- a/.github/workflows/extraction-test.yml
+++ b/.github/workflows/extraction-test.yml
@@ -123,7 +123,15 @@ jobs:
       - name: Execute the wheel
         # uvx resolves fresh from PyPI and never reads uv.lock — this leg deliberately tests what
         # `uvx remotebrowser` gives a real user, so the version caps live in pyproject.toml.
-        run: uvx ./dist/*.whl &
+        # The daytona SDK is an extra (lazy-imported), so request it via the wheel's own extra
+        # rather than `--with daytona`, which would resolve the SDK uncapped.
+        run: |
+          wheel=$(ls dist/*.whl)
+          if [ "${{ matrix.browser_backend }}" = daytona ]; then
+            uvx --from "remotebrowser[daytona] @ file://$PWD/$wheel" remotebrowser &
+          else
+            uvx "$wheel" &
+          fi
 
       - name: Run the health check validation
         run: while ! curl -s 'http://localhost:23456/health' | grep 'OK'; do sleep 1; done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # Daytona backend (BROWSER_BACKEND=daytona). Optional so podman-only installs stay unchanged.
-daytona = ["daytona>=0.183.0"]
+daytona = ["daytona>=0.183.0,<0.185"]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,18 +19,20 @@ dependencies = [
   "beautifulsoup4>=4.13.4",
   "fastmcp>=3.0.0,<4",
   "logfire[fastapi,httpx]>=4.13.2",
-  "zendriver>=0.14.2",
+  # Capped: zendriver 0.15.x and daytona 0.185+ break the browser API (CDP /json/version
+  # times out, GET /api/v1/browsers 500s). Lift once the code is ported to the newer SDKs.
+  "zendriver>=0.14.2,<0.15",
   "loguru>=0.7.3",
   "httpx-retries>=0.4.6",
   "websockets>=15.0.1",
   "async-lru>=2.0",
   "geoip2>=5.2.0",
-  "daytona>=0.183.0",
+  "daytona>=0.183.0,<0.185",
 ]
 
 [project.optional-dependencies]
 # Daytona backend (BROWSER_BACKEND=daytona). Optional so podman-only installs stay unchanged.
-daytona = ["daytona>=0.183.0"]
+daytona = ["daytona>=0.183.0,<0.185"]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,7 @@ dependencies = [
   "beautifulsoup4>=4.13.4",
   "fastmcp>=3.0.0,<4",
   "logfire[fastapi,httpx]>=4.13.2",
-  # Capped: zendriver 0.15.x and daytona 0.185+ break the browser API (CDP /json/version
-  # times out, GET /api/v1/browsers 500s). Lift once the code is ported to the newer SDKs.
-  "zendriver>=0.14.2,<0.15",
+  "zendriver>=0.14.2",
   "loguru>=0.7.3",
   "httpx-retries>=0.4.6",
   "websockets>=15.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
   "websockets>=15.0.1",
   "async-lru>=2.0",
   "geoip2>=5.2.0",
-  "daytona>=0.183.0,<0.185",
 ]
 
 [project.optional-dependencies]
@@ -36,6 +35,9 @@ daytona = ["daytona>=0.183.0,<0.185"]
 
 [dependency-groups]
 dev = [
+  # tests/test_daytona_browsers.py imports the backend module unguarded, and pyright strict checks
+  # it, so the SDK must be present for dev even though runtime imports it lazily.
+  "daytona>=0.183.0,<0.185",
   "assertpy>=1.1",
   "faker>=33.3.0",
   "nanoid>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,6 @@ daytona = ["daytona>=0.183.0,<0.185"]
 
 [dependency-groups]
 dev = [
-  # tests/test_daytona_browsers.py imports the backend module unguarded, and pyright strict checks
-  # it, so the SDK must be present for dev even though runtime imports it lazily.
-  "daytona>=0.183.0,<0.185",
   "assertpy>=1.1",
   "faker>=33.3.0",
   "nanoid>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # Daytona backend (BROWSER_BACKEND=daytona). Optional so podman-only installs stay unchanged.
-daytona = ["daytona>=0.183.0,<0.185"]
+daytona = ["daytona>=0.183.0"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -2489,7 +2489,7 @@ requires-dist = [
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.29.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.2" },
     { name = "websockets", specifier = ">=15.0.1" },
-    { name = "zendriver", specifier = ">=0.14.2,<0.15" },
+    { name = "zendriver", specifier = ">=0.14.2" },
 ]
 provides-extras = ["daytona"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2474,8 +2474,8 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "async-lru", specifier = ">=2.0" },
     { name = "beautifulsoup4", specifier = ">=4.13.4" },
-    { name = "daytona", specifier = ">=0.183.0" },
-    { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.183.0" },
+    { name = "daytona", specifier = ">=0.183.0,<0.185" },
+    { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.183.0,<0.185" },
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "fastmcp", specifier = ">=3.0.0,<4" },
     { name = "geoip2", specifier = ">=5.2.0" },
@@ -2491,7 +2491,7 @@ requires-dist = [
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.29.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.2" },
     { name = "websockets", specifier = ">=15.0.1" },
-    { name = "zendriver", specifier = ">=0.14.2" },
+    { name = "zendriver", specifier = ">=0.14.2,<0.15" },
 ]
 provides-extras = ["daytona"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2454,7 +2454,6 @@ daytona = [
 [package.dev-dependencies]
 dev = [
     { name = "assertpy" },
-    { name = "daytona" },
     { name = "faker" },
     { name = "nanoid" },
     { name = "pyinstaller" },
@@ -2497,7 +2496,6 @@ provides-extras = ["daytona"]
 [package.metadata.requires-dev]
 dev = [
     { name = "assertpy", specifier = ">=1.1" },
-    { name = "daytona", specifier = ">=0.183.0,<0.185" },
     { name = "faker", specifier = ">=33.3.0" },
     { name = "nanoid", specifier = ">=2.0.0" },
     { name = "pyinstaller", specifier = ">=6.19.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2428,7 +2428,6 @@ dependencies = [
     { name = "aiofiles" },
     { name = "async-lru" },
     { name = "beautifulsoup4" },
-    { name = "daytona" },
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "geoip2" },
@@ -2455,6 +2454,7 @@ daytona = [
 [package.dev-dependencies]
 dev = [
     { name = "assertpy" },
+    { name = "daytona" },
     { name = "faker" },
     { name = "nanoid" },
     { name = "pyinstaller" },
@@ -2474,7 +2474,6 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "async-lru", specifier = ">=2.0" },
     { name = "beautifulsoup4", specifier = ">=4.13.4" },
-    { name = "daytona", specifier = ">=0.183.0,<0.185" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.183.0,<0.185" },
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "fastmcp", specifier = ">=3.0.0,<4" },
@@ -2498,6 +2497,7 @@ provides-extras = ["daytona"]
 [package.metadata.requires-dev]
 dev = [
     { name = "assertpy", specifier = ">=1.1" },
+    { name = "daytona", specifier = ">=0.183.0,<0.185" },
     { name = "faker", specifier = ">=33.3.0" },
     { name = "nanoid", specifier = ">=2.0.0" },
     { name = "pyinstaller", specifier = ">=6.19.0" },


### PR DESCRIPTION
## Why

#1445 fixed the failing wheel legs by exporting `uv.lock` as a requirements file and handing it to `uvx` via `UV_CONSTRAINT`.

## The change

Move the pin into package metadata, where it protects the wheel wherever it's installed.

workaround:
- cap `daytona>=0.183.0,<0.185` in `pyproject.toml`
- remove the `Export uv.lock as constraints` step and `UV_CONSTRAINT` from both wheel legs