### PR TITLE
feat(browser): recover provider routes without shared state

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -14,7 +14,7 @@ BROWSER_BACKEND=podman
 BROWSER_BEST_OF_N=
 
 # Experimental: race all configured remote providers on POST /api/v1/browsers and return a
-# provider-neutral CDP proxy URL. The winner route is process-local and is lost on restart.
+# provider-neutral CDP proxy URL. The second ID character records the winning provider.
 BROWSER_PROVIDER_RACE=false
 
 # Podman backend

--- a/getgather/browsers/browserbase_browsers.py
+++ b/getgather/browsers/browserbase_browsers.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import os
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import websockets
@@ -170,8 +170,9 @@ class BrowserbaseBackend:
 
     Only `create_browser` is implemented: it POSTs to the Browserbase `/v1/sessions`
     endpoint with the `x-bb-api-key` header (read from the `BROWSERBASE_API_KEY` env var)
-    and stores the returned `id -> connectUrl` mapping in an in-memory hashmap so the
-    CDP proxy in `router.py` can later route `/cdp/<id>` traffic to the right connectUrl.
+    and stores the returned `id -> connectUrl` mapping locally. It also tags sessions with the
+    routed GetGather browser ID, allowing another process to recover the assigned ID and
+    connectUrl from Browserbase after a restart or replica hop.
 
     The Browserbase-assigned session `id` is returned as the `browser_id`, ignoring the
     caller-supplied id (Browserbase creates its own). The router's `POST /api/v1/browsers`
@@ -183,6 +184,7 @@ class BrowserbaseBackend:
     def __init__(self) -> None:
         # browser_id -> connectUrl (wss://connect.usw2.browserbase.com/?signingKey=...)
         self._sessions: dict[str, str] = {}
+        self._logical_sessions: dict[str, str] = {}
 
     async def shutdown(self) -> None:
         return None
@@ -203,7 +205,10 @@ class BrowserbaseBackend:
         # keepAlive keeps the session running between CDP connections / after disconnects.
         # Without it, Browserbase ends the session the moment the first WS drops, and any
         # subsequent connect to the same signingKey returns HTTP 410 Gone.
-        body: dict[str, Any] = {"keepAlive": True}
+        body: dict[str, Any] = {
+            "keepAlive": True,
+            "userMetadata": {"getgatherBrowserId": browser_id},
+        }
         proxy_config = await get_proxy_config(origin_ip, target_domain, settings)
         if proxy_config:
             proxy_url = proxy_config.get_proxy_url(browser_id)
@@ -219,6 +224,7 @@ class BrowserbaseBackend:
         bb_id = str(data["id"])
         connect_url = str(data["connectUrl"])
         self._sessions[bb_id] = connect_url
+        self._logical_sessions[browser_id] = bb_id
         # connectUrl embeds a signing key and is a bearer secret; never log it.
         logger.info(f"Browserbase session created: id={bb_id}")
         await self._wait_until_cdp_ready(connect_url, bb_id)
@@ -317,6 +323,77 @@ class BrowserbaseBackend:
         # discovery step. None for an unknown / already-released session.
         return self._sessions.get(browser_id)
 
