### PR TITLE
DON'T MERGED feat(daytona): log-only probe for what keeps sandboxes out of auto-stop

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -19,6 +19,7 @@ from zendriver.core._contradict import ContraDict
 from zendriver.core.config import Config
 from zendriver.core.connection import Connection, ProtocolException
 
+from getgather.browsers import daytona_probe
 from getgather.browsers.fleet_browsers import build_chromefleet_headers, call_chromefleet_api
 from getgather.config import FRIENDLY_CHARS, settings
 
@@ -164,6 +165,10 @@ async def _create_browser_from_cdp_websocket(
                 f"browser_id={browser_id}"
             )
     instance.id = browser_id  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+    # Nothing stops this handle unless a caller reaches terminate_remote_browser, and its CDP
+    # websocket stays open through the sandbox's preview proxy meanwhile. Record it so the probe
+    # can report which caller holds one open past Daytona's idle window.
+    daytona_probe.open_connection(browser_id, "zendriver-cdp")
     return instance
 
 
@@ -245,6 +250,7 @@ async def terminate_remote_browser(browser: zd.Browser) -> None:
     """Terminate an existing remote Chrome via ChromeFleet."""
     browser_id = cast(str, browser.id)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
     logger.info(f"Terminating ChromeFleet browser: {browser_id}")
+    daytona_probe.close_connection(browser_id, "zendriver-cdp")
     # no need to raise for error (which would fail the whole process)
     await call_chromefleet_api("DELETE", browser_id, timeout=1.0, retries=0, raise_for_status=False)
 

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -16,6 +16,7 @@ from fastapi import WebSocket
 from loguru import logger
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
+from getgather.browsers import daytona_probe
 from getgather.browsers.backend import (
     BROWSER_NAME_PREFIX,
     BROWSER_SCOPE,
@@ -80,6 +81,7 @@ async def _configure_sandbox_proxy(sandbox: AsyncSandbox, proxy_url: str) -> boo
         "while ! curl -s -o /dev/null -x http://localhost:8119 http://tinyproxy.stats; do sleep 0.1; done",
     ]
     for cmd in cmds:
+        daytona_probe.touch(_probe_id(sandbox), "exec:proxy-config")
         try:
             response = await sandbox.process.exec(cmd)
         except Exception as e:
@@ -98,6 +100,7 @@ async def _get_sandbox_public_ip(
 ) -> str | None:
     cmd = "curl -s --max-time 10 --proxy http://127.0.0.1:8119 https://ip.fly.dev"
     for attempt in range(1, retries + 1):
+        daytona_probe.touch(_probe_id(sandbox), "exec:ip-check", f"attempt={attempt}")
         try:
             response = await sandbox.process.exec(cmd)
             ip = response.result.strip() if response.exit_code == 0 else ""
@@ -154,6 +157,10 @@ def _browser_id_from_name(name: str) -> str:
     return name.removeprefix(BROWSER_NAME_PREFIX)
 
 
