### PR TITLE
feat(browser): race providers behind neutral CDP proxy

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -14,7 +14,7 @@ BROWSER_BACKEND=podman
 BROWSER_BEST_OF_N=
 
 # Experimental: race all configured remote providers on POST /api/v1/browsers and return a
-# provider-neutral CDP proxy URL. The winner route is process-local and is lost on restart.
+# provider-neutral CDP proxy URL. The second ID character records the winning provider.
 BROWSER_PROVIDER_RACE=false
 
 # Podman backend

--- a/.env.template
+++ b/.env.template
@@ -13,6 +13,10 @@ BROWSER_BACKEND=podman
 # Only affects POST /api/v1/browsers.
 BROWSER_BEST_OF_N=
 
+# Experimental: race all configured remote providers on POST /api/v1/browsers and return a
+# provider-neutral CDP proxy URL. The winner route is process-local and is lost on restart.
+BROWSER_PROVIDER_RACE=false
+
 # Podman backend
 CONTAINER_IMAGE=ghcr.io/remotebrowser/chrome-live
 CONTAINER_HOST=

--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -215,7 +215,7 @@ async def get_remote_browser(browser_id: str) -> zd.Browser | None:
         return None
 
     cdp_websocket_url = _setup_cdp_url(browser_id)
-    logger.debug(f"Connecting to ChromeFleet CDP at {cdp_websocket_url}")
+    logger.debug(f"Connecting to ChromeFleet CDP for browser {browser_id}")
     browser = await _create_browser_from_cdp_websocket(
         browser_id=browser_id, websocket_url=cdp_websocket_url
     )
