### PR TITLE
fix(cdp): treat 502 on devtools websocket as unreachable browser

### DIFF
--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -52,12 +52,19 @@ async def get_page_list(browser_id: str) -> list[str]:
     # own proxy and never reaches this path, so open_browser_cdp_client returns None there.
     try:
         client = await open_browser_cdp_client(browser_id)
-    except (BrowserNotFound, httpx.HTTPStatusError, httpx.TimeoutException) as e:
+    except (
+        BrowserNotFound,
+        httpx.HTTPStatusError,
+        httpx.TimeoutException,
+        websockets.exceptions.InvalidStatus,
+    ) as e:
         # A Daytona sandbox that is stopped or archived answers 400/404 on its signed
         # preview URL, and a deleted one raises BrowserNotFound (Browserbase answers 410
         # for an ended session). A sandbox that is up but unresponsive times out on the
-        # /json/version probe (httpx.TimeoutException). In every case the browser has no
-        # reachable pages, so skip it and let find_browser_id keep scanning the rest.
+        # /json/version probe (httpx.TimeoutException), or its CDP websocket gets rejected
+        # with a 502 from the fleet's front proxy (websockets.exceptions.InvalidStatus). In
+        # every case the browser has no reachable pages, so skip it and let find_browser_id
+        # keep scanning the rest.
         logger.info(f"[CDP] browser {browser_id} unreachable: {type(e).__name__}")
         return []
     if client is None:


### PR DESCRIPTION
## Summary
- `get_page_list` in `getgather/browsers/router.py` only caught `BrowserNotFound`, `httpx.HTTPStatusError`, `httpx.TimeoutException` around `open_browser_cdp_client`.
- Traced a prod error (trace `7e8fc033f5545d4a03d5e28194246b1f`) where a Daytona sandbox's CDP websocket got rejected with HTTP 502 by the fleet's front proxy, raising `websockets.exceptions.InvalidStatus` instead — this propagated up through `find_browser_id` and 500'd the `/devtools/{path}` proxy route instead of being treated as an unreachable browser and skipped, matching the sibling fix in #1450 for ReadTimeout.
- Added `websockets.exceptions.InvalidStatus` to the caught exception tuple.

## Test plan
- [x] `ruff check` passes
- [x] `pyright` passes on changed file