+def _probe_id(sandbox: AsyncSandbox) -> str:
+    return _browser_id_from_name(sandbox.name or "")
+
+
 class DaytonaBackend:
     """Launch a Daytona sandbox per browser on demand (no pool).
 
@@ -172,6 +179,7 @@ class DaytonaBackend:
         self.snapshot = snapshot
         self.client = AsyncDaytona(DaytonaConfig(api_key=api_key, api_url=api_url or None))
         self._locks: dict[str, asyncio.Lock] = {}
+        daytona_probe.enable(AUTO_STOP_MINUTES)
 
     @property
     def default_best_of_n(self) -> int:
@@ -216,6 +224,7 @@ class DaytonaBackend:
         self._locks.pop(browser_id, None)
         if sandbox is None:
             return {"status": "not found"}
+        daytona_probe.touch(browser_id, "sandbox.delete")
         await sandbox.delete()
         return {"status": "deleted"}
 
@@ -255,6 +264,7 @@ class DaytonaBackend:
         sandbox = await self._get(_sandbox_name(browser_id))
         if sandbox is None:
             raise BrowserNotFound(browser_id)
+        daytona_probe.touch(browser_id, "signed-url:cdp")
         signed = await sandbox.create_signed_preview_url(
             CDP_PORT, expires_in_seconds=SIGNED_URL_TTL_SECONDS
         )
@@ -312,6 +322,7 @@ class DaytonaBackend:
                 )
                 return None
 
+        daytona_probe.touch(browser_id, "signed-url:vnc", "live view handed out")
         signed = await sandbox.create_signed_preview_url(
             VNC_PORT, expires_in_seconds=SIGNED_URL_TTL_SECONDS
         )
@@ -328,11 +339,13 @@ class DaytonaBackend:
         # no post-start swap here.
         if sandbox.state != "started":
             logger.info(f"Starting Daytona sandbox {name} (state={sandbox.state})")
+            daytona_probe.touch(browser_id, "sandbox.start", f"from={sandbox.state}")
             await sandbox.start()
 
         return sandbox
 
     async def _get_info(self, sandbox: AsyncSandbox) -> dict[str, Any]:
+        daytona_probe.touch(_probe_id(sandbox), "signed-url:cdp")
         signed = await sandbox.create_signed_preview_url(
             CDP_PORT, expires_in_seconds=SIGNED_URL_TTL_SECONDS
         )
@@ -355,6 +368,7 @@ class DaytonaBackend:
             f"cp {CHROME_HISTORY_PATH} /tmp/cf-history.db && "
             "sqlite3 /tmp/cf-history.db 'select MAX(last_visit_time) from urls;'"
         )
+        daytona_probe.touch(_probe_id(sandbox), "exec:history-read")
         try:
             response = await sandbox.process.exec(command)
         except Exception as e:
@@ -375,6 +389,7 @@ class DaytonaBackend:
         return (chromium_time / 1_000_000) - CHROMIUM_EPOCH_OFFSET_SECONDS
 
     async def _get(self, name: str) -> AsyncSandbox | None:
+        daytona_probe.touch(_browser_id_from_name(name), "api.get")
         try:
             return await self.client.get(name)
         except DaytonaNotFoundError:
@@ -410,6 +425,7 @@ class DaytonaBackend:
             auto_delete_interval=TTL_MINUTES,
         )
         logger.info(f"Creating Daytona sandbox {name} from snapshot {self.snapshot}")
+        daytona_probe.touch(_browser_id_from_name(name), "sandbox.create")
         try:
             return await self.client.create(params, timeout=400)
         except DaytonaConflictError:

--- a/getgather/browsers/daytona_probe.py
+++ b/getgather/browsers/daytona_probe.py
@@ -1,0 +1,305 @@
+"""Log-only probe attributing what keeps Daytona sandboxes out of auto-stop.
+
+Daytona stops a sandbox after `AUTO_STOP_MINUTES` with no sandbox activity, and only a stopped
+sandbox is free. Billing data shows sandboxes running 20-46h continuously (billed hours == lifetime
+hours, ~0 stopped time), so something resets that idle clock every few minutes. This probe records
+who: every call this process makes into a sandbox, plus every long-lived connection it holds open
+through the sandbox's preview proxy (a CDP relay or a noVNC stream is activity even when no API call
+is made).
+
+It only reads process-local state and emits logs — no Daytona API calls of its own, no change to any
+lifecycle decision. Enabled by DaytonaBackend on construction, so other backends emit nothing.
+
+Logfire: filter `attributes->>'probe' = 'daytona'`; `daytona.probe.report` carries the verdict per
+browser, `daytona.probe.touch` / `daytona.probe.conn` the raw events.
+"""
+
+import sys
+import time
+from collections import deque
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from itertools import count
+
+from loguru import logger
+
+WINDOW_SECONDS = 2 * 60 * 60  # touch history retained per browser
+MAX_TOUCHES_PER_BROWSER = 500
+MAX_CALLER_FRAMES = 25  # cap the stack walk; the app-level caller is always near the top
+TOP_CALLERS = 3
+
+# Frames from these files are plumbing between the probe and the app code that triggered the touch.
+_TRANSPARENT_FILES = ("daytona_probe.py", "daytona_browsers.py", "contextlib.py")
+
+# Daytona's idle window, supplied by the backend via enable() (daytona_browsers.AUTO_STOP_MINUTES).
+# A sandbox whose consecutive touches never exceed it is, by definition, why it never auto-stops.
+_enabled = False
+_auto_stop_seconds = 15 * 60
+
+
+@dataclass(frozen=True)
+class _Touch:
+    at: float
+    op: str
+    caller: str
+
+
+@dataclass
+class _Conn:
+    browser_id: str
+    kind: str
+    caller: str
+    opened_at: float
+
+
+_touches: dict[str, deque[_Touch]] = {}
+_conns: dict[int, _Conn] = {}
+_conn_ids = count(1)
+
+
+def enable(auto_stop_minutes: int) -> None:
+    global _enabled, _auto_stop_seconds
+    _auto_stop_seconds = auto_stop_minutes * 60
+    if not _enabled:
+        _enabled = True
+        logger.info(f"Daytona probe enabled (auto_stop={auto_stop_minutes}m)")
+
+
+def _caller() -> str:
+    """Nearest frame outside the probe and the backend — the app code that triggered the touch."""
+    try:
+        frame = sys._getframe(2)  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    except ValueError:
+        return "unknown"
+    for _ in range(MAX_CALLER_FRAMES):
+        if frame is None:
+            break
+        filename = frame.f_code.co_filename
+        if not filename.endswith(_TRANSPARENT_FILES):
+            short = filename.rsplit("/", 1)[-1]
+            return f"{short}:{frame.f_lineno} {frame.f_code.co_name}"
+        frame = frame.f_back
+    return "unknown"
+
+
+def _record(browser_id: str, op: str, caller: str, now: float) -> tuple[int, float | None]:
+    history = _touches.setdefault(browser_id, deque(maxlen=MAX_TOUCHES_PER_BROWSER))
+    gap = now - history[-1].at if history else None
+    history.append(_Touch(at=now, op=op, caller=caller))
+    return len(history), gap
+
+
+def touch(browser_id: str, op: str, detail: str | None = None) -> None:
+    """Record one call this process made into `browser_id`'s sandbox."""
+    if not _enabled:
+        return
+    try:
+        now = time.time()
+        caller = _caller()
+        seen, gap = _record(browser_id, op, caller, now)
+        logger.debug(
+            f"[probe] touch {op} on {browser_id} from {caller}",
+            probe="daytona",
+            event="daytona.probe.touch",
+            browser_id=browser_id,
+            op=op,
+            detail=detail,
+            caller=caller,
+            since_prev_touch_s=round(gap, 1) if gap is not None else None,
+            touches_in_window=seen,
+        )
+    except Exception as e:  # a probe must never break the call it observes
+        logger.debug(f"[probe] touch failed: {type(e).__name__}: {e}")
+
+
+@contextmanager
+def connection(browser_id: str, kind: str) -> Generator[None]:
+    """Track a connection held open through the sandbox's preview proxy for its whole lifetime."""
+    if not _enabled:
+        yield
+        return
+    conn_id = next(_conn_ids)
+    caller = _caller()
+    opened_at = time.time()
+    try:
+        _conns[conn_id] = _Conn(
+            browser_id=browser_id, kind=kind, caller=caller, opened_at=opened_at
+        )
+        logger.info(
+            f"[probe] {kind} open on {browser_id} from {caller}",
+            probe="daytona",
+            event="daytona.probe.conn",
+            phase="open",
+            browser_id=browser_id,
+            kind=kind,
+            caller=caller,
+            open_connections=len(_conns),
+        )
+    except Exception as e:
+        logger.debug(f"[probe] conn open failed: {type(e).__name__}: {e}")
+    try:
+        yield
+    finally:
+        try:
+            _conns.pop(conn_id, None)
+            held = time.time() - opened_at
+            logger.info(
+                f"[probe] {kind} closed on {browser_id} after {held:.0f}s",
+                probe="daytona",
+                event="daytona.probe.conn",
+                phase="close",
+                browser_id=browser_id,
+                kind=kind,
+                caller=caller,
+                held_seconds=round(held, 1),
+                exceeded_auto_stop=held > _auto_stop_seconds,
+                open_connections=len(_conns),
+            )
+        except Exception as e:
+            logger.debug(f"[probe] conn close failed: {type(e).__name__}: {e}")
+
+
+def open_connection(browser_id: str, kind: str) -> int | None:
+    """Register a connection with no scope to close it (a zendriver Browser handle nothing stops).
+
+    Pair with `close_connection`; an unpaired call is the finding, not a leak in the probe — the
+    reporter surfaces its age every tick.
+    """
+    if not _enabled:
+        return None
+    try:
+        conn_id = next(_conn_ids)
+        caller = _caller()
+        _conns[conn_id] = _Conn(
+            browser_id=browser_id, kind=kind, caller=caller, opened_at=time.time()
+        )
+        logger.info(
+            f"[probe] {kind} open on {browser_id} from {caller}",
+            probe="daytona",
+            event="daytona.probe.conn",
+            phase="open",
+            browser_id=browser_id,
+            kind=kind,
+            caller=caller,
+            open_connections=len(_conns),
+        )
+        return conn_id
+    except Exception as e:
+        logger.debug(f"[probe] conn open failed: {type(e).__name__}: {e}")
+        return None
+
+
+def close_connection(browser_id: str, kind: str) -> None:
+    if not _enabled:
+        return
+    try:
+        match = next(
+            (
+                cid
+                for cid, conn in _conns.items()
+                if conn.browser_id == browser_id and conn.kind == kind
+            ),
+            None,
+        )
+        if match is None:
+            return
+        conn = _conns.pop(match)
+        held = time.time() - conn.opened_at
+        logger.info(
+            f"[probe] {kind} closed on {browser_id} after {held:.0f}s",
+            probe="daytona",
+            event="daytona.probe.conn",
+            phase="close",
+            browser_id=browser_id,
+            kind=kind,
+            caller=conn.caller,
+            held_seconds=round(held, 1),
+            exceeded_auto_stop=held > _auto_stop_seconds,
+            open_connections=len(_conns),
+        )
+    except Exception as e:
+        logger.debug(f"[probe] conn close failed: {type(e).__name__}: {e}")
+
+
+def _prune(now: float) -> None:
+    for browser_id in list(_touches):
+        history = _touches[browser_id]
+        while history and now - history[0].at > WINDOW_SECONDS:
+            history.popleft()
+        if not history:
+            del _touches[browser_id]
+
+
+def report() -> None:
+    """Emit one verdict per browser touched in the retained window. Reads local state only."""
+    if not _enabled:
+        return
+    try:
+        now = time.time()
+        _prune(now)
+        idle_window = _auto_stop_seconds
+
+        conns_by_browser: dict[str, list[_Conn]] = {}
+        for conn in _conns.values():
+            conns_by_browser.setdefault(conn.browser_id, []).append(conn)
+
+        keepalive_count = 0
+        for browser_id in set(_touches) | set(conns_by_browser):
+            history = list(_touches.get(browser_id, ()))
+            conns = conns_by_browser.get(browser_id, [])
+            observed = now - history[0].at if history else 0.0
+
+            gaps = [b.at - a.at for a, b in zip(history, history[1:])]
+            max_gap = max(gaps) if gaps else None
+            # Every gap inside the idle window means our own traffic, not the user's browser, is
+            # what stops this sandbox from ever auto-stopping.
+            touch_keepalive = observed > idle_window and all(g < idle_window for g in gaps)
+            conn_keepalive = any(now - c.opened_at > idle_window for c in conns)
+            if touch_keepalive or conn_keepalive:
+                keepalive_count += 1
+
+            by_op: dict[str, int] = {}
+            by_caller: dict[str, int] = {}
+            for t in history:
+                by_op[t.op] = by_op.get(t.op, 0) + 1
+                by_caller[t.caller] = by_caller.get(t.caller, 0) + 1
+            top_callers = dict(sorted(by_caller.items(), key=lambda kv: -kv[1])[:TOP_CALLERS])
+
+            logger.info(
+                f"[probe] {browser_id}: {len(history)} touches over {observed / 60:.0f}m, "
+                f"{len(conns)} open conn(s), "
+                f"keepalive={touch_keepalive or conn_keepalive}",
+                probe="daytona",
+                event="daytona.probe.report",
+                browser_id=browser_id,
+                touches=len(history),
+                observed_seconds=round(observed, 1),
+                max_gap_seconds=round(max_gap, 1) if max_gap is not None else None,
+                auto_stop_seconds=idle_window,
+                touch_keepalive=touch_keepalive,
+                conn_keepalive=conn_keepalive,
+                keepalive=touch_keepalive or conn_keepalive,
+                touches_by_op=by_op,
+                top_callers=top_callers,
+                open_connections=[
+                    {
+                        "kind": c.kind,
+                        "caller": c.caller,
+                        "age_seconds": round(now - c.opened_at, 1),
+                    }
+                    for c in conns
+                ],
+            )
+
+        logger.info(
+            f"[probe] {len(_touches)} browser(s) touched, "
+            f"{len(_conns)} open conn(s), {keepalive_count} keeping a sandbox alive",
+            probe="daytona",
+            event="daytona.probe.summary",
+            browsers_touched=len(_touches),
+            open_connections=len(_conns),
+            keepalive_browsers=keepalive_count,
+        )
+    except Exception as e:
+        logger.warning(f"[probe] report failed: {type(e).__name__}: {e}")

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -11,6 +11,7 @@ from fastapi.websockets import WebSocketState
 from loguru import logger
 from websockets.exceptions import ConnectionClosed
 