@@ -234,7 +234,7 @@ async def create_remote_browser(
         browser_id = generate(FRIENDLY_CHARS, 6)
     logger.info(f"Connecting to ChromeFleet browser: {browser_id}")
     cdp_websocket_url = _setup_cdp_url(browser_id)
-    logger.debug(f"Connecting to ChromeFleet CDP at {cdp_websocket_url}")
+    logger.debug(f"Connecting to ChromeFleet CDP for browser {browser_id}")
     browser = await _create_browser_from_cdp_websocket(
         browser_id=browser_id, websocket_url=cdp_websocket_url, target_domain=target_domain
     )

--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Awaitable, Callable
 from typing import Any, Literal, Protocol, cast, runtime_checkable
 
 import httpx
@@ -15,6 +16,11 @@ BROWSER_NAME_PREFIX = "chromium-"
 # Which browsers a listing should include. `all` is the full inventory, including ones a
 # backend can resume on demand; `live` is only those able to serve CDP right now.
 BROWSER_SCOPE = Literal["all", "live"]
+
+CDP_READY_ATTEMPTS = 30
+CDP_READY_RETRY_SECONDS = 1.0
+CDP_OPEN_TIMEOUT_SECONDS = 10.0
+CDP_COMMAND_TIMEOUT_SECONDS = 10.0
 
 
 def rewrite_ws_url(ws_url: str, cdp_base_url: str) -> str:
@@ -66,6 +72,44 @@ async def get_page_websocket_debugger_url(cdp_base_url: str, page_id: str) -> st
                 ws_url = item.get("webSocketDebuggerUrl")
                 return rewrite_ws_url(str(ws_url), cdp_base_url) if ws_url else None
         return None
+
+
+async def wait_for_cdp_ready(
+    browser_id: str,
+    resolve_remote_url: Callable[[], Awaitable[str | None]],
+) -> None:
+    """Wait until a backend's browser socket accepts a real CDP command.
+
+    Backends own URL resolution and expose this helper through their `wait_until_cdp_ready`
+    implementation. Keeping retries here avoids duplicating transport mechanics while leaving
+    provider-specific readiness decisions out of the provider-race coordinator.
+    """
+    # Imported lazily because cdp_client imports browser.py, which in turn imports backend modules.
+    from getgather.cdp_client import open_cdp_url
+
+    last_error_name = "UnknownError"
+    for attempt in range(1, CDP_READY_ATTEMPTS + 1):
+        try:
+            remote_url = await resolve_remote_url()
+            if remote_url is None:
+                raise RuntimeError("CDP URL is not available")
+            client = await open_cdp_url(remote_url, timeout=CDP_OPEN_TIMEOUT_SECONDS)
+            try:
+                await asyncio.wait_for(
+                    client.send("Target.getTargets"), timeout=CDP_COMMAND_TIMEOUT_SECONDS
+                )
+                return
+            finally:
+                await client.aclose()
+        except Exception as e:
+            last_error_name = type(e).__name__
+            logger.debug(
+                f"[CDP] Readiness probe {attempt}/{CDP_READY_ATTEMPTS} for {browser_id} "
+                f"failed: {last_error_name}"
+            )
+        if attempt < CDP_READY_ATTEMPTS:
+            await asyncio.sleep(CDP_READY_RETRY_SECONDS)
+    raise RuntimeError(f"Browser {browser_id} did not become CDP-ready: {last_error_name}")
 
 
 def new_browser_id() -> str:
@@ -244,6 +288,14 @@ class Backend(Protocol):
         derived (per-session connectUrl for Browserbase, the external fleet's /cdp relay for
         Fleet, the per-browser /json/version discovery for Podman/Daytona). Returns None when
         the URL can't (yet) be resolved."""
+
+    async def wait_until_cdp_ready(self, browser_id: str) -> None:
+        """Return only after the browser accepts a real CDP command.
+
+        Each backend owns this decision because its create and connection semantics differ.
+        Provider racing relies on this method instead of knowing how a provider exposes CDP.
+        """
+        ...
 
     def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
         """Whether `websocket_proxy` should rewrite target ids to namespace them by `browser_id`

--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -245,7 +245,7 @@ class Backend(Protocol):
         Fleet, the per-browser /json/version discovery for Podman/Daytona). Returns None when
         the URL can't (yet) be resolved."""
 
-    def cdp_targets_need_namespacing(self) -> bool:
+    def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
         """Whether `websocket_proxy` should rewrite target ids to namespace them by `browser_id`
         when relaying to this backend's URL. True for backends that hand back a single browser's
         raw CDP socket (Podman / Daytona); False for the Fleet relay, whose /cdp proxy already
@@ -275,6 +275,15 @@ class Backend(Protocol):
 
 
 def create_backend() -> Backend:
+    backend = _create_single_backend()
+    if settings.BROWSER_PROVIDER_RACE:
+        from getgather.browsers.provider_race import create_provider_race_backend
+
+        return create_provider_race_backend(backend)
+    return backend
+
+
+def _create_single_backend() -> Backend:
     if settings.CHROMEFLEET_URL:
         from getgather.browsers.fleet_browsers import FleetBackend
 

--- a/getgather/browsers/browserbase_browsers.py
+++ b/getgather/browsers/browserbase_browsers.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import os
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import websockets
@@ -170,8 +170,9 @@ class BrowserbaseBackend:
 
     Only `create_browser` is implemented: it POSTs to the Browserbase `/v1/sessions`
     endpoint with the `x-bb-api-key` header (read from the `BROWSERBASE_API_KEY` env var)
-    and stores the returned `id -> connectUrl` mapping in an in-memory hashmap so the
-    CDP proxy in `router.py` can later route `/cdp/<id>` traffic to the right connectUrl.
+    and stores the returned `id -> connectUrl` mapping locally. It also tags sessions with the
+    routed GetGather browser ID, allowing another process to recover the assigned ID and
+    connectUrl from Browserbase after a restart or replica hop.
 
     The Browserbase-assigned session `id` is returned as the `browser_id`, ignoring the
     caller-supplied id (Browserbase creates its own). The router's `POST /api/v1/browsers`
@@ -183,6 +184,7 @@ class BrowserbaseBackend:
     def __init__(self) -> None:
         # browser_id -> connectUrl (wss://connect.usw2.browserbase.com/?signingKey=...)
         self._sessions: dict[str, str] = {}
+        self._logical_sessions: dict[str, str] = {}
 
     async def shutdown(self) -> None:
         return None
@@ -203,7 +205,10 @@ class BrowserbaseBackend:
         # keepAlive keeps the session running between CDP connections / after disconnects.
         # Without it, Browserbase ends the session the moment the first WS drops, and any
         # subsequent connect to the same signingKey returns HTTP 410 Gone.
-        body: dict[str, Any] = {"keepAlive": True}
+        body: dict[str, Any] = {
+            "keepAlive": True,
+            "userMetadata": {"getgatherBrowserId": browser_id},
+        }
         proxy_config = await get_proxy_config(origin_ip, target_domain, settings)
         if proxy_config:
             proxy_url = proxy_config.get_proxy_url(browser_id)
@@ -219,6 +224,7 @@ class BrowserbaseBackend:
         bb_id = str(data["id"])
         connect_url = str(data["connectUrl"])
         self._sessions[bb_id] = connect_url
+        self._logical_sessions[browser_id] = bb_id
         # connectUrl embeds a signing key and is a bearer secret; never log it.
         logger.info(f"Browserbase session created: id={bb_id}")
         await self._wait_until_cdp_ready(connect_url, bb_id)
@@ -317,6 +323,77 @@ class BrowserbaseBackend:
         # discovery step. None for an unknown / already-released session.
         return self._sessions.get(browser_id)
 
+    async def resolve_session(self, logical_browser_id: str) -> str | None:
+        """Recover a Browserbase session after a GetGather restart or replica hop."""
+        cached_id = self._logical_sessions.get(logical_browser_id)
+        if cached_id is not None and cached_id in self._sessions:
+            return cached_id
+
+        headers = {"x-bb-api-key": _api_key()}
+        query = f"user_metadata['getgatherBrowserId']:'{logical_browser_id}'"
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.get(BROWSERBASE_API_URL, headers=headers, params={"q": query})
+            response.raise_for_status()
+            raw_sessions: Any = response.json()
+            if not isinstance(raw_sessions, list):
+                return None
+            candidates: list[dict[str, Any]] = []
+            for raw_session in raw_sessions:  # pyright: ignore[reportUnknownVariableType]
+                if not isinstance(raw_session, dict):
+                    continue
+                session = cast(dict[str, Any], raw_session)
+                if session.get("status") in {"PENDING", "RUNNING"}:
+                    candidates.append(session)
+            if not candidates:
+                return None
+            candidate = max(candidates, key=lambda item: str(item.get("updatedAt", "")))
+            session_id: Any = candidate.get("id")
+            if not isinstance(session_id, str):
+                return None
+            detail = await client.get(f"{BROWSERBASE_API_URL}/{session_id}", headers=headers)
+            detail.raise_for_status()
+            raw_data: Any = detail.json()
+            if not isinstance(raw_data, dict):
+                return None
+            data = cast(dict[str, Any], raw_data)
+            connect_url: Any = data.get("connectUrl")
+            if not isinstance(connect_url, str):
+                return None
+
+        self._sessions[session_id] = connect_url
+        self._logical_sessions[logical_browser_id] = session_id
+        return session_id
+
+    async def list_routed_sessions(self) -> dict[str, str]:
+        """Return active routed IDs and their Browserbase-assigned session IDs."""
+        from getgather.browsers.route_id import parse_routed_browser_id
+
+        headers = {"x-bb-api-key": _api_key()}
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.get(BROWSERBASE_API_URL, headers=headers)
+            response.raise_for_status()
+            raw_sessions: Any = response.json()
+        if not isinstance(raw_sessions, list):
+            return {}
+
+        routes: dict[str, str] = {}
+        for raw_session in raw_sessions:  # pyright: ignore[reportUnknownVariableType]
+            if not isinstance(raw_session, dict):
+                continue
+            session = cast(dict[str, Any], raw_session)
+            if session.get("status") not in {"PENDING", "RUNNING"}:
+                continue
+            metadata = session.get("userMetadata")
+            session_id = session.get("id")
+            if not isinstance(metadata, dict) or not isinstance(session_id, str):
+                continue
+            typed_metadata = cast(dict[str, Any], metadata)
+            routed_id: Any = typed_metadata.get("getgatherBrowserId")
+            if isinstance(routed_id, str) and parse_routed_browser_id(routed_id) is not None:
+                routes[routed_id] = session_id
+                self._logical_sessions[routed_id] = session_id
+        return routes
+
     def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
         # The connectUrl is a single browser's socket; the router namespaces its target ids by
         # browser_id so the devtools route can route /devtools/{browser_id@page_id} back here.
@@ -357,6 +434,9 @@ class BrowserbaseBackend:
         # clear the local id -> connectUrl mapping, regardless of whether the upstream call
         # succeeds (a 404 means the session is already gone, which is the desired state).
         self._sessions.pop(browser_id, None)
+        for logical_id, session_id in list(self._logical_sessions.items()):
+            if session_id == browser_id:
+                self._logical_sessions.pop(logical_id, None)
         try:
             headers = {"Content-Type": "application/json", "x-bb-api-key": _api_key()}
             body = {"status": "REQUEST_RELEASE"}

--- a/getgather/browsers/browserbase_browsers.py
+++ b/getgather/browsers/browserbase_browsers.py
@@ -323,6 +323,12 @@ class BrowserbaseBackend:
         # discovery step. None for an unknown / already-released session.
         return self._sessions.get(browser_id)
 
+    async def wait_until_cdp_ready(self, browser_id: str) -> None:
+        # create_browser already probes Target.getTargets before returning. Unlike the other
+        # providers, repeating that probe here would open a redundant Browserbase connection.
+        if browser_id not in self._sessions:
+            raise BrowserNotFound(browser_id)
+
     async def resolve_session(self, logical_browser_id: str) -> str | None:
         """Recover a Browserbase session after a GetGather restart or replica hop."""
         cached_id = self._logical_sessions.get(logical_browser_id)

--- a/getgather/browsers/browserbase_browsers.py
+++ b/getgather/browsers/browserbase_browsers.py
@@ -108,7 +108,7 @@ async def websocket_proxy_attached(
                 except (WebSocketDisconnect, RuntimeError):
                     logger.info("[CDP] Client disconnected")
                 except Exception as e:
-                    logger.error(f"[CDP] client_to_remote error: {type(e).__name__}: {e}")
+                    logger.error(f"[CDP] client_to_remote error: {type(e).__name__}")
 
             async def remote_to_client() -> None:
                 try:
@@ -136,7 +136,7 @@ async def websocket_proxy_attached(
                 except ConnectionClosed as e:
                     logger.info(f"[CDP] Remote disconnected: code={e.code} reason={e.reason}")
                 except Exception as e:
-                    logger.error(f"[CDP] remote_to_client error: {type(e).__name__}: {e}")
+                    logger.error(f"[CDP] remote_to_client error: {type(e).__name__}")
 
             tasks = [
                 asyncio.create_task(client_to_remote()),
@@ -150,12 +150,12 @@ async def websocket_proxy_attached(
                 except (asyncio.CancelledError, Exception):
                     pass
             return
-    except OSError as e:
-        logger.warning(f"[CDP] Attach to {target_id} failed (OSError): {e}")
+    except OSError:
+        logger.warning(f"[CDP] Attach to {target_id} failed (OSError)")
     except InvalidStatus as e:
         logger.warning(f"[CDP] Attach to {target_id} rejected with HTTP {e.response.status_code}")
     except Exception as e:
-        logger.warning(f"[CDP] Attach to {target_id} failed ({type(e).__name__}): {e}")
+        logger.warning(f"[CDP] Attach to {target_id} failed ({type(e).__name__})")
 
     if client_ws.client_state == WebSocketState.CONNECTED:
         await client_ws.close(code=4502, reason="Remote server unreachable")
@@ -219,7 +219,8 @@ class BrowserbaseBackend:
         bb_id = str(data["id"])
         connect_url = str(data["connectUrl"])
         self._sessions[bb_id] = connect_url
-        logger.info(f"Browserbase session created: id={bb_id} connectUrl={connect_url}")
+        # connectUrl embeds a signing key and is a bearer secret; never log it.
+        logger.info(f"Browserbase session created: id={bb_id}")
         await self._wait_until_cdp_ready(connect_url, bb_id)
         return {"browser_id": bb_id, "status": "created", "ip": None}
 
@@ -279,8 +280,7 @@ class BrowserbaseBackend:
             except OSError as e:
                 last_exc = e
                 logger.warning(
-                    f"[CDP] Readiness probe {attempt}/{attempts} for {browser_id} "
-                    f"failed (OSError): {e}"
+                    f"[CDP] Readiness probe {attempt}/{attempts} for {browser_id} failed (OSError)"
                 )
             except InvalidStatus as e:
                 last_exc = e
@@ -292,13 +292,14 @@ class BrowserbaseBackend:
                 last_exc = e
                 logger.warning(
                     f"[CDP] Readiness probe {attempt}/{attempts} for {browser_id} "
-                    f"failed ({type(e).__name__}): {e}"
+                    f"failed ({type(e).__name__})"
                 )
 
             if attempt < attempts:
                 await asyncio.sleep(delay)
 
-        logger.error(f"[CDP] Browser {browser_id} not ready after {attempts} probes: {last_exc}")
+        error_name = type(last_exc).__name__ if last_exc is not None else "UnknownError"
+        logger.error(f"[CDP] Browser {browser_id} not ready after {attempts} probes: {error_name}")
         # Don't hand back a dead id — release the upstream session and surface the failure.
         try:
             await self.delete_browser(browser_id)

--- a/getgather/browsers/browserbase_browsers.py
+++ b/getgather/browsers/browserbase_browsers.py
@@ -316,9 +316,10 @@ class BrowserbaseBackend:
         # discovery step. None for an unknown / already-released session.
         return self._sessions.get(browser_id)
 
-    def cdp_targets_need_namespacing(self) -> bool:
+    def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
         # The connectUrl is a single browser's socket; the router namespaces its target ids by
         # browser_id so the devtools route can route /devtools/{browser_id@page_id} back here.
+        del browser_id
         return True
 
     async def get_devtools_websocket_remote_url(

--- a/getgather/browsers/browserbase_browsers.py
+++ b/getgather/browsers/browserbase_browsers.py
@@ -369,7 +369,7 @@ class BrowserbaseBackend:
                     response.raise_for_status()
             logger.info(f"Browserbase session released: id={browser_id}")
         except Exception as e:
-            logger.warning(f"Browserbase release failed for {browser_id}: {type(e).__name__}: {e}")
+            logger.warning(f"Browserbase release failed for {browser_id}: error={type(e).__name__}")
         return {"browser_id": browser_id, "status": "deleted"}
 
     async def browser_exists(self, browser_id: str) -> bool:
@@ -406,7 +406,10 @@ class BrowserbaseBackend:
                 )
                 response.raise_for_status()
             except httpx.HTTPError as e:
-                logger.warning(f"Browserbase live view lookup failed for {browser_id}: {e}")
+                logger.warning(
+                    f"Browserbase live view lookup failed for {browser_id}: "
+                    f"error={type(e).__name__}"
+                )
                 return None
         data: dict[str, Any] = response.json()
         url: Any = data.get("debuggerFullscreenUrl")  # pyright: ignore[reportUnknownMemberType]

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -273,9 +273,10 @@ class DaytonaBackend:
         cdp_base_url = await self.get_cdp_base_url(browser_id)
         return await get_browser_websocket_debugger_url(cdp_base_url)
 
-    def cdp_targets_need_namespacing(self) -> bool:
+    def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
         # The per-sandbox socket reports raw target ids; the router namespaces them by browser_id
         # so the devtools route can route /devtools/{browser_id@page_id} back to this sandbox.
+        del browser_id
         return True
 
     async def get_devtools_websocket_remote_url(

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -23,6 +23,7 @@ from getgather.browsers.backend import (
     ProxyVerificationError,
     get_browser_websocket_debugger_url,
     get_page_websocket_debugger_url,
+    wait_for_cdp_ready,
 )
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
@@ -272,6 +273,10 @@ class DaytonaBackend:
         # retries 10x before giving up.
         cdp_base_url = await self.get_cdp_base_url(browser_id)
         return await get_browser_websocket_debugger_url(cdp_base_url)
+
+    async def wait_until_cdp_ready(self, browser_id: str) -> None:
+        # Daytona create can finish while Chrome and its signed preview route are still starting.
+        await wait_for_cdp_ready(browser_id, lambda: self.get_cdp_websocket_remote_url(browser_id))
 
     def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
         # The per-sandbox socket reports raw target ids; the router namespaces them by browser_id

--- a/getgather/browsers/fleet_browsers.py
+++ b/getgather/browsers/fleet_browsers.py
@@ -111,6 +111,8 @@ class FleetBackend:
         browser_type: str | None,
     ) -> dict[str, Any]:
         headers = {"x-origin-ip": origin_ip} if origin_ip else {}
+        if target_domain:
+            headers["x-target-domains"] = target_domain
         if browser_type:
             headers["x-browser-type"] = browser_type
         response = _require(await call_chromefleet_api("POST", browser_id, headers=headers))
@@ -166,9 +168,10 @@ class FleetBackend:
         # from CHROMEFLEET_URL + browser_id, so this never returns None — no retry needed.
         return f"{self.cdp_websocket_base()}/cdp/{browser_id}"
 
-    def cdp_targets_need_namespacing(self) -> bool:
+    def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
         # The external fleet's /cdp proxy already namespaces target ids by browser_id; the
         # router patching here would double-prefix them, so opt out.
+        del browser_id
         return False
 
     async def get_devtools_websocket_remote_url(

--- a/getgather/browsers/fleet_browsers.py
+++ b/getgather/browsers/fleet_browsers.py
@@ -5,7 +5,7 @@ from fastapi import WebSocket
 from fastmcp.server.dependencies import get_http_headers
 from httpx_retries import Retry, RetryTransport
 
-from getgather.browsers.backend import BROWSER_SCOPE, BrowserNotFound
+from getgather.browsers.backend import BROWSER_SCOPE, BrowserNotFound, wait_for_cdp_ready
 from getgather.client_ip import client_ip_var
 from getgather.config import settings
 
@@ -167,6 +167,11 @@ class FleetBackend:
         # ids; the router does not patch again (see cdp_targets_need_namespacing). Deterministic
         # from CHROMEFLEET_URL + browser_id, so this never returns None — no retry needed.
         return f"{self.cdp_websocket_base()}/cdp/{browser_id}"
+
+    async def wait_until_cdp_ready(self, browser_id: str) -> None:
+        # Fleet exposes a shared relay URL, so readiness must be proven through that relay rather
+        # than inferred from the upstream REST create response.
+        await wait_for_cdp_ready(browser_id, lambda: self.get_cdp_websocket_remote_url(browser_id))
 
     def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
         # The external fleet's /cdp proxy already namespaces target ids by browser_id; the

--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -437,9 +437,10 @@ class PodmanBackend:
         cdp_base_url = await self.get_cdp_base_url(browser_id)
         return await get_browser_websocket_debugger_url(cdp_base_url)
 
-    def cdp_targets_need_namespacing(self) -> bool:
+    def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
         # The per-browser socket reports raw target ids; the router namespaces them by browser_id
         # so the devtools route can route /devtools/{browser_id@page_id} back to this browser.
+        del browser_id
         return True
 
     async def get_devtools_websocket_remote_url(

--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -16,6 +16,7 @@ from getgather.browsers.backend import (
     ProxyVerificationError,
     get_browser_websocket_debugger_url,
     get_page_websocket_debugger_url,
+    wait_for_cdp_ready,
 )
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
@@ -436,6 +437,10 @@ class PodmanBackend:
         # missed boot race (chrome not ready yet) — the router retries 10x before giving up.
         cdp_base_url = await self.get_cdp_base_url(browser_id)
         return await get_browser_websocket_debugger_url(cdp_base_url)
+
+    async def wait_until_cdp_ready(self, browser_id: str) -> None:
+        # Container launch does not imply that Chrome's debugging socket is accepting commands.
+        await wait_for_cdp_ready(browser_id, lambda: self.get_cdp_websocket_remote_url(browser_id))
 
     def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
         # The per-browser socket reports raw target ids; the router namespaces them by browser_id

--- a/getgather/browsers/provider_race.py
+++ b/getgather/browsers/provider_race.py
@@ -192,9 +192,17 @@ class ProviderRaceBackend:
         target_domain: str | None,
         browser_type: str | None,
     ) -> dict[str, Any]:
-        return await self._fallback.create_browser(
-            browser_id, origin_ip, target_domain, browser_type
+        provider_backend, provider_browser_id = self._route(browser_id)
+        # Preserve a raced browser's provider affinity when /cdp auto-starts it after deletion.
+        # Browserbase may assign a fresh provider id, so refresh the internal route from the result.
+        result = await provider_backend.create_browser(
+            provider_browser_id, origin_ip, target_domain, browser_type
         )
+        route = self._routes.get(browser_id)
+        result_browser_id = result.get("browser_id")
+        if route is not None and isinstance(result_browser_id, str):
+            self._routes[browser_id] = _WinnerRoute(provider_backend, result_browser_id)
+        return result
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
@@ -206,13 +214,19 @@ class ProviderRaceBackend:
     async def delete_browser(self, browser_id: str) -> dict[str, Any]:
         provider_backend, provider_browser_id = self._route(browser_id)
         await provider_backend.delete_browser(provider_browser_id)
-        self._routes.pop(browser_id, None)
+        # Keep the route as a tombstone. Falling through to the default backend after deletion can
+        # turn a subsequent GET into an upstream 500 or auto-start the id on a different provider.
         return {"browser_id": browser_id, "status": "deleted"}
 
     async def list_browser_ids(self, scope: BROWSER_SCOPE = "all") -> list[str]:
         fallback_ids = await self._fallback.list_browser_ids(scope)
         hidden_ids = {route.provider_browser_id for route in self._routes.values()}
-        return sorted((set(fallback_ids) - hidden_ids) | set(self._routes))
+        active_routes = {
+            browser_id
+            for browser_id, route in self._routes.items()
+            if await route.backend.browser_exists(route.provider_browser_id)
+        }
+        return sorted((set(fallback_ids) - hidden_ids) | active_routes)
 
     async def browser_exists(self, browser_id: str) -> bool:
         provider_backend, provider_browser_id = self._route(browser_id)

--- a/getgather/browsers/provider_race.py
+++ b/getgather/browsers/provider_race.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -26,6 +27,8 @@ class _Candidate:
     provider: str
     backend: Backend
     provider_browser_id: str
+    create_seconds: float
+    cdp_ready_seconds: float
 
 
 class ProviderRaceBackend:
@@ -57,6 +60,8 @@ class ProviderRaceBackend:
         browser_type: str | None,
     ) -> None:
         """Create one candidate per provider and register the first CDP-ready winner."""
+        race_started = time.monotonic()
+        logger.info(f"Provider race started for {browser_id}: candidates={len(self._providers)}")
         tasks = {
             provider: asyncio.create_task(
                 self._create_ready_candidate(
@@ -75,8 +80,8 @@ class ProviderRaceBackend:
         for completed in asyncio.as_completed(tasks.values()):
             try:
                 winner = await completed
-            except Exception as e:
-                logger.warning(f"Provider-race candidate failed: {type(e).__name__}: {e}")
+            except Exception:
+                # The candidate logs its provider, phase, duration, and error type before raising.
                 continue
             break
 
@@ -87,7 +92,12 @@ class ProviderRaceBackend:
             backend=winner.backend,
             provider_browser_id=winner.provider_browser_id,
         )
-        logger.info(f"Provider-race winner for {browser_id}: {winner.provider}")
+        logger.info(
+            f"Provider-race winner for {browser_id}: provider={winner.provider} "
+            f"create_ms={winner.create_seconds * 1000:.0f} "
+            f"cdp_ready_ms={winner.cdp_ready_seconds * 1000:.0f} "
+            f"race_ms={(time.monotonic() - race_started) * 1000:.0f}"
+        )
 
         cleanup_task = asyncio.create_task(
             self._cleanup_race_losers(tasks, winner_provider=winner.provider)
@@ -105,16 +115,40 @@ class ProviderRaceBackend:
         browser_type: str | None,
     ) -> _Candidate:
         provider_browser_id = public_browser_id
+        candidate_started = time.monotonic()
+        phase = "create"
         try:
             result = await provider_backend.create_browser(
                 public_browser_id, origin_ip, target_domain, browser_type
             )
+            created_at = time.monotonic()
             result_browser_id = result.get("browser_id")
             if isinstance(result_browser_id, str):
                 provider_browser_id = result_browser_id
+            phase = "cdp_ready"
             await self._wait_until_cdp_ready(provider_backend, provider_browser_id)
-            return _Candidate(provider, provider_backend, provider_browser_id)
-        except Exception:
+            ready_at = time.monotonic()
+            create_seconds = created_at - candidate_started
+            cdp_ready_seconds = ready_at - created_at
+            logger.info(
+                f"Provider-race candidate ready for {public_browser_id}: provider={provider} "
+                f"create_ms={create_seconds * 1000:.0f} "
+                f"cdp_ready_ms={cdp_ready_seconds * 1000:.0f} "
+                f"total_ms={(ready_at - candidate_started) * 1000:.0f}"
+            )
+            return _Candidate(
+                provider,
+                provider_backend,
+                provider_browser_id,
+                create_seconds,
+                cdp_ready_seconds,
+            )
+        except Exception as e:
+            logger.warning(
+                f"Provider-race candidate failed for {public_browser_id}: provider={provider} "
+                f"phase={phase} elapsed_ms={(time.monotonic() - candidate_started) * 1000:.0f} "
+                f"error={type(e).__name__}"
+            )
             await self._delete_quietly(provider, provider_backend, provider_browser_id)
             raise
 
@@ -134,8 +168,8 @@ class ProviderRaceBackend:
             except Exception as e:
                 last_error = e
                 logger.debug(
-                    f"Provider-race CDP probe {attempt}/{CDP_READY_ATTEMPTS} "
-                    f"for {browser_id} failed: {type(e).__name__}: {e}"
+                    f"Provider-race CDP probe {attempt}/{CDP_READY_ATTEMPTS} failed: "
+                    f"{type(e).__name__}"
                 )
             finally:
                 if client is not None:
@@ -162,11 +196,19 @@ class ProviderRaceBackend:
     async def _delete_quietly(
         self, provider: str, provider_backend: Backend, provider_browser_id: str
     ) -> None:
+        cleanup_started = time.monotonic()
         try:
             await provider_backend.delete_browser(provider_browser_id)
-            logger.info(f"Provider-race candidate cleaned up: {provider}")
+            logger.info(
+                f"Provider-race candidate cleaned up: provider={provider} "
+                f"cleanup_ms={(time.monotonic() - cleanup_started) * 1000:.0f}"
+            )
         except Exception as e:
-            logger.warning(f"Provider-race cleanup failed for {provider}: {type(e).__name__}: {e}")
+            logger.warning(
+                f"Provider-race cleanup failed: provider={provider} "
+                f"cleanup_ms={(time.monotonic() - cleanup_started) * 1000:.0f} "
+                f"error={type(e).__name__}"
+            )
 
     def _route(self, browser_id: str) -> tuple[Backend, str]:
         route = self._routes.get(browser_id)

--- a/getgather/browsers/provider_race.py
+++ b/getgather/browsers/provider_race.py
@@ -7,6 +7,11 @@ from fastapi import WebSocket
 from loguru import logger
 
 from getgather.browsers.backend import BROWSER_SCOPE, Backend
+from getgather.browsers.route_id import (
+    BrowserRoute,
+    make_routed_browser_id,
+    parse_routed_browser_id,
+)
 from getgather.cdp_client import open_cdp_url
 from getgather.config import settings
 
@@ -14,12 +19,6 @@ CDP_READY_ATTEMPTS = 30
 CDP_READY_RETRY_SECONDS = 1.0
 CDP_OPEN_TIMEOUT_SECONDS = 10.0
 CDP_COMMAND_TIMEOUT_SECONDS = 10.0
-
-
-@dataclass(frozen=True)
-class _WinnerRoute:
-    backend: Backend
-    provider_browser_id: str
 
 
 @dataclass(frozen=True)
@@ -32,19 +31,22 @@ class _Candidate:
 
 
 class ProviderRaceBackend:
-    """Race configured browser providers and proxy the winner behind an opaque public id.
+    """Race configured browser providers and proxy the winner behind a routed public id.
 
-    Routes intentionally live in memory for the first experiment. A restart, or a follow-up
-    request landing on another server replica, loses the route. The public API never exposes the
-    provider name, provider browser id, or provider CDP URL.
+    The public ID carries a short provider code, so another process or replica can recover the
+    route from the provider without a shared database. Provider browser IDs and CDP URLs remain
+    internal.
     """
 
-    def __init__(self, fallback: Backend, providers: dict[str, Backend]) -> None:
+    def __init__(
+        self,
+        fallback: Backend,
+        providers: dict[str, Backend],
+    ) -> None:
         if len(providers) < 2:
             raise ValueError("BROWSER_PROVIDER_RACE requires at least two configured providers")
         self._fallback = fallback
         self._providers = providers
-        self._routes: dict[str, _WinnerRoute] = {}
         self._cleanup_tasks: set[asyncio.Task[None]] = set()
 
     @property
@@ -58,7 +60,7 @@ class ProviderRaceBackend:
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,
-    ) -> None:
+    ) -> str:
         """Create one candidate per provider and register the first CDP-ready winner."""
         race_started = time.monotonic()
         logger.info(f"Provider race started for {browser_id}: candidates={len(self._providers)}")