+    async def resolve_session(self, logical_browser_id: str) -> str | None:
+        """Recover a Browserbase session after a GetGather restart or replica hop."""
+        cached_id = self._logical_sessions.get(logical_browser_id)
+        if cached_id is not None and cached_id in self._sessions:
+            return cached_id
+
+        headers = {"x-bb-api-key": _api_key()}
+        query = f"user_metadata['getgatherBrowserId']:'{logical_browser_id}'"
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.get(BROWSERBASE_API_URL, headers=headers, params={"q": query})
+            response.raise_for_status()
+            raw_sessions: Any = response.json()
+            if not isinstance(raw_sessions, list):
+                return None
+            candidates: list[dict[str, Any]] = []
+            for raw_session in raw_sessions:  # pyright: ignore[reportUnknownVariableType]
+                if not isinstance(raw_session, dict):
+                    continue
+                session = cast(dict[str, Any], raw_session)
+                if session.get("status") in {"PENDING", "RUNNING"}:
+                    candidates.append(session)
+            if not candidates:
+                return None
+            candidate = max(candidates, key=lambda item: str(item.get("updatedAt", "")))
+            session_id: Any = candidate.get("id")
+            if not isinstance(session_id, str):
+                return None
+            detail = await client.get(f"{BROWSERBASE_API_URL}/{session_id}", headers=headers)
+            detail.raise_for_status()
+            raw_data: Any = detail.json()
+            if not isinstance(raw_data, dict):
+                return None
+            data = cast(dict[str, Any], raw_data)
+            connect_url: Any = data.get("connectUrl")
+            if not isinstance(connect_url, str):
+                return None
+
+        self._sessions[session_id] = connect_url
+        self._logical_sessions[logical_browser_id] = session_id
+        return session_id
+
+    async def list_routed_sessions(self) -> dict[str, str]:
+        """Return active routed IDs and their Browserbase-assigned session IDs."""
+        from getgather.browsers.route_id import parse_routed_browser_id
+
+        headers = {"x-bb-api-key": _api_key()}
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.get(BROWSERBASE_API_URL, headers=headers)
+            response.raise_for_status()
+            raw_sessions: Any = response.json()
+        if not isinstance(raw_sessions, list):
+            return {}
+
+        routes: dict[str, str] = {}
+        for raw_session in raw_sessions:  # pyright: ignore[reportUnknownVariableType]
+            if not isinstance(raw_session, dict):
+                continue
+            session = cast(dict[str, Any], raw_session)
+            if session.get("status") not in {"PENDING", "RUNNING"}:
+                continue
+            metadata = session.get("userMetadata")
+            session_id = session.get("id")
+            if not isinstance(metadata, dict) or not isinstance(session_id, str):
+                continue
+            typed_metadata = cast(dict[str, Any], metadata)
+            routed_id: Any = typed_metadata.get("getgatherBrowserId")
+            if isinstance(routed_id, str) and parse_routed_browser_id(routed_id) is not None:
+                routes[routed_id] = session_id
+                self._logical_sessions[routed_id] = session_id
+        return routes
+
     def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
         # The connectUrl is a single browser's socket; the router namespaces its target ids by
         # browser_id so the devtools route can route /devtools/{browser_id@page_id} back here.
@@ -357,6 +434,9 @@ class BrowserbaseBackend:
         # clear the local id -> connectUrl mapping, regardless of whether the upstream call
         # succeeds (a 404 means the session is already gone, which is the desired state).
         self._sessions.pop(browser_id, None)
+        for logical_id, session_id in list(self._logical_sessions.items()):
+            if session_id == browser_id:
+                self._logical_sessions.pop(logical_id, None)
         try:
             headers = {"Content-Type": "application/json", "x-bb-api-key": _api_key()}
             body = {"status": "REQUEST_RELEASE"}

--- a/getgather/browsers/provider_race.py
+++ b/getgather/browsers/provider_race.py
@@ -7,6 +7,11 @@ from fastapi import WebSocket
 from loguru import logger
 
 from getgather.browsers.backend import BROWSER_SCOPE, Backend
+from getgather.browsers.route_id import (
+    BrowserRoute,
+    make_routed_browser_id,
+    parse_routed_browser_id,
+)
 from getgather.cdp_client import open_cdp_url
 from getgather.config import settings
 
@@ -14,12 +19,6 @@ CDP_READY_ATTEMPTS = 30
 CDP_READY_RETRY_SECONDS = 1.0
 CDP_OPEN_TIMEOUT_SECONDS = 10.0
 CDP_COMMAND_TIMEOUT_SECONDS = 10.0
-
-
-@dataclass(frozen=True)
-class _WinnerRoute:
-    backend: Backend
-    provider_browser_id: str
 
 
 @dataclass(frozen=True)
@@ -32,19 +31,22 @@ class _Candidate:
 
 
 class ProviderRaceBackend:
-    """Race configured browser providers and proxy the winner behind an opaque public id.
+    """Race configured browser providers and proxy the winner behind a routed public id.
 