+from getgather.browsers import daytona_probe
 from getgather.browsers.backend import (
     Backend,
     BrowserNotFound,
@@ -148,6 +149,16 @@ def patch_cdp_target(message: str, browser_id: str) -> str:
 
 
 async def websocket_proxy(
+    client_ws: WebSocket, remote_url: str, browser_id: str, patch: bool = True
+) -> None:
+    # The probe wrapper is observation only: on Daytona this relay is a live connection through the
+    # sandbox's preview proxy, so how long it stays open is a candidate answer for "what keeps the
+    # sandbox from auto-stopping". See daytona_probe.
+    with daytona_probe.connection(browser_id, "cdp-relay"):
+        await _websocket_proxy(client_ws, remote_url, browser_id, patch)
+
+
+async def _websocket_proxy(
     client_ws: WebSocket, remote_url: str, browser_id: str, patch: bool = True
 ) -> None:
     # `patch` rewrites target ids to namespace them by browser_id (local backends multiplex many

--- a/getgather/main.py
+++ b/getgather/main.py
@@ -16,6 +16,7 @@ from fastapi.staticfiles import StaticFiles
 from loguru import logger
 
 from getgather.browser import create_remote_browser, terminate_remote_browser
+from getgather.browsers import daytona_probe
 from getgather.browsers.router import backend, router as browsers_router
 from getgather.config import PROJECT_DIR, settings
 from getgather.logs import MCPLoggingContextMiddleware
@@ -53,6 +54,8 @@ async def lifespan(app: FastAPI):
                     await backend.cleanup_idle()
                 except Exception as e:
                     logger.error(f"Idle cleanup failed: {e}")
+                # Reads process-local probe state only; issues no backend calls.
+                daytona_probe.report()
 
     background_task = asyncio.create_task(timer_loop())
 


### PR DESCRIPTION
## Why

Daytona billing data (200 sandboxes, \$181.39) shows **58 sandboxes lived >1h and cost \$66.86**, and among those the average *stopped* time is **0.06h** — `Billed Running (h)` ≈ `Lifetime (h)`. `auto_delete_interval` works fine (142 auto-deletes); what doesn't is `auto_stop_interval`: something resets the 15-minute idle clock continuously, for up to 46 hours.

This adds a probe to find out which function, before changing any behavior.

## What it records

`getgather/browsers/daytona_probe.py`:

- **Sandbox touches** — every call this process makes into a sandbox: `process.exec` (history read, proxy config, IP check), signed preview URLs, `start`, `create`, `delete`, `api.get` — each attributed to the nearest app-level caller frame (`dpage.py:211 poll`, etc).
- **Long-lived connections through the preview proxy** — the CDP relay in `websocket_proxy`, and zendriver `Browser` handles, which nothing closes unless a caller reaches `terminate_remote_browser`. An open socket is sandbox activity even when no API call is made, so this is the candidate an exec-only probe would miss.

Every 5 minutes the existing background loop emits one report per browser: touch counts by op, top callers, max gap between touches, open connections and their ages, and a **keepalive verdict** (no gap ever exceeded the idle window, or a connection outlived it).

## Log-only

- No Daytona API calls of its own; the reporter reads process-local state.
- No lifecycle decision changed; the diff is 36 added lines across 4 files plus the new module.
- Disabled unless `DaytonaBackend` is constructed in the process, so podman/browserbase deployments emit nothing.
- Reports and connection open/close are INFO; per-touch events are DEBUG (aggregates ride in the report).
- Not tracked: the noVNC live view. That iframe connects the viewer's browser straight to Daytona's preview proxy, so this process only sees the URL handout.

## Reading it

In Logfire, filter `attributes->>'probe' = 'daytona'`:
- `daytona.probe.report` — per-browser verdict, `top_callers` names the culprit
- `daytona.probe.conn` — `held_seconds`, `exceeded_auto_stop`
- `daytona.probe.summary` — `keepalive_browsers` per tick

## Checks

`make check` clean (ruff, pyright strict, ty, prettier, yamlfix); `make test` 134 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)