@@ -67,7 +69,7 @@ class ProviderRaceBackend:
                 self._create_ready_candidate(
                     provider,
                     provider_backend,
-                    browser_id,
+                    make_routed_browser_id(provider, browser_id),
                     origin_ip,
                     target_domain,
                     browser_type,
@@ -88,10 +90,7 @@ class ProviderRaceBackend:
         if winner is None:
             raise RuntimeError("No browser provider became CDP-ready")
 
-        self._routes[browser_id] = _WinnerRoute(
-            backend=winner.backend,
-            provider_browser_id=winner.provider_browser_id,
-        )
+        public_browser_id = make_routed_browser_id(winner.provider, browser_id)
         logger.info(
             f"Provider-race winner for {browser_id}: provider={winner.provider} "
             f"create_ms={winner.create_seconds * 1000:.0f} "
@@ -104,6 +103,7 @@ class ProviderRaceBackend:
         )
         self._cleanup_tasks.add(cleanup_task)
         cleanup_task.add_done_callback(self._cleanup_tasks.discard)
+        return public_browser_id
 
     async def _create_ready_candidate(
         self,
@@ -210,11 +210,24 @@ class ProviderRaceBackend:
                 f"error={type(e).__name__}"
             )
 
-    def _route(self, browser_id: str) -> tuple[Backend, str]:
-        route = self._routes.get(browser_id)
+    async def _route(
+        self, browser_id: str, *, resolve_provider_id: bool = True
+    ) -> tuple[Backend, str, BrowserRoute | None]:
+        route = parse_routed_browser_id(browser_id)
         if route is None:
-            return self._fallback, browser_id
-        return route.backend, route.provider_browser_id
+            return self._fallback, browser_id, None
+        provider_backend = self._providers.get(route.provider)
+        if provider_backend is None:
+            raise RuntimeError(f"Provider route cannot be resolved: {route.provider}")
+        provider_browser_id = route.browser_id
+        if route.provider == "browserbase" and resolve_provider_id:
+            from getgather.browsers.browserbase_browsers import BrowserbaseBackend
+
+            if isinstance(provider_backend, BrowserbaseBackend):
+                resolved_id = await provider_backend.resolve_session(route.browser_id)
+                if resolved_id is not None:
+                    provider_browser_id = resolved_id
+        return provider_backend, provider_browser_id, route
 
     async def shutdown(self) -> None:
         if self._cleanup_tasks:
@@ -234,44 +247,51 @@ class ProviderRaceBackend:
         target_domain: str | None,
         browser_type: str | None,
     ) -> dict[str, Any]:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(
+            browser_id, resolve_provider_id=False
+        )
         # Preserve a raced browser's provider affinity when /cdp auto-starts it after deletion.
-        # Browserbase may assign a fresh provider id, so refresh the internal route from the result.
+        # Browserbase attaches this routed id as metadata and may assign a fresh provider UUID.
         result = await provider_backend.create_browser(
             provider_browser_id, origin_ip, target_domain, browser_type
         )
-        route = self._routes.get(browser_id)
-        result_browser_id = result.get("browser_id")
-        if route is not None and isinstance(result_browser_id, str):
-            self._routes[browser_id] = _WinnerRoute(provider_backend, result_browser_id)
         return result
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         await provider_backend.get_browser(provider_browser_id, origin_ip, target_domain)
         return {"browser_id": browser_id, "status": "created"}
 
     async def delete_browser(self, browser_id: str) -> dict[str, Any]:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         await provider_backend.delete_browser(provider_browser_id)
-        # Keep the route as a tombstone. Falling through to the default backend after deletion can
-        # turn a subsequent GET into an upstream 500 or auto-start the id on a different provider.
         return {"browser_id": browser_id, "status": "deleted"}
 
     async def list_browser_ids(self, scope: BROWSER_SCOPE = "all") -> list[str]:
         fallback_ids = await self._fallback.list_browser_ids(scope)
