### PR TITLE
fix(ci): drive fly BROWSER_BACKEND build-arg from Doppler

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -65,8 +65,4 @@ jobs:
           doppler-project: remotebrowser
           doppler-config: ${{ matrix.config }}
           app-name: ${{ matrix.app_name }}
-          # Resolved from the app's Doppler config by the action, so the value that selects the
-          # backend at runtime is the same one that decides whether its SDK is installed into the
-          # image (see Dockerfile ARG BROWSER_BACKEND). Every config must define BROWSER_BACKEND
-          # or the deploy fails.
           build-args: BROWSER_BACKEND=$BROWSER_BACKEND

--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -3,10 +3,6 @@ name: Deploy to Fly.io
 on:
   push:
     branches: [main]
-  # TEMPORARY (revert before merge): exercise the BROWSER_BACKEND build-arg on remotebrowser-dev
-  # from this branch's PR. Gated on head_ref below so no other PR deploys anything.
-  pull_request:
-    branches: [main]
   workflow_dispatch:
     inputs:
       demo:
@@ -32,7 +28,6 @@ on:
 
 jobs:
   prepare-matrix:
-    if: github.event_name != 'pull_request' || github.head_ref == 'test/deploy-fly-backend-build-arg'
     runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.pm.outputs.matrix }}
@@ -45,14 +40,11 @@ jobs:
             { "env": "dev",         "config": "dev",         "app_name": "remotebrowser-dev" }
             { "env": "daytona",     "config": "daytona",     "app_name": "remotebrowser-daytona" }
             { "env": "browserbase", "config": "browserbase", "app_name": "remotebrowser-browserbase" }
-          # An empty selection list means "deploy everything", so the pull_request case must name
-          # dev explicitly — otherwise a PR would deploy demo and the rest too.
           selections: |
-            ${{ github.event_name == 'pull_request' && 'dev' || '' }}
-            ${{ github.event_name != 'pull_request' && inputs.demo        && 'demo'        || '' }}
-            ${{ github.event_name != 'pull_request' && inputs.dev         && 'dev'         || '' }}
-            ${{ github.event_name != 'pull_request' && inputs.daytona     && 'daytona'     || '' }}
-            ${{ github.event_name != 'pull_request' && inputs.browserbase && 'browserbase' || '' }}
+            ${{ inputs.demo        && 'demo'        || '' }}
+            ${{ inputs.dev         && 'dev'         || '' }}
+            ${{ inputs.daytona     && 'daytona'     || '' }}
+            ${{ inputs.browserbase && 'browserbase' || '' }}
           key-field: env
 
   deploy:
@@ -73,4 +65,8 @@ jobs:
           doppler-project: remotebrowser
           doppler-config: ${{ matrix.config }}
           app-name: ${{ matrix.app_name }}
+          # Resolved from the app's Doppler config by the action, so the value that selects the
+          # backend at runtime is the same one that decides whether its SDK is installed into the
+          # image (see Dockerfile ARG BROWSER_BACKEND). Every config must define BROWSER_BACKEND
+          # or the deploy fails.
           build-args: BROWSER_BACKEND=$BROWSER_BACKEND

--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -3,6 +3,10 @@ name: Deploy to Fly.io
 on:
   push:
     branches: [main]
+  # TEMPORARY (revert before merge): exercise the BROWSER_BACKEND build-arg on remotebrowser-dev
+  # from this branch's PR. Gated on head_ref below so no other PR deploys anything.
+  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       demo:
@@ -28,6 +32,7 @@ on:
 
 jobs:
   prepare-matrix:
+    if: github.event_name != 'pull_request' || github.head_ref == 'test/deploy-fly-backend-build-arg'
     runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.pm.outputs.matrix }}
@@ -40,11 +45,14 @@ jobs:
             { "env": "dev",         "config": "dev",         "app_name": "remotebrowser-dev" }
             { "env": "daytona",     "config": "daytona",     "app_name": "remotebrowser-daytona" }
             { "env": "browserbase", "config": "browserbase", "app_name": "remotebrowser-browserbase" }
+          # An empty selection list means "deploy everything", so the pull_request case must name
+          # dev explicitly — otherwise a PR would deploy demo and the rest too.
           selections: |
-            ${{ inputs.demo        && 'demo'        || '' }}
-            ${{ inputs.dev         && 'dev'         || '' }}
-            ${{ inputs.daytona     && 'daytona'     || '' }}
-            ${{ inputs.browserbase && 'browserbase' || '' }}
+            ${{ github.event_name == 'pull_request' && 'dev' || '' }}
+            ${{ github.event_name != 'pull_request' && inputs.demo        && 'demo'        || '' }}
+            ${{ github.event_name != 'pull_request' && inputs.dev         && 'dev'         || '' }}
+            ${{ github.event_name != 'pull_request' && inputs.daytona     && 'daytona'     || '' }}
+            ${{ github.event_name != 'pull_request' && inputs.browserbase && 'browserbase' || '' }}
           key-field: env
 
   deploy:
@@ -65,4 +73,4 @@ jobs:
           doppler-project: remotebrowser
           doppler-config: ${{ matrix.config }}
           app-name: ${{ matrix.app_name }}
-          build-args: ${{ matrix.env == 'daytona' && 'BROWSER_BACKEND=daytona' || '' }}
+          build-args: BROWSER_BACKEND=$BROWSER_BACKEND


### PR DESCRIPTION
## Problem

`remotebrowser-dev` has been crash-looping since #1454 made the Daytona SDK an optional extra:

```
File "/app/getgather/browsers/daytona_browsers.py", line 5, in <module>
    from daytona import (
ModuleNotFoundError: No module named 'daytona'
... machine has reached its max restart count of 10
```

The problem is that the secret is *runtime* config, while `ARG BROWSER_BACKEND` in the Dockerfile is a *build-time* value that decides whether `uv sync --extra daytona` runs. The workflow only passed that build arg when `matrix.env == 'daytona'` — which matched the `remotebrowser-daytona` entry but not `dev`, even though both run the daytona backend. So `dev` got the lean image.


## Verification

<img width="992" height="532" alt="image" src="https://github.com/user-attachments/assets/8ab9ebf7-2216-4218-82f7-086c896bc988" />

<img width="518" height="56" alt="image" src="https://github.com/user-attachments/assets/7ddeb487-16a6-4e63-b886-3dfd059f88ba" />