-    Routes intentionally live in memory for the first experiment. A restart, or a follow-up
-    request landing on another server replica, loses the route. The public API never exposes the
-    provider name, provider browser id, or provider CDP URL.
+    The public ID carries a short provider code, so another process or replica can recover the
+    route from the provider without a shared database. Provider browser IDs and CDP URLs remain
+    internal.
     """
 
-    def __init__(self, fallback: Backend, providers: dict[str, Backend]) -> None:
+    def __init__(
+        self,
+        fallback: Backend,
+        providers: dict[str, Backend],
+    ) -> None:
         if len(providers) < 2:
             raise ValueError("BROWSER_PROVIDER_RACE requires at least two configured providers")
         self._fallback = fallback
         self._providers = providers
-        self._routes: dict[str, _WinnerRoute] = {}
         self._cleanup_tasks: set[asyncio.Task[None]] = set()
 
     @property
@@ -58,7 +60,7 @@ class ProviderRaceBackend:
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,
-    ) -> None:
+    ) -> str:
         """Create one candidate per provider and register the first CDP-ready winner."""
         race_started = time.monotonic()
         logger.info(f"Provider race started for {browser_id}: candidates={len(self._providers)}")
@@ -67,7 +69,7 @@ class ProviderRaceBackend:
                 self._create_ready_candidate(
                     provider,
                     provider_backend,
-                    browser_id,
+                    make_routed_browser_id(provider, browser_id),
                     origin_ip,
                     target_domain,
                     browser_type,
@@ -88,10 +90,7 @@ class ProviderRaceBackend:
         if winner is None:
             raise RuntimeError("No browser provider became CDP-ready")
 
-        self._routes[browser_id] = _WinnerRoute(
-            backend=winner.backend,
-            provider_browser_id=winner.provider_browser_id,
-        )
+        public_browser_id = make_routed_browser_id(winner.provider, browser_id)
         logger.info(
             f"Provider-race winner for {browser_id}: provider={winner.provider} "
             f"create_ms={winner.create_seconds * 1000:.0f} "
@@ -104,6 +103,7 @@ class ProviderRaceBackend:
         )
         self._cleanup_tasks.add(cleanup_task)
         cleanup_task.add_done_callback(self._cleanup_tasks.discard)
+        return public_browser_id
 
     async def _create_ready_candidate(
         self,
@@ -210,11 +210,24 @@ class ProviderRaceBackend:
                 f"error={type(e).__name__}"
             )
 
-    def _route(self, browser_id: str) -> tuple[Backend, str]:
-        route = self._routes.get(browser_id)
+    async def _route(
+        self, browser_id: str, *, resolve_provider_id: bool = True
+    ) -> tuple[Backend, str, BrowserRoute | None]:
+        route = parse_routed_browser_id(browser_id)
         if route is None:
-            return self._fallback, browser_id
-        return route.backend, route.provider_browser_id
+            return self._fallback, browser_id, None
+        provider_backend = self._providers.get(route.provider)
+        if provider_backend is None:
+            raise RuntimeError(f"Provider route cannot be resolved: {route.provider}")
+        provider_browser_id = route.browser_id
+        if route.provider == "browserbase" and resolve_provider_id:
+            from getgather.browsers.browserbase_browsers import BrowserbaseBackend
+
+            if isinstance(provider_backend, BrowserbaseBackend):
+                resolved_id = await provider_backend.resolve_session(route.browser_id)
+                if resolved_id is not None:
+                    provider_browser_id = resolved_id
+        return provider_backend, provider_browser_id, route
 
     async def shutdown(self) -> None:
         if self._cleanup_tasks:
@@ -234,44 +247,51 @@ class ProviderRaceBackend:
         target_domain: str | None,
         browser_type: str | None,
     ) -> dict[str, Any]:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(
+            browser_id, resolve_provider_id=False
+        )
         # Preserve a raced browser's provider affinity when /cdp auto-starts it after deletion.
-        # Browserbase may assign a fresh provider id, so refresh the internal route from the result.
+        # Browserbase attaches this routed id as metadata and may assign a fresh provider UUID.
         result = await provider_backend.create_browser(
             provider_browser_id, origin_ip, target_domain, browser_type
         )
-        route = self._routes.get(browser_id)
-        result_browser_id = result.get("browser_id")
-        if route is not None and isinstance(result_browser_id, str):
-            self._routes[browser_id] = _WinnerRoute(provider_backend, result_browser_id)
         return result
 
     async def get_browser(
         self, browser_id: str, origin_ip: str | None, target_domain: str | None
     ) -> dict[str, Any]:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         await provider_backend.get_browser(provider_browser_id, origin_ip, target_domain)
         return {"browser_id": browser_id, "status": "created"}
 
     async def delete_browser(self, browser_id: str) -> dict[str, Any]:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         await provider_backend.delete_browser(provider_browser_id)
-        # Keep the route as a tombstone. Falling through to the default backend after deletion can
-        # turn a subsequent GET into an upstream 500 or auto-start the id on a different provider.
         return {"browser_id": browser_id, "status": "deleted"}
 
     async def list_browser_ids(self, scope: BROWSER_SCOPE = "all") -> list[str]:
         fallback_ids = await self._fallback.list_browser_ids(scope)
-        hidden_ids = {route.provider_browser_id for route in self._routes.values()}
-        active_routes = {
-            browser_id
-            for browser_id, route in self._routes.items()
-            if await route.backend.browser_exists(route.provider_browser_id)
-        }
-        return sorted((set(fallback_ids) - hidden_ids) | active_routes)
+        browser_ids = set(fallback_ids)
+        for provider, provider_backend in self._providers.items():
+            if provider == "browserbase":
+                from getgather.browsers.browserbase_browsers import BrowserbaseBackend
+
+                if isinstance(provider_backend, BrowserbaseBackend):
+                    routes = await provider_backend.list_routed_sessions()
+                    browser_ids.difference_update(routes.values())
+                    browser_ids.update(routes)
+                    continue
+            provider_ids = await provider_backend.list_browser_ids(scope)
+            browser_ids.update(
+                provider_id
+                for provider_id in provider_ids
+                if (route := parse_routed_browser_id(provider_id)) is not None
+                and route.provider == provider
+            )
+        return sorted(browser_ids)
 
     async def browser_exists(self, browser_id: str) -> bool:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         return await provider_backend.browser_exists(provider_browser_id)
 
     async def cleanup_idle(self) -> list[str]:
@@ -286,7 +306,7 @@ class ProviderRaceBackend:
         return deleted
 
     async def get_cdp_base_url(self, browser_id: str) -> str:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         return await provider_backend.get_cdp_base_url(provider_browser_id)
 
     def cdp_websocket_base(self) -> None:
@@ -294,29 +314,34 @@ class ProviderRaceBackend:
         return None
 
     async def get_cdp_websocket_remote_url(self, browser_id: str) -> str | None:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         return await provider_backend.get_cdp_websocket_remote_url(provider_browser_id)
 
     def cdp_targets_need_namespacing(self, browser_id: str | None = None) -> bool:
         if browser_id is None:
             return self._fallback.cdp_targets_need_namespacing()
-        provider_backend, provider_browser_id = self._route(browser_id)
-        return provider_backend.cdp_targets_need_namespacing(provider_browser_id)
+        route = parse_routed_browser_id(browser_id)
+        if route is None:
+            return self._fallback.cdp_targets_need_namespacing(browser_id)
+        provider_backend = self._providers.get(route.provider)
+        if provider_backend is None:
+            raise RuntimeError(f"Provider route cannot be resolved: {route.provider}")
+        return provider_backend.cdp_targets_need_namespacing(route.browser_id)
 
     async def get_devtools_websocket_remote_url(
         self, client_ws: WebSocket, browser_id: str, page_id: str
     ) -> str | None:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         return await provider_backend.get_devtools_websocket_remote_url(
             client_ws, provider_browser_id, page_id
         )
 
     async def get_vnc_endpoint(self, browser_id: str) -> tuple[str, int] | None:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         return await provider_backend.get_vnc_endpoint(provider_browser_id)
 
     async def get_live_view_url(self, browser_id: str) -> str | None:
-        provider_backend, provider_browser_id = self._route(browser_id)
+        provider_backend, provider_browser_id, _route = await self._route(browser_id)
         return await provider_backend.get_live_view_url(provider_browser_id)
 
 

--- a/getgather/browsers/route_id.py
+++ b/getgather/browsers/route_id.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+
+PROVIDER_CODES = {"fly": "f", "daytona": "d", "browserbase": "b"}
+CODE_PROVIDERS = {code: provider for provider, code in PROVIDER_CODES.items()}
+ROUTED_BROWSER_ID_LENGTH = 9
+
+
+@dataclass(frozen=True)
+class BrowserRoute:
+    provider: str
+    browser_id: str
+
+
+def make_routed_browser_id(provider: str, generated_browser_id: str) -> str:
+    provider_code = PROVIDER_CODES.get(provider)
+    if provider_code is None:
+        raise ValueError(f"Unknown browser provider: {provider}")
+    if len(generated_browser_id) != ROUTED_BROWSER_ID_LENGTH or not generated_browser_id.startswith(
+        "B"
+    ):
+        raise ValueError("Expected a nine-character server-assigned browser ID")
+    return f"B{provider_code}{generated_browser_id[2:]}"
+
+
+def parse_routed_browser_id(browser_id: str) -> BrowserRoute | None:
+    if len(browser_id) != ROUTED_BROWSER_ID_LENGTH or not browser_id.startswith("B"):
+        return None
+    provider = CODE_PROVIDERS.get(browser_id[1])
+    return BrowserRoute(provider, browser_id) if provider is not None else None

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -233,8 +233,10 @@ async def create_browser_auto_endpoint(request: Request) -> dict[str, Any]:
         target_domain = request.headers.get("x-target-domains")
         browser_type = request.headers.get("x-browser-type")
         if isinstance(backend, ProviderRaceBackend):
-            browser_id = new_browser_id()
-            await backend.create_raced_browser(browser_id, origin_ip, target_domain, browser_type)
+            logical_browser_id = new_browser_id()
+            browser_id = await backend.create_raced_browser(
+                logical_browser_id, origin_ip, target_domain, browser_type
+            )
             cdp_url = str(request.url_for("cdp_browser_websocket_proxy", browser_id=browser_id))
             logger.info(f"Browser {browser_id} is CDP-ready.")
             # Preserve the existing create contract. cdp_url is additive; CDP readiness is an

--- a/tests/test_browserbase_backend.py
+++ b/tests/test_browserbase_backend.py
@@ -133,13 +133,71 @@ async def test_browserbase_create_browser_stores_connect_url_mapping(
     assert fake_client.create_call["url"] == BROWSERBASE_SESSIONS_URL
     assert fake_client.create_call["headers"]["x-bb-api-key"] == "test-key"
     assert fake_client.create_call["headers"]["Content-Type"] == "application/json"
-    assert fake_client.create_call["json"] == {"keepAlive": True}
+    assert fake_client.create_call["json"] == {
+        "keepAlive": True,
+        "userMetadata": {"getgatherBrowserId": "ignored-id"},
+    }
 
     # The id -> connectUrl mapping is stored for the CDP proxy to look up.
     assert await backend.get_cdp_websocket_remote_url(SESSION_ID) == CONNECT_URL
     assert await backend.get_cdp_websocket_remote_url("unknown") is None
     assert await backend.browser_exists(SESSION_ID) is True
     assert SESSION_ID in await backend.list_browser_ids()
+
+
+@pytest.mark.asyncio
+async def test_browserbase_recovers_session_from_provider_metadata(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "BROWSERBASE_API_KEY", "test-key")
+    get_calls: list[dict[str, Any]] = []
+
+    class RecoveryResponse:
+        def __init__(self, body: Any) -> None:
+            self._body = body
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> Any:
+            return self._body
+
+    class RecoveryClient:
+        async def __aenter__(self) -> "RecoveryClient":
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def get(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            params: dict[str, str] | None = None,
+        ) -> RecoveryResponse:
+            get_calls.append({"url": url, "headers": headers, "params": params})
+            if url == BROWSERBASE_SESSIONS_URL:
+                return RecoveryResponse([
+                    {
+                        "id": SESSION_ID,
+                        "status": "RUNNING",
+                        "updatedAt": "2026-08-19",
+                        "userMetadata": {"getgatherBrowserId": "Bbuxvstp6"},
+                    }
+                ])
+            return RecoveryResponse(SAMPLE_RESPONSE)
+
+    def recovery_client_factory(**kwargs: Any) -> RecoveryClient:
+        return RecoveryClient()
+
+    monkeypatch.setattr(httpx, "AsyncClient", recovery_client_factory)
+
+    backend = BrowserbaseBackend()
+    assert await backend.resolve_session("logical-id") == SESSION_ID
+    assert await backend.get_cdp_websocket_remote_url(SESSION_ID) == CONNECT_URL
+    assert get_calls[0]["params"] == {"q": "user_metadata['getgatherBrowserId']:'logical-id'"}
+    assert await backend.list_routed_sessions() == {"Bbuxvstp6": SESSION_ID}
 
 
 @pytest.mark.asyncio
@@ -176,6 +234,7 @@ async def test_browserbase_create_browser_attaches_residential_proxy(
     assert result == {"browser_id": SESSION_ID, "status": "created", "ip": None}
     assert fake_client.create_call["json"] == {
         "keepAlive": True,
+        "userMetadata": {"getgatherBrowserId": "bid"},
         "proxies": [{"type": "external", "server": proxy_url}],
     }
 
@@ -198,7 +257,10 @@ async def test_browserbase_create_browser_omits_proxies_without_proxy(
 
     backend = BrowserbaseBackend()
     await backend.create_browser("bid", "1.2.3.4", "amazon.com", None)
-    assert fake_client.create_call["json"] == {"keepAlive": True}
+    assert fake_client.create_call["json"] == {
+        "keepAlive": True,
+        "userMetadata": {"getgatherBrowserId": "bid"},
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider_race.py
+++ b/tests/test_provider_race.py
@@ -109,30 +109,26 @@ async def test_provider_race_routes_public_id_to_fastest_ready_provider(
     monkeypatch: MonkeyPatch,
 ) -> None:
     slow = _FakeBackend(create_delay=0.02, remote_url="wss://slow.invalid", namespacing=False)
-    fast = _FakeBackend(
-        provider_browser_id="provider-assigned-secret-id",
-        remote_url="wss://fast.invalid",
-    )
-    race = ProviderRaceBackend(slow, {"slow": slow, "fast": fast})
+    fast = _FakeBackend(remote_url="wss://fast.invalid")
+    race = ProviderRaceBackend(slow, {"fly": slow, "daytona": fast})
 
     async def ready(self: Any, provider_backend: _FakeBackend, browser_id: str) -> None:
         assert await provider_backend.get_cdp_websocket_remote_url(browser_id)
 
     monkeypatch.setattr(ProviderRaceBackend, "_wait_until_cdp_ready", ready)
 
-    await race.create_raced_browser("public-id", "1.2.3.4", "example.com", "chrome")
+    public_id = await race.create_raced_browser("Bpuxvstp6", "1.2.3.4", "example.com", "chrome")
 
-    assert await race.get_cdp_websocket_remote_url("public-id") == (
-        "wss://fast.invalid/provider-assigned-secret-id"
-    )
-    assert race.cdp_targets_need_namespacing("public-id") is True
-    assert await race.get_browser("public-id", None, None) == {
-        "browser_id": "public-id",
+    assert public_id == "Bduxvstp6"
+    assert await race.get_cdp_websocket_remote_url(public_id) == ("wss://fast.invalid/Bduxvstp6")
+    assert race.cdp_targets_need_namespacing(public_id) is True
+    assert await race.get_browser(public_id, None, None) == {
+        "browser_id": public_id,
         "status": "created",
     }
 
     await race.shutdown()
-    assert slow.deleted == ["public-id"]
+    assert slow.deleted == ["Bfuxvstp6"]
     assert fast.deleted == []
 
 
@@ -140,7 +136,7 @@ async def test_provider_race_routes_public_id_to_fastest_ready_provider(
 async def test_provider_race_cleans_failed_candidates(monkeypatch: MonkeyPatch) -> None:
     first = _FakeBackend(create_error=RuntimeError("create failed"))
     second = _FakeBackend()
-    race = ProviderRaceBackend(first, {"first": first, "second": second})
+    race = ProviderRaceBackend(first, {"fly": first, "daytona": second})
 
     async def never_ready(self: Any, provider_backend: _FakeBackend, browser_id: str) -> None:
         del provider_backend, browser_id
@@ -149,10 +145,10 @@ async def test_provider_race_cleans_failed_candidates(monkeypatch: MonkeyPatch) 
     monkeypatch.setattr(ProviderRaceBackend, "_wait_until_cdp_ready", never_ready)
 
     with pytest.raises(RuntimeError, match="No browser provider became CDP-ready"):
-        await race.create_raced_browser("public-id", None, None, None)
+        await race.create_raced_browser("Bpuxvstp6", None, None, None)
 
-    assert first.deleted == ["public-id"]
-    assert second.deleted == ["public-id"]
+    assert first.deleted == ["Bfuxvstp6"]
+    assert second.deleted == ["Bduxvstp6"]
 
 
 @pytest.mark.asyncio
@@ -160,32 +156,29 @@ async def test_deleted_winner_does_not_fall_through_to_fallback(monkeypatch: Mon
     fallback = _FakeBackend(
         remote_url="wss://fallback.invalid", create_error=RuntimeError("fallback used")
     )
-    winner = _FakeBackend(
-        provider_browser_id="provider-assigned-secret-id",
-        remote_url="wss://winner.invalid",
-    )
-    race = ProviderRaceBackend(fallback, {"fallback": fallback, "winner": winner})
+    winner = _FakeBackend(remote_url="wss://winner.invalid")
+    race = ProviderRaceBackend(fallback, {"fly": fallback, "daytona": winner})
 
     async def ready(self: Any, provider_backend: _FakeBackend, browser_id: str) -> None:
         assert await provider_backend.get_cdp_websocket_remote_url(browser_id)
 
     monkeypatch.setattr(ProviderRaceBackend, "_wait_until_cdp_ready", ready)
-    await race.create_raced_browser("public-id", None, None, None)
+    public_id = await race.create_raced_browser("Bpuxvstp6", None, None, None)
 
-    assert await race.delete_browser("public-id") == {
-        "browser_id": "public-id",
+    assert await race.delete_browser(public_id) == {
+        "browser_id": public_id,
         "status": "deleted",
     }
-    assert await race.browser_exists("public-id") is False
+    assert await race.browser_exists(public_id) is False
     with pytest.raises(BrowserNotFound):
-        await race.get_browser("public-id", None, None)
-    assert "public-id" not in await race.list_browser_ids()
+        await race.get_browser(public_id, None, None)
+    assert public_id not in await race.list_browser_ids()
     assert fallback.created == set()
 
     # Existing CDP auto-start semantics are retained, but the browser stays on its winning provider.
-    result = await race.create_browser("public-id", None, None, None)
-    assert result["browser_id"] == "provider-assigned-secret-id"
-    assert await race.browser_exists("public-id") is True
+    result = await race.create_browser(public_id, None, None, None)
+    assert result["browser_id"] == "Bduxvstp6"
+    assert await race.browser_exists(public_id) is True
     assert fallback.created == set()
 
     await race.shutdown()
@@ -195,15 +188,16 @@ def test_provider_race_create_response_contains_only_proxy_url(monkeypatch: Monk
     from getgather.browsers import router as router_module
 
     fallback = _FakeBackend()
-    race = ProviderRaceBackend(fallback, {"one": fallback, "two": _FakeBackend()})
+    race = ProviderRaceBackend(fallback, {"fly": fallback, "daytona": _FakeBackend()})
 
     async def fake_create_raced_browser(
         browser_id: str,
         origin_ip: str | None,
         target_domain: str | None,
         browser_type: str | None,
-    ) -> None:
+    ) -> str:
         del browser_id, origin_ip, target_domain, browser_type
+        return "Bduxvstp6"
 
     monkeypatch.setattr(race, "create_raced_browser", fake_create_raced_browser)
     monkeypatch.setattr(router_module, "backend", race)
@@ -215,8 +209,49 @@ def test_provider_race_create_response_contains_only_proxy_url(monkeypatch: Monk
 
     assert response.status_code == 200
     assert response.json() == {
-        "browser_id": "public-id",
-        "cdp_url": "ws://testserver/cdp/public-id",
+        "browser_id": "Bduxvstp6",
+        "cdp_url": "ws://testserver/cdp/Bduxvstp6",
         "status": "created",
     }
     assert "provider" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_provider_route_survives_process_boundary(monkeypatch: MonkeyPatch) -> None:
+    first_backend = _FakeBackend()
+    first = ProviderRaceBackend(
+        first_backend,
+        {"daytona": first_backend, "fly": _FakeBackend(create_delay=0.02)},
+    )
+
+    async def ready(self: Any, provider_backend: _FakeBackend, browser_id: str) -> None:
+        assert await provider_backend.get_cdp_websocket_remote_url(browser_id)
+
+    monkeypatch.setattr(ProviderRaceBackend, "_wait_until_cdp_ready", ready)
+    public_id = await first.create_raced_browser("Bpuxvstp6", None, None, None)
+
+    second_backend = _FakeBackend()
+    second_backend.created.add("Bduxvstp6")
+    second_fallback = _FakeBackend()
+    second = ProviderRaceBackend(
+        second_fallback,
+        {"daytona": second_backend, "fly": second_fallback},
+    )
+
+    assert await second.get_browser(public_id, None, None) == {
+        "browser_id": public_id,
+        "status": "created",
+    }
+    assert await second.get_cdp_websocket_remote_url(public_id) == (
+        "wss://provider.invalid/cdp/Bduxvstp6"
+    )
+    assert public_id in await second.list_browser_ids()
+    assert await second.delete_browser(public_id) == {
+        "browser_id": public_id,
+        "status": "deleted",
+    }
+    first_backend.created.clear()
+    assert await first.browser_exists(public_id) is False
+
+    await first.shutdown()
+    await second.shutdown()

--- a/tests/test_route_id.py
+++ b/tests/test_route_id.py
@@ -1,0 +1,23 @@
+import pytest
+
+from getgather.browsers.route_id import (
+    BrowserRoute,
+    make_routed_browser_id,
+    parse_routed_browser_id,
+)
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [("fly", "Bfuxvstp6"), ("daytona", "Bduxvstp6"), ("browserbase", "Bbuxvstp6")],
+)
+def test_routed_browser_id_keeps_short_public_contract(provider: str, expected: str) -> None:
+    browser_id = make_routed_browser_id(provider, "Bpuxvstp6")
+
+    assert browser_id == expected
+    assert parse_routed_browser_id(browser_id) == BrowserRoute(provider, expected)
+
+
+def test_non_routed_browser_id_is_left_for_the_fallback_backend() -> None:
+    assert parse_routed_browser_id("B9uxvstp6") is None
+    assert parse_routed_browser_id("named-browser") is None


### PR DESCRIPTION
## What this adds

Builds on #1458 by removing the process-local winner route map. Server-assigned raced browsers keep the existing nine-character ID shape while the second character records the winner:

- `Bf.......` — Fly / external Chrome Fleet
- `Bd.......` — Daytona
- `Bb.......` — Browserbase

GET, DELETE, CDP, DevTools, live-view, auto-start, and listing can therefore select the winning backend after a restart or replica hop without Redis.

## Browserbase recovery

Browserbase assigns its own UUID, so creation attaches the routed `Bb...` ID as `userMetadata.getgatherBrowserId`. On a local cache miss GetGather queries Browserbase by that metadata, fetches the active session and current `connectUrl`, then repopulates its local acceleration cache. Direct provider URLs remain internal.

## Contract and tradeoffs

- Response fields and the nine-character browser-ID length remain unchanged.
- The provider is intentionally visible in the second character, as agreed for this experiment.
- `Bf`, `Bd`, and `Bb` are reserved prefixes for server-assigned raced browsers.
- Recovery depends on the winning provider API and credentials remaining available.
- This does not make loser cleanup durable if the creating process crashes mid-race.

## Validation

- `make check`
- Unit suite: 157 passed, 30 deselected
- Focused coverage includes routed-ID parsing, tamper-free fallback behavior, process-boundary routing, provider-backed listing, Browserbase metadata recovery, delete, and same-provider auto-start.