-        hidden_ids = {route.provider_browser_id for route in self._routes.values()}
-        active_routes = {
-            browser_id
-            for browser_id, route in self._routes.items()
-            if await route.backend.browser_exists(route.provider_browser_id)
-        }
-        return sorted((set(fallback_ids) - hidden_ids) | active_routes)
+        browser_ids = set(fallback_ids)
+        for provider, provider_backend in self._providers.items():
+            if provider == "browserbase":
+                from getgather.browsers.browserbase_browsers import BrowserbaseBackend
+
+                if isinstance(provider_backend, BrowserbaseBackend):
+                    routes = await provider_backend.list_routed_sessions()
+                    browser_ids.difference_update(routes.values())
+                    browser_ids.update(routes)
+                    continue
+            provider_ids = await provider_backend.list_browser_ids(scope)
+            browser_ids.update(
+                provider_id
+                for provider_id in provider_ids
+                if (route := parse_routed_browser_id(provider_id)) is not None
+                and route.provider == provider
+            )
+        return sorted(browser_ids)
 
     async def browser_exists(self, browser_id: str) -> bool:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         return await provider_backend.browser_exists(provider_browser_id)
 
     async def cleanup_idle(self) -> list[str]:
@@ -286,7 +306,7 @@ class ProviderRaceBackend:
         return deleted
 
     async def get_cdp_base_url(self, browser_id: str) -> str:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         return await provider_backend.get_cdp_base_url(provider_browser_id)
 
     def cdp_websocket_base(self) -> None:
@@ -294,29 +314,34 @@ class ProviderRaceBackend:
         return None
 
     async def get_cdp_websocket_remote_url(self, browser_id: str) -> str | None:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         return await provider_backend.get_cdp_websocket_remote_url(provider_browser_id)
 
     def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
         if browser_id is None:
             return self._fallback.cdp_targets_need_namespacing()
-        provider_backend, provider_browser_id = self._route(browser_id)
-        return provider_backend.cdp_targets_need_namespacing(provider_browser_id)
+        route = parse_routed_browser_id(browser_id)
+        if route is None:
+            return self._fallback.cdp_targets_need_namespacing(browser_id)
+        provider_backend = self._providers.get(route.provider)
+        if provider_backend is None:
+            raise RuntimeError(f"Provider route cannot be resolved: {route.provider}")
+        return provider_backend.cdp_targets_need_namespacing(route.browser_id)
 
     async def get_devtools_websocket_remote_url(
         self, client_ws: WebSocket, browser_id: str, page_id: str
     ) -> str | None:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         return await provider_backend.get_devtools_websocket_remote_url(
             client_ws, provider_browser_id, page_id
         )
 
     async def get_vnc_endpoint(self, browser_id: str) -> tuple[str, int] | None:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         return await provider_backend.get_vnc_endpoint(provider_browser_id)
 
     async def get_live_view_url(self, browser_id: str) -> str | None:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         return await provider_backend.get_live_view_url(provider_browser_id)
 
 

--- a/getgather/browsers/provider_race.py
+++ b/getgather/browsers/provider_race.py
@@ -1,0 +1,294 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import WebSocket
+from loguru import logger
+
+from getgather.browsers.backend import BROWSER_SCOPE, Backend
+from getgather.cdp_client import open_cdp_url
+from getgather.config import settings
+
+CDP_READY_ATTEMPTS = 30
+CDP_READY_RETRY_SECONDS = 1.0
+CDP_OPEN_TIMEOUT_SECONDS = 10.0
+CDP_COMMAND_TIMEOUT_SECONDS = 10.0
+
+
+@dataclass(frozen=True)
+class _WinnerRoute:
+    backend: Backend
+    provider_browser_id: str
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    provider: str
+    backend: Backend
+    provider_browser_id: str
+
+
+class ProviderRaceBackend:
+    """Race configured browser providers and proxy the winner behind an opaque public id.
+
+    Routes intentionally live in memory for the first experiment. A restart, or a follow-up
+    request landing on another server replica, loses the route. The public API never exposes the
+    provider name, provider browser id, or provider CDP URL.
+    """
+
+    def __init__(self, fallback: Backend, providers: dict[str, Backend]) -> None:
+        if len(providers) < 2:
+            raise ValueError("BROWSER_PROVIDER_RACE requires at least two configured providers")
+        self._fallback = fallback
+        self._providers = providers
+        self._routes: dict[str, _WinnerRoute] = {}
+        self._cleanup_tasks: set[asyncio.Task[None]] = set()
+
+    @property
+    def default_best_of_n(self) -> int:
+        # The outer race is across providers. Do not also multiply candidates within a provider.
+        return 1
+
+    async def create_raced_browser(
+        self,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        browser_type: str | None,
+    ) -> None:
+        """Create one candidate per provider and register the first CDP-ready winner."""
+        tasks = {
+            provider: asyncio.create_task(
+                self._create_ready_candidate(
+                    provider,
+                    provider_backend,
+                    browser_id,
+                    origin_ip,
+                    target_domain,
+                    browser_type,
+                )
+            )
+            for provider, provider_backend in self._providers.items()
+        }
+
+        winner: _Candidate | None = None
+        for completed in asyncio.as_completed(tasks.values()):
+            try:
+                winner = await completed
+            except Exception as e:
+                logger.warning(f"Provider-race candidate failed: {type(e).__name__}: {e}")
+                continue
+            break
+
+        if winner is None:
+            raise RuntimeError("No browser provider became CDP-ready")
+
+        self._routes[browser_id] = _WinnerRoute(
+            backend=winner.backend,
+            provider_browser_id=winner.provider_browser_id,
+        )
+        logger.info(f"Provider-race winner for {browser_id}: {winner.provider}")
+
+        cleanup_task = asyncio.create_task(
+            self._cleanup_race_losers(tasks, winner_provider=winner.provider)
+        )
+        self._cleanup_tasks.add(cleanup_task)
+        cleanup_task.add_done_callback(self._cleanup_tasks.discard)
+
+    async def _create_ready_candidate(
+        self,
+        provider: str,
+        provider_backend: Backend,
+        public_browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        browser_type: str | None,
+    ) -> _Candidate:
+        provider_browser_id = public_browser_id
+        try:
+            result = await provider_backend.create_browser(
+                public_browser_id, origin_ip, target_domain, browser_type
+            )
+            result_browser_id = result.get("browser_id")
+            if isinstance(result_browser_id, str):
+                provider_browser_id = result_browser_id
+            await self._wait_until_cdp_ready(provider_backend, provider_browser_id)
+            return _Candidate(provider, provider_backend, provider_browser_id)
+        except Exception:
+            await self._delete_quietly(provider, provider_backend, provider_browser_id)
+            raise
+
+    async def _wait_until_cdp_ready(self, provider_backend: Backend, browser_id: str) -> None:
+        last_error: Exception | None = None
+        for attempt in range(1, CDP_READY_ATTEMPTS + 1):
+            client = None
+            try:
+                remote_url = await provider_backend.get_cdp_websocket_remote_url(browser_id)
+                if remote_url is None:
+                    raise RuntimeError("CDP URL is not available")
+                client = await open_cdp_url(remote_url, timeout=CDP_OPEN_TIMEOUT_SECONDS)
+                await asyncio.wait_for(
+                    client.send("Target.getTargets"), timeout=CDP_COMMAND_TIMEOUT_SECONDS
+                )
+                return
+            except Exception as e:
+                last_error = e
+                logger.debug(
+                    f"Provider-race CDP probe {attempt}/{CDP_READY_ATTEMPTS} "
+                    f"for {browser_id} failed: {type(e).__name__}: {e}"
+                )
+            finally:
+                if client is not None:
+                    await client.aclose()
+            if attempt < CDP_READY_ATTEMPTS:
+                await asyncio.sleep(CDP_READY_RETRY_SECONDS)
+        raise RuntimeError(f"Browser {browser_id} did not become CDP-ready: {last_error}")
+
+    async def _cleanup_race_losers(
+        self, tasks: dict[str, asyncio.Task[_Candidate]], *, winner_provider: str
+    ) -> None:
+        for provider, task in tasks.items():
+            if provider == winner_provider:
+                continue
+            try:
+                candidate = await task
+            except Exception:
+                # _create_ready_candidate already performs best-effort cleanup on failure.
+                continue
+            await self._delete_quietly(
+                candidate.provider, candidate.backend, candidate.provider_browser_id
+            )
+
+    async def _delete_quietly(
+        self, provider: str, provider_backend: Backend, provider_browser_id: str
+    ) -> None:
+        try:
+            await provider_backend.delete_browser(provider_browser_id)
+            logger.info(f"Provider-race candidate cleaned up: {provider}")
+        except Exception as e:
+            logger.warning(f"Provider-race cleanup failed for {provider}: {type(e).__name__}: {e}")
+
+    def _route(self, browser_id: str) -> tuple[Backend, str]:
+        route = self._routes.get(browser_id)
+        if route is None:
+            return self._fallback, browser_id
+        return route.backend, route.provider_browser_id
+
+    async def shutdown(self) -> None:
+        if self._cleanup_tasks:
+            await asyncio.gather(*self._cleanup_tasks, return_exceptions=True)
+        seen: set[int] = set()
+        for provider_backend in [self._fallback, *self._providers.values()]:
+            identity = id(provider_backend)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            await provider_backend.shutdown()
+
+    async def create_browser(
+        self,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        browser_type: str | None,
+    ) -> dict[str, Any]:
+        return await self._fallback.create_browser(
+            browser_id, origin_ip, target_domain, browser_type
+        )
+
+    async def get_browser(
+        self, browser_id: str, origin_ip: str | None, target_domain: str | None
+    ) -> dict[str, Any]:
+        provider_backend, provider_browser_id = self._route(browser_id)
+        await provider_backend.get_browser(provider_browser_id, origin_ip, target_domain)
+        return {"browser_id": browser_id, "status": "created"}
+
+    async def delete_browser(self, browser_id: str) -> dict[str, Any]:
+        provider_backend, provider_browser_id = self._route(browser_id)
+        await provider_backend.delete_browser(provider_browser_id)
+        self._routes.pop(browser_id, None)
+        return {"browser_id": browser_id, "status": "deleted"}
+
+    async def list_browser_ids(self, scope: BROWSER_SCOPE = "all") -> list[str]:
+        fallback_ids = await self._fallback.list_browser_ids(scope)
+        hidden_ids = {route.provider_browser_id for route in self._routes.values()}
+        return sorted((set(fallback_ids) - hidden_ids) | set(self._routes))
+
+    async def browser_exists(self, browser_id: str) -> bool:
+        provider_backend, provider_browser_id = self._route(browser_id)
+        return await provider_backend.browser_exists(provider_browser_id)
+
+    async def cleanup_idle(self) -> list[str]:
+        deleted: list[str] = []
+        seen: set[int] = set()
+        for provider_backend in [self._fallback, *self._providers.values()]:
+            identity = id(provider_backend)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            deleted.extend(await provider_backend.cleanup_idle())
+        return deleted
+
+    async def get_cdp_base_url(self, browser_id: str) -> str:
+        provider_backend, provider_browser_id = self._route(browser_id)
+        return await provider_backend.get_cdp_base_url(provider_browser_id)
+
+    def cdp_websocket_base(self) -> None:
+        # Provider selection is per browser, so there is no single shared relay base.
+        return None
+
+    async def get_cdp_websocket_remote_url(self, browser_id: str) -> str | None:
+        provider_backend, provider_browser_id = self._route(browser_id)
+        return await provider_backend.get_cdp_websocket_remote_url(provider_browser_id)
+
+    def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
+        if browser_id is None:
+            return self._fallback.cdp_targets_need_namespacing()
+        provider_backend, provider_browser_id = self._route(browser_id)
+        return provider_backend.cdp_targets_need_namespacing(provider_browser_id)
+
+    async def get_devtools_websocket_remote_url(
+        self, client_ws: WebSocket, browser_id: str, page_id: str
+    ) -> str | None:
+        provider_backend, provider_browser_id = self._route(browser_id)
+        return await provider_backend.get_devtools_websocket_remote_url(
+            client_ws, provider_browser_id, page_id
+        )
+
+    async def get_vnc_endpoint(self, browser_id: str) -> tuple[str, int] | None:
+        provider_backend, provider_browser_id = self._route(browser_id)
+        return await provider_backend.get_vnc_endpoint(provider_browser_id)
+
+    async def get_live_view_url(self, browser_id: str) -> str | None:
+        provider_backend, provider_browser_id = self._route(browser_id)
+        return await provider_backend.get_live_view_url(provider_browser_id)
+
+
+def create_provider_race_backend(fallback: Backend) -> ProviderRaceBackend:
+    """Build the experimental provider set from configured credentials."""
+    providers: dict[str, Backend] = {}
+
+    if settings.CHROMEFLEET_URL:
+        from getgather.browsers.fleet_browsers import FleetBackend
+
+        providers["fly"] = fallback if isinstance(fallback, FleetBackend) else FleetBackend()
+
+    if settings.DAYTONA_API_KEY and settings.DAYTONA_SNAPSHOT:
+        from getgather.browsers.daytona_browsers import DaytonaBackend
+
+        providers["daytona"] = (
+            fallback
+            if isinstance(fallback, DaytonaBackend)
+            else DaytonaBackend(
+                settings.DAYTONA_API_KEY, settings.DAYTONA_API_URL, settings.DAYTONA_SNAPSHOT
+            )
+        )
+
+    if settings.BROWSERBASE_API_KEY:
+        from getgather.browsers.browserbase_browsers import BrowserbaseBackend
+
+        providers["browserbase"] = (
+            fallback if isinstance(fallback, BrowserbaseBackend) else BrowserbaseBackend()
+        )
+
+    return ProviderRaceBackend(fallback, providers)

