### PR TITLE
fix(distill): reload on the amazon.com 503 error page, not just amazon.ca

### DIFF
--- a/getgather/zen_distill.py
+++ b/getgather/zen_distill.py
@@ -53,7 +53,7 @@ NETWORK_ERROR_PATTERNS = (
     "err-connection-closed",
     "err-empty-response",
     "err-http-protocol-error",
-    "amazon-something-error-ca",
+    "amazon-something-error",
 )
 
 


### PR DESCRIPTION
## Why

When Amazon serves its "Sorry! Something went wrong on our end" 503 page, `distill()` is supposed to reload once and retry before giving up. That only happened on `amazon.ca`.s.

## Verification

### The two patterns are the same page in two locales

Same `rb-error` code and same body text; only the selector differs, because each storefront
renders the 503 with different markup.

```console
$ cat getgather/mcp/patterns/amazon-something-error.html
<html rb-domain="amazon">
  <head>
    <title>Amazon Something Error</title>
  </head>
  <body>
    <h1
      rb-stop
      rb-error="something_error"
      rb-match-html="//div[@id='g']//a[contains(@href, 'cs_503_link')]"
    >
      Sorry! Something went wrong on our end. Please go back and try again or go to Amazon's home
      page.
    </h1>
  </body>
</html>

$ cat getgather/mcp/patterns/amazon-something-error-ca.html
<html rb-domain="amazon">
  <head>
    <title>Amazon Something Error</title>
  </head>

  <body>
    <h1
      rb-stop
      rb-error="something_error"
      rb-match="//img[contains(@alt, 'Please go back and try again or go to Amazon.ca')]"
    >
      Sorry! Something went wrong on our end. Please go back and try again or go to Amazon's home
      page.
    </h1>
  </body>
</html>
```

### Before: only the .ca variant reloaded. After: both do

```console
$ uv run python -  # evaluates NETWORK_ERROR_PATTERNS from origin/main vs HEAD
before (origin/main):
  RELOAD  /app/getgather/mcp/patterns/amazon-something-error-ca.html
  no-op   /app/getgather/mcp/patterns/amazon-something-error.html
after (HEAD):
  RELOAD  /app/getgather/mcp/patterns/amazon-something-error-ca.html
  RELOAD  /app/getgather/mcp/patterns/amazon-something-error.html
```