--- a/getgather/browsers/provider_race.py
+++ b/getgather/browsers/provider_race.py
@@ -12,13 +12,7 @@ from getgather.browsers.route_id import (
     make_routed_browser_id,
     parse_routed_browser_id,
 )
-from getgather.cdp_client import open_cdp_url
 from getgather.config import settings
-
-CDP_READY_ATTEMPTS = 30
-CDP_READY_RETRY_SECONDS = 1.0
-CDP_OPEN_TIMEOUT_SECONDS = 10.0
-CDP_COMMAND_TIMEOUT_SECONDS = 10.0
 
 
 @dataclass(frozen=True)
@@ -126,7 +120,7 @@ class ProviderRaceBackend:
             if isinstance(result_browser_id, str):
                 provider_browser_id = result_browser_id
             phase = "cdp_ready"
-            await self._wait_until_cdp_ready(provider_backend, provider_browser_id)
+            await provider_backend.wait_until_cdp_ready(provider_browser_id)
             ready_at = time.monotonic()
             create_seconds = created_at - candidate_started
             cdp_ready_seconds = ready_at - created_at
@@ -151,32 +145,6 @@ class ProviderRaceBackend:
             )
             await self._delete_quietly(provider, provider_backend, provider_browser_id)
             raise
-
-    async def _wait_until_cdp_ready(self, provider_backend: Backend, browser_id: str) -> None:
-        last_error: Exception | None = None
-        for attempt in range(1, CDP_READY_ATTEMPTS + 1):
-            client = None
-            try:
-                remote_url = await provider_backend.get_cdp_websocket_remote_url(browser_id)
-                if remote_url is None:
-                    raise RuntimeError("CDP URL is not available")
-                client = await open_cdp_url(remote_url, timeout=CDP_OPEN_TIMEOUT_SECONDS)
-                await asyncio.wait_for(
-                    client.send("Target.getTargets"), timeout=CDP_COMMAND_TIMEOUT_SECONDS
-                )
-                return
-            except Exception as e:
-                last_error = e
-                logger.debug(
-                    f"Provider-race CDP probe {attempt}/{CDP_READY_ATTEMPTS} failed: "
-                    f"{type(e).__name__}"
-                )
-            finally:
-                if client is not None:
-                    await client.aclose()
-            if attempt < CDP_READY_ATTEMPTS:
-                await asyncio.sleep(CDP_READY_RETRY_SECONDS)
-        raise RuntimeError(f"Browser {browser_id} did not become CDP-ready: {last_error}")
 
     async def _cleanup_race_losers(
         self, tasks: dict[str, asyncio.Task[_Candidate]], *, winner_provider: str
@@ -316,6 +284,10 @@ class ProviderRaceBackend:
     async def get_cdp_websocket_remote_url(self, browser_id: str) -> str | None:
         provider_backend, provider_browser_id, _route = await self._route(browser_id)
         return await provider_backend.get_cdp_websocket_remote_url(provider_browser_id)
+
+    async def wait_until_cdp_ready(self, browser_id: str) -> None:
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
+        await provider_backend.wait_until_cdp_ready(provider_browser_id)
 
     def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
         if browser_id is None:

--- a/getgather/browsers/route_id.py
+++ b/getgather/browsers/route_id.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+
+PROVIDER_CODES = {"fly": "f", "daytona": "d", "browserbase": "b"}
+CODE_PROVIDERS = {code: provider for provider, code in PROVIDER_CODES.items()}
+ROUTED_BROWSER_ID_LENGTH = 9
+
+
+@dataclass(frozen=True)
+class BrowserRoute:
+    provider: str
+    browser_id: str
+
+
+def make_routed_browser_id(provider: str, generated_browser_id: str) -> str:
+    provider_code = PROVIDER_CODES.get(provider)
+    if provider_code is None:
+        raise ValueError(f"Unknown browser provider: {provider}")
+    if len(generated_browser_id) != ROUTED_BROWSER_ID_LENGTH or not generated_browser_id.startswith(
+        "B"
+    ):
+        raise ValueError("Expected a nine-character server-assigned browser ID")
+    return f"B{provider_code}{generated_browser_id[2:]}"
+
+
+def parse_routed_browser_id(browser_id: str) -> BrowserRoute | None:
+    if len(browser_id) != ROUTED_BROWSER_ID_LENGTH or not browser_id.startswith("B"):
+        return None
+    provider = CODE_PROVIDERS.get(browser_id[1])
+    return BrowserRoute(provider, browser_id) if provider is not None else None

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -237,11 +237,10 @@ async def create_browser_auto_endpoint(request: Request) -> dict[str, Any]:
             browser_id = await backend.create_raced_browser(
                 logical_browser_id, origin_ip, target_domain, browser_type
             )
-            cdp_url = str(request.url_for("cdp_browser_websocket_proxy", browser_id=browser_id))
             logger.info(f"Browser {browser_id} is CDP-ready.")
-            # Preserve the existing create contract. cdp_url is additive; CDP readiness is an
-            # internal guarantee rather than a new externally visible status value.
-            return {"browser_id": browser_id, "cdp_url": cdp_url, "status": "created"}
+            # CDP readiness is an internal guarantee rather than a new externally visible status.
+            # Keep the original create response shape; clients derive /cdp/{browser_id} themselves.
+            return {"browser_id": browser_id, "status": "created"}
         explicit = settings.BROWSER_BEST_OF_N
         n = max(1, explicit if explicit is not None else backend.default_best_of_n)
         if n == 1:

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -233,8 +233,10 @@ async def create_browser_auto_endpoint(request: Request) -> dict[str, Any]:
         target_domain = request.headers.get("x-target-domains")
         browser_type = request.headers.get("x-browser-type")
         if isinstance(backend, ProviderRaceBackend):
-            browser_id = new_browser_id()
-            await backend.create_raced_browser(browser_id, origin_ip, target_domain, browser_type)
+            logical_browser_id = new_browser_id()
+            browser_id = await backend.create_raced_browser(
+                logical_browser_id, origin_ip, target_domain, browser_type
+            )
             cdp_url = str(request.url_for("cdp_browser_websocket_proxy", browser_id=browser_id))
             logger.info(f"Browser {browser_id} is CDP-ready.")
             # Preserve the existing create contract. cdp_url is additive; CDP readiness is an

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -18,6 +18,7 @@ from getgather.browsers.backend import (
     create_backend,
     new_browser_id,
 )
+from getgather.browsers.provider_race import ProviderRaceBackend
 from getgather.cdp_client import CDPClient, open_cdp_url
 from getgather.config import settings
 
@@ -231,6 +232,14 @@ async def create_browser_auto_endpoint(request: Request) -> dict[str, Any]:
         origin_ip = request.headers.get("x-origin-ip")
         target_domain = request.headers.get("x-target-domains")
         browser_type = request.headers.get("x-browser-type")
+        if isinstance(backend, ProviderRaceBackend):
+            browser_id = new_browser_id()
+            await backend.create_raced_browser(browser_id, origin_ip, target_domain, browser_type)
+            cdp_url = str(request.url_for("cdp_browser_websocket_proxy", browser_id=browser_id))
+            logger.info(f"Browser {browser_id} is CDP-ready.")
+            # Preserve the existing create contract. cdp_url is additive; CDP readiness is an
+            # internal guarantee rather than a new externally visible status value.
+            return {"browser_id": browser_id, "cdp_url": cdp_url, "status": "created"}
         explicit = settings.BROWSER_BEST_OF_N
         n = max(1, explicit if explicit is not None else backend.default_best_of_n)
         if n == 1:
@@ -361,7 +370,9 @@ async def cdp_browser_websocket_proxy(client_ws: WebSocket, browser_id: str) -> 
     # already namespaces target ids (Fleet's external /cdp proxy) — in which case we do not patch
     # again (would double-prefix browser_id).
     logger.debug(f"[CDP] Entered cdp_browser_websocket_proxy for browser_id={browser_id}")
-    await relay_browser_cdp(client_ws, browser_id, patch=backend.cdp_targets_need_namespacing())
+    await relay_browser_cdp(
+        client_ws, browser_id, patch=backend.cdp_targets_need_namespacing(browser_id)
+    )
     logger.debug("[CDP] cdp_browser_websocket_proxy exiting")
 
 
@@ -457,7 +468,10 @@ async def cdp_devtools_websocket_proxy(client_ws: WebSocket, path: str) -> None:
     # we do not patch again (would double-prefix browser_id).
     logger.info(f"[CDP] Connecting to {remote_url}")
     await websocket_proxy(
-        client_ws, remote_url, browser_id, patch=backend.cdp_targets_need_namespacing()
+        client_ws,
+        remote_url,
+        browser_id,
+        patch=backend.cdp_targets_need_namespacing(browser_id),
     )
     logger.debug("[CDP] cdp_devtools_websocket_proxy exiting")
 

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -175,7 +175,7 @@ async def websocket_proxy(
                 except (WebSocketDisconnect, RuntimeError):
                     logger.info("[CDP] Client disconnected")
                 except Exception as e:
-                    logger.error(f"[CDP] client_to_remote error: {type(e).__name__}: {e}")
+                    logger.error(f"[CDP] client_to_remote error: {type(e).__name__}")
 
             async def remote_to_client() -> None:
                 try:
@@ -192,7 +192,7 @@ async def websocket_proxy(
                 except ConnectionClosed as e:
                     logger.info(f"[CDP] Remote disconnected: code={e.code} reason={e.reason}")
                 except Exception as e:
-                    logger.error(f"[CDP] remote_to_client error: {type(e).__name__}: {e}")
+                    logger.error(f"[CDP] remote_to_client error: {type(e).__name__}")
 
             tasks = [
                 asyncio.create_task(client_to_remote()),
@@ -207,12 +207,12 @@ async def websocket_proxy(
                 except (asyncio.CancelledError, Exception):
                     pass
 
-    except OSError as e:
-        logger.error(f"[CDP] Could not connect to remote: {e}")
+    except OSError:
+        logger.error("[CDP] Could not connect to remote")
         if client_ws.client_state == WebSocketState.CONNECTED:
             await client_ws.close(code=4502, reason="Remote server unreachable")
     except Exception as e:
-        logger.error(f"[CDP] Unexpected error: {type(e).__name__}: {e}")
+        logger.error(f"[CDP] Unexpected error: {type(e).__name__}")
         if client_ws.client_state == WebSocketState.CONNECTED:
             await client_ws.close(code=4500, reason="Internal proxy error")
     finally:
@@ -346,10 +346,13 @@ async def relay_browser_cdp(client_ws: WebSocket, browser_id: str, *, patch: boo
             remote_url = await backend.get_cdp_websocket_remote_url(browser_id)
         except Exception as e:
             logger.warning(
-                f"[CDP] Attempt {attempt + 1}/10 failed to get debugger URL from {browser_id}: {e}"
+                f"[CDP] Attempt {attempt + 1}/10 failed to get debugger URL from "
+                f"{browser_id}: {type(e).__name__}"
             )
         if remote_url is not None:
-            logger.info(f"[CDP] Got remote URL: {remote_url}")
+            # Provider URLs may contain bearer credentials (Daytona preview tokens,
+            # Browserbase signing keys). Never emit them to logs.
+            logger.info(f"[CDP] Resolved remote debugger URL for browser {browser_id}")
             break
         if attempt < 9:
             logger.debug("[CDP] Retrying in 3 seconds...")
@@ -360,7 +363,7 @@ async def relay_browser_cdp(client_ws: WebSocket, browser_id: str, *, patch: boo
         return
 
     # (3) Relay.
-    logger.info(f"[CDP] Client connected, proxying to {remote_url}")
+    logger.info(f"[CDP] Client connected, proxying browser {browser_id}")
     await websocket_proxy(client_ws, remote_url, browser_id, patch)
 
 
@@ -444,11 +447,11 @@ async def cdp_devtools_websocket_proxy(client_ws: WebSocket, path: str) -> None:
         except Exception as e:
             logger.warning(
                 f"[CDP] Attempt {attempt + 1}/10 failed to get page URL for "
-                f"{browser_id}/{page_id}: {e}"
+                f"{browser_id}/{page_id}: {type(e).__name__}"
             )
         if remote_url is not None:
             if remote_url != "":
-                logger.info(f"[CDP] Got page remote URL: {remote_url}")
+                logger.info(f"[CDP] Resolved remote debugger URL for page {page_id}")
             break
         if attempt < 9:
             logger.debug("[CDP] Retrying in 3 seconds...")
@@ -466,7 +469,7 @@ async def cdp_devtools_websocket_proxy(client_ws: WebSocket, path: str) -> None:
     # Relay. `cdp_targets_need_namespacing` lets each backend tell the router whether the URL it
     # returned already namespaces target ids (Fleet's external /devtools proxy) — in which case
     # we do not patch again (would double-prefix browser_id).
-    logger.info(f"[CDP] Connecting to {remote_url}")
+    logger.info(f"[CDP] Connecting remote debugger for page {page_id}")
     await websocket_proxy(
         client_ws,
         remote_url,

--- a/getgather/browsers/settings.py
+++ b/getgather/browsers/settings.py
@@ -65,6 +65,11 @@ class BrowserSettings(BaseSettings):
     # (see `Backend.default_best_of_n`): Podman=5, Daytona=3, Fleet=1.
     BROWSER_BEST_OF_N: int | None = None
 
+    # Experimental best-of-providers browser creation. When enabled, the server-assigned create
+    # endpoint races every configured remote provider (Fly/Chrome Fleet, Daytona, Browserbase),
+    # returns a provider-neutral local /cdp URL, and keeps an in-memory route to the winner.
+    BROWSER_PROVIDER_RACE: bool = False
+
     @property
     def effective_chromefleet_url(self) -> str:
         """Returns CHROMEFLEET_URL if set, otherwise falls back to the local backend."""

--- a/getgather/browsers/settings.py
+++ b/getgather/browsers/settings.py
@@ -67,7 +67,7 @@ class BrowserSettings(BaseSettings):
 
     # Experimental best-of-providers browser creation. When enabled, the server-assigned create
     # endpoint races every configured remote provider (Fly/Chrome Fleet, Daytona, Browserbase),
-    # returns a provider-neutral local /cdp URL, and keeps an in-memory route to the winner.
+    # returns the first CDP-ready browser, and encodes its provider route in the browser ID.
     BROWSER_PROVIDER_RACE: bool = False
 
     @property

--- a/scripts/test-provider-race.sh
+++ b/scripts/test-provider-race.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -eu
+
+base_url="${1:-http://localhost:23456}"
+runs="${2:-3}"
+
+command -v jq >/dev/null 2>&1 || {
+  echo "jq is required" >&2
+  exit 1
+}
+
+i=1
+while [ "$i" -le "$runs" ]; do
+  echo "Race $i/$runs"
+
+  response="$(curl -fsS -X POST "$base_url/api/v1/browsers")"
+  echo "$response" | jq
+
+  browser_id="$(echo "$response" | jq -er '.browser_id')"
+  curl -fsS -X DELETE "$base_url/api/v1/browsers/$browser_id" | jq
+
+  i=$((i + 1))
+done

--- a/tests/test_browser_backend.py
+++ b/tests/test_browser_backend.py
@@ -2,12 +2,13 @@ import asyncio
 import json
 from typing import Any
 
+import pytest
 import websockets
 from pytest import MonkeyPatch
 
 from getgather.browser import _setup_cdp_url  # pyright: ignore[reportPrivateUsage]
 from getgather.browsers import router as browsers_router
-from getgather.browsers.backend import create_backend
+from getgather.browsers.backend import create_backend, wait_for_cdp_ready
 from getgather.browsers.fleet_browsers import FleetBackend
 from getgather.browsers.podman_browsers import PodmanBackend
 from getgather.config import settings
@@ -43,6 +44,38 @@ def test_fleet_relay_url_matches_internal_cdp_url(monkeypatch: MonkeyPatch) -> N
 def test_local_backend_opts_out_of_relay() -> None:
     # None signals the router to use the per-browser /json/version flow instead of a relay.
     assert PodmanBackend().cdp_websocket_base() is None
+
+
+@pytest.mark.asyncio
+async def test_wait_for_cdp_ready_sends_real_cdp_command(monkeypatch: MonkeyPatch) -> None:
+    from getgather import cdp_client
+
+    commands: list[str] = []
+    closed = False
+
+    class _ReadyClient:
+        async def send(self, method: str) -> dict[str, Any]:
+            commands.append(method)
+            return {"targetInfos": []}
+
+        async def aclose(self) -> None:
+            nonlocal closed
+            closed = True
+
+    async def open_ready_client(url: str, timeout: float | None = None) -> _ReadyClient:
+        assert url == "wss://provider.invalid/cdp"
+        assert timeout == 10.0
+        return _ReadyClient()
+
+    async def resolve_url() -> str:
+        return "wss://provider.invalid/cdp"
+
+    monkeypatch.setattr(cdp_client, "open_cdp_url", open_ready_client)
+
+    await wait_for_cdp_ready("browser-id", resolve_url)
+
+    assert commands == ["Target.getTargets"]
+    assert closed is True
 
 
 def test_create_browser_auto_name_starts_with_b(monkeypatch: MonkeyPatch) -> None:

--- a/tests/test_browser_backend.py
+++ b/tests/test_browser_backend.py
@@ -113,7 +113,8 @@ class _FakeCDPBackend:
     async def get_cdp_websocket_remote_url(self, browser_id: str) -> str:
         return "ws://remote/devtools/browser/xyz"
 
-    def cdp_targets_need_namespacing(self) -> bool:
+    def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
+        del browser_id
         return True
 
 

--- a/tests/test_browserbase_backend.py
+++ b/tests/test_browserbase_backend.py
@@ -133,13 +133,71 @@ async def test_browserbase_create_browser_stores_connect_url_mapping(
     assert fake_client.create_call["url"] == BROWSERBASE_SESSIONS_URL
     assert fake_client.create_call["headers"]["x-bb-api-key"] == "test-key"
     assert fake_client.create_call["headers"]["Content-Type"] == "application/json"
-    assert fake_client.create_call["json"] == {"keepAlive": True}
+    assert fake_client.create_call["json"] == {
+        "keepAlive": True,
+        "userMetadata": {"getgatherBrowserId": "ignored-id"},
+    }
 
     # The id -> connectUrl mapping is stored for the CDP proxy to look up.
     assert await backend.get_cdp_websocket_remote_url(SESSION_ID) == CONNECT_URL
     assert await backend.get_cdp_websocket_remote_url("unknown") is None
     assert await backend.browser_exists(SESSION_ID) is True
     assert SESSION_ID in await backend.list_browser_ids()
+
+
+@pytest.mark.asyncio
+async def test_browserbase_recovers_session_from_provider_metadata(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "BROWSERBASE_API_KEY", "test-key")
+    get_calls: list[dict[str, Any]] = []
+
+    class RecoveryResponse:
+        def __init__(self, body: Any) -> None:
+            self._body = body
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> Any:
+            return self._body
+
+    class RecoveryClient:
+        async def __aenter__(self) -> "RecoveryClient":
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def get(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            params: dict[str, str] | None = None,
+        ) -> RecoveryResponse:
+            get_calls.append({"url": url, "headers": headers, "params": params})
+            if url == BROWSERBASE_SESSIONS_URL:
+                return RecoveryResponse([
+                    {
+                        "id": SESSION_ID,
+                        "status": "RUNNING",
+                        "updatedAt": "2026-08-19",
+                        "userMetadata": {"getgatherBrowserId": "Bbuxvstp6"},
+                    }
+                ])
+            return RecoveryResponse(SAMPLE_RESPONSE)
+
+    def recovery_client_factory(**kwargs: Any) -> RecoveryClient:
+        return RecoveryClient()
+
+    monkeypatch.setattr(httpx, "AsyncClient", recovery_client_factory)
+
+    backend = BrowserbaseBackend()
+    assert await backend.resolve_session("logical-id") == SESSION_ID
+    assert await backend.get_cdp_websocket_remote_url(SESSION_ID) == CONNECT_URL
+    assert get_calls[0]["params"] == {"q": "user_metadata['getgatherBrowserId']:'logical-id'"}
+    assert await backend.list_routed_sessions() == {"Bbuxvstp6": SESSION_ID}
 
 
 @pytest.mark.asyncio
@@ -176,6 +234,7 @@ async def test_browserbase_create_browser_attaches_residential_proxy(
     assert result == {"browser_id": SESSION_ID, "status": "created", "ip": None}
     assert fake_client.create_call["json"] == {
         "keepAlive": True,
+        "userMetadata": {"getgatherBrowserId": "bid"},
         "proxies": [{"type": "external", "server": proxy_url}],
     }
 
@@ -198,7 +257,10 @@ async def test_browserbase_create_browser_omits_proxies_without_proxy(
 
     backend = BrowserbaseBackend()
     await backend.create_browser("bid", "1.2.3.4", "amazon.com", None)
-    assert fake_client.create_call["json"] == {"keepAlive": True}
+    assert fake_client.create_call["json"] == {
+        "keepAlive": True,
+        "userMetadata": {"getgatherBrowserId": "bid"},
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_browserbase_backend.py
+++ b/tests/test_browserbase_backend.py
@@ -294,6 +294,28 @@ async def test_browserbase_delete_browser_swallows_404(monkeypatch: MonkeyPatch)
 
 
 @pytest.mark.asyncio
+async def test_browserbase_delete_browser_redacts_release_error(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "BROWSERBASE_API_KEY", "test-key")
+    _patch_cdp_wait(monkeypatch)
+    _fake_client, factory = _make_fake_client_factory(release_status=401)
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+    warnings: list[str] = []
+    monkeypatch.setattr("getgather.browsers.browserbase_browsers.logger.warning", warnings.append)
+
+    backend = BrowserbaseBackend()
+    await backend.create_browser("ignored", None, None, None)
+    result = await backend.delete_browser(SESSION_ID)
+
+    assert result == {"browser_id": SESSION_ID, "status": "deleted"}
+    log_text = "\n".join(warnings)
+    assert "error=RuntimeError" in log_text
+    assert "HTTP 401" not in log_text
+    assert BROWSERBASE_SESSIONS_URL not in log_text
+
+
+@pytest.mark.asyncio
 async def test_browserbase_delete_browser_for_unknown_id_clears_silently(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/test_provider_race.py
+++ b/tests/test_provider_race.py
@@ -109,30 +109,26 @@ async def test_provider_race_routes_public_id_to_fastest_ready_provider(
     monkeypatch: MonkeyPatch,
 ) -> None:
     slow = _FakeBackend(create_delay=0.02, remote_url="wss://slow.invalid", namespacing=False)
-    fast = _FakeBackend(
-        provider_browser_id="provider-assigned-secret-id",
-        remote_url="wss://fast.invalid",
-    )
-    race = ProviderRaceBackend(slow, {"slow": slow, "fast": fast})
+    fast = _FakeBackend(remote_url="wss://fast.invalid")
+    race = ProviderRaceBackend(slow, {"fly": slow, "daytona": fast})
 
     async def ready(self: Any, provider_backend: _FakeBackend, browser_id: str) -> None:
         assert await provider_backend.get_cdp_websocket_remote_url(browser_id)
 
     monkeypatch.setattr(ProviderRaceBackend, "_wait_until_cdp_ready", ready)
 
-    await race.create_raced_browser("public-id", "1.2.3.4", "example.com", "chrome")
+    public_id = await race.create_raced_browser("Bpuxvstp6", "1.2.3.4", "example.com", "chrome")
 
-    assert await race.get_cdp_websocket_remote_url("public-id") == (
-        "wss://fast.invalid/provider-assigned-secret-id"
-    )
-    assert race.cdp_targets_need_namespacing("public-id") is True
-    assert await race.get_browser("public-id", None, None) == {
-        "browser_id": "public-id",
+    assert public_id == "Bduxvstp6"
+    assert await race.get_cdp_websocket_remote_url(public_id) == ("wss://fast.invalid/Bduxvstp6")
+    assert race.cdp_targets_need_namespacing(public_id) is True
+    assert await race.get_browser(public_id, None, None) == {
+        "browser_id": public_id,
         "status": "created",
     }
 
     await race.shutdown()
-    assert slow.deleted == ["public-id"]
+    assert slow.deleted == ["Bfuxvstp6"]
     assert fast.deleted == []
 
 
@@ -140,7 +136,7 @@ async def test_provider_race_routes_public_id_to_fastest_ready_provider(
 async def test_provider_race_cleans_failed_candidates(monkeypatch: MonkeyPatch) -> None:
     first = _FakeBackend(create_error=RuntimeError("create failed"))
     second = _FakeBackend()
-    race = ProviderRaceBackend(first, {"first": first, "second": second})
+    race = ProviderRaceBackend(first, {"fly": first, "daytona": second})
 
     async def never_ready(self: Any, provider_backend: _FakeBackend, browser_id: str) -> None:
         del provider_backend, browser_id
@@ -149,10 +145,10 @@ async def test_provider_race_cleans_failed_candidates(monkeypatch: MonkeyPatch) 
     monkeypatch.setattr(ProviderRaceBackend, "_wait_until_cdp_ready", never_ready)
 
     with pytest.raises(RuntimeError, match="No browser provider became CDP-ready"):
-        await race.create_raced_browser("public-id", None, None, None)
+        await race.create_raced_browser("Bpuxvstp6", None, None, None)
 
-    assert first.deleted == ["public-id"]
-    assert second.deleted == ["public-id"]
+    assert first.deleted == ["Bfuxvstp6"]
+    assert second.deleted == ["Bduxvstp6"]
 
 
 @pytest.mark.asyncio
@@ -160,32 +156,29 @@ async def test_deleted_winner_does_not_fall_through_to_fallback(monkeypatch: Mon
     fallback = _FakeBackend(
         remote_url="wss://fallback.invalid", create_error=RuntimeError("fallback used")
     )
-    winner = _FakeBackend(
-        provider_browser_id="provider-assigned-secret-id",
-        remote_url="wss://winner.invalid",
-    )
-    race = ProviderRaceBackend(fallback, {"fallback": fallback, "winner": winner})
+    winner = _FakeBackend(remote_url="wss://winner.invalid")
+    race = ProviderRaceBackend(fallback, {"fly": fallback, "daytona": winner})
 
     async def ready(self: Any, provider_backend: _FakeBackend, browser_id: str) -> None:
         assert await provider_backend.get_cdp_websocket_remote_url(browser_id)
 
     monkeypatch.setattr(ProviderRaceBackend, "_wait_until_cdp_ready", ready)
-    await race.create_raced_browser("public-id", None, None, None)
+    public_id = await race.create_raced_browser("Bpuxvstp6", None, None, None)
 
-    assert await race.delete_browser("public-id") == {
-        "browser_id": "public-id",
+    assert await race.delete_browser(public_id) == {
+        "browser_id": public_id,
         "status": "deleted",
     }
-    assert await race.browser_exists("public-id") is False
+    assert await race.browser_exists(public_id) is False
     with pytest.raises(BrowserNotFound):
-        await race.get_browser("public-id", None, None)
-    assert "public-id" not in await race.list_browser_ids()
+        await race.get_browser(public_id, None, None)
+    assert public_id not in await race.list_browser_ids()
     assert fallback.created == set()
 
     # Existing CDP auto-start semantics are retained, but the browser stays on its winning provider.
-    result = await race.create_browser("public-id", None, None, None)
-    assert result["browser_id"] == "provider-assigned-secret-id"
-    assert await race.browser_exists("public-id") is True
+    result = await race.create_browser(public_id, None, None, None)
+    assert result["browser_id"] == "Bduxvstp6"
+    assert await race.browser_exists(public_id) is True
     assert fallback.created == set()
 
     await race.shutdown()
@@ -195,15 +188,16 @@ def test_provider_race_create_response_contains_only_proxy_url(monkeypatch: Monk
     from getgather.browsers import router as router_module
 
     fallback = _FakeBackend()
-    race = ProviderRaceBackend(fallback, {"one": fallback, "two": _FakeBackend()})
+    race = ProviderRaceBackend(fallback, {"fly": fallback, "daytona": _FakeBackend()})
 
     async def fake_create_raced_browser(
         browser_id: str,
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,
-    ) -> None:
+    ) -> str:
         del browser_id, origin_ip, target_domain, browser_type
+        return "Bduxvstp6"
 
     monkeypatch.setattr(race, "create_raced_browser", fake_create_raced_browser)
     monkeypatch.setattr(router_module, "backend", race)
@@ -215,8 +209,49 @@ def test_provider_race_create_response_contains_only_proxy_url(monkeypatch: Monk
 
     assert response.status_code == 200
     assert response.json() == {
-        "browser_id": "public-id",
-        "cdp_url": "ws://testserver/cdp/public-id",
+        "browser_id": "Bduxvstp6",
+        "cdp_url": "ws://testserver/cdp/Bduxvstp6",
         "status": "created",
     }
     assert "provider" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_provider_route_survives_process_boundary(monkeypatch: MonkeyPatch) -> None:
+    first_backend = _FakeBackend()
+    first = ProviderRaceBackend(
+        first_backend,
+        {"daytona": first_backend, "fly": _FakeBackend(create_delay=0.02)},
+    )
+
+    async def ready(self: Any, provider_backend: _FakeBackend, browser_id: str) -> None:
+        assert await provider_backend.get_cdp_websocket_remote_url(browser_id)
+
+    monkeypatch.setattr(ProviderRaceBackend, "_wait_until_cdp_ready", ready)
+    public_id = await first.create_raced_browser("Bpuxvstp6", None, None, None)
+
+    second_backend = _FakeBackend()
+    second_backend.created.add("Bduxvstp6")
+    second_fallback = _FakeBackend()
+    second = ProviderRaceBackend(
+        second_fallback,
+        {"daytona": second_backend, "fly": second_fallback},
+    )
+
+    assert await second.get_browser(public_id, None, None) == {
+        "browser_id": public_id,
+        "status": "created",
+    }
+    assert await second.get_cdp_websocket_remote_url(public_id) == (
+        "wss://provider.invalid/cdp/Bduxvstp6"
+    )
+    assert public_id in await second.list_browser_ids()
+    assert await second.delete_browser(public_id) == {
+        "browser_id": public_id,
+        "status": "deleted",
+    }
+    first_backend.created.clear()
+    assert await first.browser_exists(public_id) is False
+
+    await first.shutdown()
+    await second.shutdown()

--- a/tests/test_provider_race.py
+++ b/tests/test_provider_race.py
@@ -155,6 +155,42 @@ async def test_provider_race_cleans_failed_candidates(monkeypatch: MonkeyPatch) 
     assert second.deleted == ["public-id"]
 
 
+@pytest.mark.asyncio
+async def test_deleted_winner_does_not_fall_through_to_fallback(monkeypatch: MonkeyPatch) -> None:
+    fallback = _FakeBackend(
+        remote_url="wss://fallback.invalid", create_error=RuntimeError("fallback used")
+    )
+    winner = _FakeBackend(
+        provider_browser_id="provider-assigned-secret-id",
+        remote_url="wss://winner.invalid",
+    )
+    race = ProviderRaceBackend(fallback, {"fallback": fallback, "winner": winner})
+
+    async def ready(self: Any, provider_backend: _FakeBackend, browser_id: str) -> None:
+        assert await provider_backend.get_cdp_websocket_remote_url(browser_id)
+
+    monkeypatch.setattr(ProviderRaceBackend, "_wait_until_cdp_ready", ready)
+    await race.create_raced_browser("public-id", None, None, None)
+
+    assert await race.delete_browser("public-id") == {
+        "browser_id": "public-id",
+        "status": "deleted",
+    }
+    assert await race.browser_exists("public-id") is False
+    with pytest.raises(BrowserNotFound):
+        await race.get_browser("public-id", None, None)
+    assert "public-id" not in await race.list_browser_ids()
+    assert fallback.created == set()
+
+    # Existing CDP auto-start semantics are retained, but the browser stays on its winning provider.
+    result = await race.create_browser("public-id", None, None, None)
+    assert result["browser_id"] == "provider-assigned-secret-id"
+    assert await race.browser_exists("public-id") is True
+    assert fallback.created == set()
+
+    await race.shutdown()
+
+
 def test_provider_race_create_response_contains_only_proxy_url(monkeypatch: MonkeyPatch) -> None:
     from getgather.browsers import router as router_module
 

--- a/tests/test_provider_race.py
+++ b/tests/test_provider_race.py
@@ -1,0 +1,186 @@
+import asyncio
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, WebSocket
+from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
+
+from getgather.browsers.backend import BROWSER_SCOPE, BrowserNotFound
+from getgather.browsers.provider_race import ProviderRaceBackend
+
+
+class _FakeBackend:
+    def __init__(
+        self,
+        *,
+        create_delay: float = 0,
+        provider_browser_id: str | None = None,
+        remote_url: str = "wss://provider.invalid/cdp",
+        namespacing: bool = True,
+        create_error: Exception | None = None,
+    ) -> None:
+        self.create_delay = create_delay
+        self.provider_browser_id = provider_browser_id
+        self.remote_url = remote_url
+        self.namespacing = namespacing
+        self.create_error = create_error
+        self.created: set[str] = set()
+        self.deleted: list[str] = []
+
+    @property
+    def default_best_of_n(self) -> int:
+        return 1
+
+    async def shutdown(self) -> None:
+        return None
+
+    async def create_browser(
+        self,
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        browser_type: str | None,
+    ) -> dict[str, Any]:
+        del origin_ip, target_domain, browser_type
+        if self.create_delay:
+            await asyncio.sleep(self.create_delay)
+        if self.create_error:
+            raise self.create_error
+        actual_id = self.provider_browser_id or browser_id
+        self.created.add(actual_id)
+        return {"browser_id": actual_id, "provider_secret": self.remote_url}
+
+    async def get_browser(
+        self, browser_id: str, origin_ip: str | None, target_domain: str | None
+    ) -> dict[str, Any]:
+        del origin_ip, target_domain
+        if browser_id not in self.created:
+            raise BrowserNotFound(browser_id)
+        return {"browser_id": browser_id}
+
+    async def delete_browser(self, browser_id: str) -> dict[str, Any]:
+        self.created.discard(browser_id)
+        self.deleted.append(browser_id)
+        return {"status": "deleted"}
+
+    async def list_browser_ids(self, scope: BROWSER_SCOPE = "all") -> list[str]:
+        del scope
+        return list(self.created)
+
+    async def browser_exists(self, browser_id: str) -> bool:
+        return browser_id in self.created
+
+    async def cleanup_idle(self) -> list[str]:
+        return []
+
+    async def get_cdp_base_url(self, browser_id: str) -> str:
+        return f"https://provider.invalid/{browser_id}"
+
+    def cdp_websocket_base(self) -> None:
+        return None
+
+    async def get_cdp_websocket_remote_url(self, browser_id: str) -> str | None:
+        if browser_id not in self.created:
+            return None
+        return f"{self.remote_url}/{browser_id}"
+
+    def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
+        del browser_id
+        return self.namespacing
+
+    async def get_devtools_websocket_remote_url(
+        self, client_ws: WebSocket, browser_id: str, page_id: str
+    ) -> str | None:
+        del client_ws
+        return f"{self.remote_url}/{browser_id}/page/{page_id}"
+
+    async def get_vnc_endpoint(self, browser_id: str) -> tuple[str, int] | None:
+        del browser_id
+        return None
+
+    async def get_live_view_url(self, browser_id: str) -> str | None:
+        del browser_id
+        return None
+
+
+@pytest.mark.asyncio
+async def test_provider_race_routes_public_id_to_fastest_ready_provider(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    slow = _FakeBackend(create_delay=0.02, remote_url="wss://slow.invalid", namespacing=False)
+    fast = _FakeBackend(
+        provider_browser_id="provider-assigned-secret-id",
+        remote_url="wss://fast.invalid",
+    )
+    race = ProviderRaceBackend(slow, {"slow": slow, "fast": fast})
+
+    async def ready(self: Any, provider_backend: _FakeBackend, browser_id: str) -> None:
+        assert await provider_backend.get_cdp_websocket_remote_url(browser_id)
+
+    monkeypatch.setattr(ProviderRaceBackend, "_wait_until_cdp_ready", ready)
+
+    await race.create_raced_browser("public-id", "1.2.3.4", "example.com", "chrome")
+
+    assert await race.get_cdp_websocket_remote_url("public-id") == (
+        "wss://fast.invalid/provider-assigned-secret-id"
+    )
+    assert race.cdp_targets_need_namespacing("public-id") is True
+    assert await race.get_browser("public-id", None, None) == {
+        "browser_id": "public-id",
+        "status": "created",
+    }
+
+    await race.shutdown()
+    assert slow.deleted == ["public-id"]
+    assert fast.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_provider_race_cleans_failed_candidates(monkeypatch: MonkeyPatch) -> None:
+    first = _FakeBackend(create_error=RuntimeError("create failed"))
+    second = _FakeBackend()
+    race = ProviderRaceBackend(first, {"first": first, "second": second})
+
+    async def never_ready(self: Any, provider_backend: _FakeBackend, browser_id: str) -> None:
+        del provider_backend, browser_id
+        raise RuntimeError("CDP failed")
+
+    monkeypatch.setattr(ProviderRaceBackend, "_wait_until_cdp_ready", never_ready)
+
+    with pytest.raises(RuntimeError, match="No browser provider became CDP-ready"):
+        await race.create_raced_browser("public-id", None, None, None)
+
+    assert first.deleted == ["public-id"]
+    assert second.deleted == ["public-id"]
+
+
+def test_provider_race_create_response_contains_only_proxy_url(monkeypatch: MonkeyPatch) -> None:
+    from getgather.browsers import router as router_module
+
+    fallback = _FakeBackend()
+    race = ProviderRaceBackend(fallback, {"one": fallback, "two": _FakeBackend()})
+
+    async def fake_create_raced_browser(
+        browser_id: str,
+        origin_ip: str | None,
+        target_domain: str | None,
+        browser_type: str | None,
+    ) -> None:
+        del browser_id, origin_ip, target_domain, browser_type
+
+    monkeypatch.setattr(race, "create_raced_browser", fake_create_raced_browser)
+    monkeypatch.setattr(router_module, "backend", race)
+    monkeypatch.setattr(router_module, "new_browser_id", lambda: "public-id")
+
+    app = FastAPI()
+    app.include_router(router_module.router)
+    response = TestClient(app).post("/api/v1/browsers")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "browser_id": "public-id",
+        "cdp_url": "ws://testserver/cdp/public-id",
+        "status": "created",
+    }
+    assert "provider" not in response.text

--- a/tests/test_provider_race.py
+++ b/tests/test_provider_race.py
@@ -19,14 +19,17 @@ class _FakeBackend:
         remote_url: str = "wss://provider.invalid/cdp",
         namespacing: bool = True,
         create_error: Exception | None = None,
+        readiness_error: Exception | None = None,
     ) -> None:
         self.create_delay = create_delay
         self.provider_browser_id = provider_browser_id
         self.remote_url = remote_url
         self.namespacing = namespacing
         self.create_error = create_error
+        self.readiness_error = readiness_error
         self.created: set[str] = set()
         self.deleted: list[str] = []
+        self.readiness_checks: list[str] = []
 
     @property
     def default_best_of_n(self) -> int:
@@ -85,6 +88,12 @@ class _FakeBackend:
             return None
         return f"{self.remote_url}/{browser_id}"
 
+    async def wait_until_cdp_ready(self, browser_id: str) -> None:
+        self.readiness_checks.append(browser_id)
+        if self.readiness_error is not None:
+            raise self.readiness_error
+        assert await self.get_cdp_websocket_remote_url(browser_id)
+
     def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
         del browser_id
         return self.namespacing
@@ -105,23 +114,17 @@ class _FakeBackend:
 
 
 @pytest.mark.asyncio
-async def test_provider_race_routes_public_id_to_fastest_ready_provider(
-    monkeypatch: MonkeyPatch,
-) -> None:
+async def test_provider_race_routes_public_id_to_fastest_ready_provider() -> None:
     slow = _FakeBackend(create_delay=0.02, remote_url="wss://slow.invalid", namespacing=False)
     fast = _FakeBackend(remote_url="wss://fast.invalid")
     race = ProviderRaceBackend(slow, {"fly": slow, "daytona": fast})
-
-    async def ready(self: Any, provider_backend: _FakeBackend, browser_id: str) -> None:
-        assert await provider_backend.get_cdp_websocket_remote_url(browser_id)
-
-    monkeypatch.setattr(ProviderRaceBackend, "_wait_until_cdp_ready", ready)
 
     public_id = await race.create_raced_browser("Bpuxvstp6", "1.2.3.4", "example.com", "chrome")
 
     assert public_id == "Bduxvstp6"
     assert await race.get_cdp_websocket_remote_url(public_id) == ("wss://fast.invalid/Bduxvstp6")
     assert race.cdp_targets_need_namespacing(public_id) is True
+    assert fast.readiness_checks == ["Bduxvstp6"]
     assert await race.get_browser(public_id, None, None) == {
         "browser_id": public_id,
         "status": "created",
@@ -133,16 +136,10 @@ async def test_provider_race_routes_public_id_to_fastest_ready_provider(
 
 
 @pytest.mark.asyncio
-async def test_provider_race_cleans_failed_candidates(monkeypatch: MonkeyPatch) -> None:
+async def test_provider_race_cleans_failed_candidates() -> None:
     first = _FakeBackend(create_error=RuntimeError("create failed"))
-    second = _FakeBackend()
+    second = _FakeBackend(readiness_error=RuntimeError("CDP failed"))
     race = ProviderRaceBackend(first, {"fly": first, "daytona": second})
-
-    async def never_ready(self: Any, provider_backend: _FakeBackend, browser_id: str) -> None:
-        del provider_backend, browser_id
-        raise RuntimeError("CDP failed")
-
-    monkeypatch.setattr(ProviderRaceBackend, "_wait_until_cdp_ready", never_ready)
 
     with pytest.raises(RuntimeError, match="No browser provider became CDP-ready"):
         await race.create_raced_browser("Bpuxvstp6", None, None, None)
@@ -152,17 +149,13 @@ async def test_provider_race_cleans_failed_candidates(monkeypatch: MonkeyPatch) 
 
 
 @pytest.mark.asyncio
-async def test_deleted_winner_does_not_fall_through_to_fallback(monkeypatch: MonkeyPatch) -> None:
+async def test_deleted_winner_does_not_fall_through_to_fallback() -> None:
     fallback = _FakeBackend(
         remote_url="wss://fallback.invalid", create_error=RuntimeError("fallback used")
     )
     winner = _FakeBackend(remote_url="wss://winner.invalid")
     race = ProviderRaceBackend(fallback, {"fly": fallback, "daytona": winner})
 
-    async def ready(self: Any, provider_backend: _FakeBackend, browser_id: str) -> None:
-        assert await provider_backend.get_cdp_websocket_remote_url(browser_id)
-
-    monkeypatch.setattr(ProviderRaceBackend, "_wait_until_cdp_ready", ready)
     public_id = await race.create_raced_browser("Bpuxvstp6", None, None, None)
 
     assert await race.delete_browser(public_id) == {
@@ -216,17 +209,13 @@ def test_provider_race_create_response_preserves_contract(monkeypatch: MonkeyPat
 
 
 @pytest.mark.asyncio
-async def test_provider_route_survives_process_boundary(monkeypatch: MonkeyPatch) -> None:
+async def test_provider_route_survives_process_boundary() -> None:
     first_backend = _FakeBackend()
     first = ProviderRaceBackend(
         first_backend,
         {"daytona": first_backend, "fly": _FakeBackend(create_delay=0.02)},
     )
 
-    async def ready(self: Any, provider_backend: _FakeBackend, browser_id: str) -> None:
-        assert await provider_backend.get_cdp_websocket_remote_url(browser_id)
-
-    monkeypatch.setattr(ProviderRaceBackend, "_wait_until_cdp_ready", ready)
     public_id = await first.create_raced_browser("Bpuxvstp6", None, None, None)
 
     second_backend = _FakeBackend()

--- a/tests/test_provider_race.py
+++ b/tests/test_provider_race.py
@@ -184,7 +184,7 @@ async def test_deleted_winner_does_not_fall_through_to_fallback(monkeypatch: Mon
     await race.shutdown()
 
 
-def test_provider_race_create_response_contains_only_proxy_url(monkeypatch: MonkeyPatch) -> None:
+def test_provider_race_create_response_preserves_contract(monkeypatch: MonkeyPatch) -> None:
     from getgather.browsers import router as router_module
 
     fallback = _FakeBackend()
@@ -210,7 +210,6 @@ def test_provider_race_create_response_contains_only_proxy_url(monkeypatch: Monk
     assert response.status_code == 200
     assert response.json() == {
         "browser_id": "Bduxvstp6",
-        "cdp_url": "ws://testserver/cdp/Bduxvstp6",
         "status": "created",
     }
     assert "provider" not in response.text

--- a/tests/test_route_id.py
+++ b/tests/test_route_id.py
@@ -1,0 +1,23 @@
+import pytest
+
+from getgather.browsers.route_id import (
+    BrowserRoute,
+    make_routed_browser_id,
+    parse_routed_browser_id,
+)
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [("fly", "Bfuxvstp6"), ("daytona", "Bduxvstp6"), ("browserbase", "Bbuxvstp6")],
+)
+def test_routed_browser_id_keeps_short_public_contract(provider: str, expected: str) -> None:
+    browser_id = make_routed_browser_id(provider, "Bpuxvstp6")
+
+    assert browser_id == expected
+    assert parse_routed_browser_id(browser_id) == BrowserRoute(provider, expected)
+
+
+def test_non_routed_browser_id_is_left_for_the_fallback_backend() -> None:
+    assert parse_routed_browser_id("B9uxvstp6") is None
+    assert parse_routed_browser_id("named-browser") is None


### PR DESCRIPTION
## What this does

Adds an opt-in best-of-providers experiment for server-assigned browser creation.

When `BROWSER_PROVIDER_RACE=true`, `POST /api/v1/browsers` starts one candidate on every configured remote provider:

- Fly / external Chrome Fleet (`CHROMEFLEET_URL`)
- Daytona (`DAYTONA_API_KEY` + `DAYTONA_SNAPSHOT`)
- Browserbase (`BROWSERBASE_API_KEY`)

A candidate wins only after its CDP connection successfully answers `Target.getTargets`. The first CDP-ready browser is returned; remaining candidates finish in the background and are cleaned up asynchronously.

## Compatibility

The create response keeps the previous contract:

```json
{
  "browser_id": "Bdabc1234",
  "status": "created"
}
```

Clients continue constructing the proxied CDP endpoint as `/cdp/{browser_id}`. Direct provider CDP URLs, signed credentials, and provider-assigned Browserbase session IDs are never returned.

- The experiment is disabled by default.
- `POST /api/v1/browsers/{browser_id}` is unchanged.
- GET, DELETE, CDP, DevTools, and live-view requests continue using the returned `browser_id`.
- CDP target-ID namespacing remains specific to the winning provider.

## Routing without shared state

Server-assigned IDs remain nine characters. Their second character records the winning provider:

- `Bf.......` — Fly / external Chrome Fleet
- `Bd.......` — Daytona
- `Bb.......` — Browserbase

This lets any GetGather replica route later requests without Redis or an in-memory winner registry. The accepted tradeoff is that the winning provider is visible from the ID prefix.

Fly and Daytona use the routed ID as their native browser ID. Browserbase assigns its own session ID, so creation attaches the routed `Bb...` ID as user metadata. After a restart or replica hop, GetGather queries that metadata and fetches the current Browserbase connection URL.

## Enabling the experiment

```env
BROWSER_PROVIDER_RACE=true
CHROMEFLEET_URL=...
DAYTONA_API_KEY=...
DAYTONA_SNAPSHOT=...
BROWSERBASE_API_KEY=...
```

Only configured providers participate, and at least two are required. The deployment image must include the optional Daytona SDK when Daytona participates.

## Validation

- `make check`
- 157 unit tests passed
- Live smoke tests covered three-provider racing, two-provider racing, fallback when Browserbase returns 401, proxied CDP commands, and browser deletion.
- Automated tests cover fastest-ready selection, provider failures, loser cleanup, routed-ID recovery across process boundaries, Browserbase metadata recovery, log redaction, and the unchanged create response contract.

## Remaining follow-up

1. Collect canary latency, winner distribution, provider failure, and cleanup metrics.
2. Add durable reconciliation for losing candidates that survive a process crash or exhaust cleanup retries.
3. Add cost and concurrency guardrails before broad rollout.
4. Decide later whether provider racing should cover named creation and MCP/dpage flows; this PR intentionally limits it to server-assigned browser creation.
