### PR TITLE
fix(target): new ONLINE order-history contract, stable OTP selector

### DIFF
--- a/getgather/mcp/patterns/target-signin-otp-2.html
+++ b/getgather/mcp/patterns/target-signin-otp-2.html
@@ -12,7 +12,7 @@
       type="tel"
       placeholder="Enter your code"
       data-testid="otp"
-      rb-match="input.styles_input__8Dfzg"
+      rb-match="//input[contains(@class, 'styles_input__') and @type='tel']"
     />
     <button type="submit" data-testid="submit" rb-match="button#verify">Verify</button>
   </body>

--- a/getgather/mcp/patterns/target-signin-otp-invalid.html
+++ b/getgather/mcp/patterns/target-signin-otp-invalid.html
@@ -14,7 +14,7 @@
       type="tel"
       placeholder="Enter your code"
       data-testid="otp"
-      rb-match="input.styles_input__8Dfzg"
+      rb-match="//input[contains(@class, 'styles_input__') and @type='tel']"
     />
     <button type="submit" data-testid="submit" rb-match="button#verify">Verify</button>
   </body>

--- a/getgather/mcp/patterns/target-signin-otp.html
+++ b/getgather/mcp/patterns/target-signin-otp.html
@@ -12,7 +12,7 @@
       type="tel"
       placeholder="Enter your code"
       data-testid="otp"
-      rb-match="input.styles_input__8Dfzg"
+      rb-match="//input[contains(@class, 'styles_input__') and @type='tel']"
     />
     <button type="submit" data-testid="submit" rb-match="button#verify">Verify</button>
   </body>

--- a/getgather/mcp/target.py
+++ b/getgather/mcp/target.py
@@ -15,32 +15,72 @@ BASE_URL = "https://www.target.com"
 API_BASE = "https://api.target.com"
 LIST_PAGE_SIZE = 10
 
-_LIST_URL = (
+_FETCH_TIMEOUT_SECONDS = 30.0
+_FETCH_RETRIES = 3
+
+# ONLINE now returns fully-populated orders from a single call; STORE still uses
+# the legacy lean list + per-order detail fetch.
+_ONLINE_LIST_URL = (
+    f"{API_BASE}/post_orders/v1/orders/history"
+    f"?page_size={LIST_PAGE_SIZE}&order_purchase_type=ONLINE"
+)
+_STORE_LIST_URL = (
     f"{API_BASE}/guest_order_aggregations/v1/order_history"
     f"?page_size={LIST_PAGE_SIZE}&pending_order=true&shipt_status=true"
+    f"&order_purchase_type=STORE"
 )
 _DETAIL_BASE = f"{API_BASE}/post_orders/v1"
 
-_ORDER_ID_FIELD = {"ONLINE": "order_number", "STORE": "store_receipt_id"}
+# Matched against the app's own natural request so the x-api-key header can be read off it.
+_LIST_PATH_MARKERS = (
+    "/post_orders/v1/orders/history",
+    "/guest_order_aggregations/v1/order_history",
+)
+
+_JS_HEADERS = """
+    'accept': 'application/json',
+    'origin': 'https://www.target.com',
+    'referer': 'https://www.target.com/',
+"""
 
 
-def _detail_url(order_purchase_type: str, identifier: str) -> str:
-    if order_purchase_type == "STORE":
-        return f"{_DETAIL_BASE}/orders/{identifier}/store"
-    return f"{_DETAIL_BASE}/{identifier}"
+def _list_url(order_purchase_type: str, page_number: int) -> str:
+    base = _STORE_LIST_URL if order_purchase_type == "STORE" else _ONLINE_LIST_URL
+    return f"{base}&page_number={page_number}"
 
 
-async def _fetch_list_page(
-    page: zd.Tab, page_number: int, x_api_key: str, order_purchase_type: str
-) -> dict[str, Any]:
-    url = f"{_LIST_URL}&order_purchase_type={order_purchase_type}&page_number={page_number}"
+async def _capture_api_key(page: zd.Tab) -> str:
+    """Read x-api-key off the page's own order-history request (it rotates, so never hardcode)."""
+    markers_json = json.dumps(list(_LIST_PATH_MARKERS))
     js_code = f"""
         (async () => {{
-            const res = await fetch('{url}', {{
+            const markers = {markers_json};
+            const args = await new Promise(resolve => {{
+                const originalFetch = window.fetch;
+                window.fetch = function (...args) {{
+                    const url = typeof args[0] === 'string' ? args[0] : (args[0] && args[0].url) || '';
+                    if (markers.some(m => url.includes(m))) {{
+                        window.fetch = originalFetch;
+                        resolve(args);
+                    }}
+                    return originalFetch.apply(this, args);
+                }};
+            }});
+            const headers = (args[1] || {{}}).headers || {{}};
+            return headers['x-api-key'] || headers['X-Api-Key'] || '';
+        }})()
+    """
+    return str(await page.evaluate(js_code, True))
+
+
+async def _fetch_json(page: zd.Tab, url: str, x_api_key: str) -> dict[str, Any]:
+    js_code = f"""
+        (async () => {{
+            const res = await fetch({json.dumps(url)}, {{
                 credentials: 'include',
                 headers: {{
-                    'accept': 'application/json',
-                    'x-api-key': '{x_api_key}',
+                    {_JS_HEADERS}
+                    'x-api-key': {json.dumps(x_api_key)},
                 }},
             }});
             if (!res.ok) throw new Error('HTTP ' + res.status);
@@ -50,26 +90,49 @@ async def _fetch_list_page(
     return cast(dict[str, Any], await page.evaluate(js_code, True))
 
 
-async def _fetch_all_details(
-    page: zd.Tab, order_purchase_type: str, identifiers: list[str], x_api_key: str
+async def _fetch_list_page(
+    page: zd.Tab, page_number: int, x_api_key: str, order_purchase_type: str
+) -> dict[str, Any]:
+    """Fetch one list page, retrying on timeout/error (the request can hang if the page stalls)."""
+    url = _list_url(order_purchase_type, page_number)
+    for attempt in range(1, _FETCH_RETRIES + 1):
+        try:
+            return await asyncio.wait_for(
+                _fetch_json(page, url, x_api_key), timeout=_FETCH_TIMEOUT_SECONDS
+            )
+        except Exception as exc:  # noqa: BLE001 - retry on timeout or JS-side failure
+            logger.warning(
+                "Target list fetch attempt %s/%s failed type=%s page=%s: %s",
+                attempt,
+                _FETCH_RETRIES,
+                order_purchase_type,
+                page_number,
+                exc,
+            )
+    raise RuntimeError(
+        f"Target: list fetch failed after {_FETCH_RETRIES} attempts "
+        f"type={order_purchase_type} page={page_number}"
+    )
+
+
+async def _fetch_all_store_details(
+    page: zd.Tab, identifiers: list[str], x_api_key: str
 ) -> list[dict[str, Any]]:
-    urls = [_detail_url(order_purchase_type, identifier) for identifier in identifiers]
-    urls_json = json.dumps(urls)
+    urls = [f"{_DETAIL_BASE}/orders/{identifier}/store" for identifier in identifiers]
     js_code = f"""
         (async () => {{
-            const urls = {urls_json};
-            const results = await Promise.all(urls.map(u =>
+            const urls = {json.dumps(urls)};
+            return await Promise.all(urls.map(u =>
                 fetch(u, {{
                     credentials: 'include',
                     headers: {{
-                        'accept': 'application/json',
-                        'x-api-key': '{x_api_key}',
+                        {_JS_HEADERS}
+                        'x-api-key': {json.dumps(x_api_key)},
                     }},
                 }})
                 .then(r => r.ok ? r.json() : null)
                 .catch(() => null)
             ));
-            return results;
         }})()
     """
     raw = await page.evaluate(js_code, True)
@@ -87,64 +150,47 @@ async def _get_purchases(
     )
 
     await zen_navigate_with_retry(page, f"{BASE_URL}/orders", wait_for_ready=False)
-    intercept_result = cast(
-        dict[str, Any],
-        await page.evaluate(
-            """
-        (async () => {
-            const httpRequest = await new Promise(resolve => {
-                const originalFetch = window.fetch;
-                window.fetch = async function (...args) {
-                    if (typeof args[0] === 'string' && args[0].includes('/guest_order_aggregations/v1/order_history')) {
-                        window.fetch = originalFetch;
-                        resolve(args);
-                    }
-                    return originalFetch.apply(this, args);
-                };
-            });
-            const res = await fetch(httpRequest[0], {...httpRequest[1], credentials: 'include'});
-            return {
-                page1: await res.json(),
-                x_api_key: (httpRequest[1].headers || {})['x-api-key'] ?? ''
-            };
-        })()
-        """,
-            True,
-        ),
-    )
 
-    x_api_key = str(intercept_result.get("x_api_key", ""))
+    try:
+        x_api_key = await asyncio.wait_for(_capture_api_key(page), timeout=_FETCH_TIMEOUT_SECONDS)
+    except TimeoutError as exc:
+        raise RuntimeError(
+            "Target: x-api-key capture timed out - no order-history request fired "
+            "(user is likely not signed in)"
+        ) from exc
 
-    # The page's own load only fires the ONLINE-type request (intercepted above), so
-    # only that case can reuse it as page 1 for free; STORE always needs a manual fetch.
-    if order_purchase_type == "ONLINE" and page_number == 1:
-        page_data = cast(dict[str, Any], intercept_result.get("page1", {}))
-    else:
-        page_data = await _fetch_list_page(page, page_number, x_api_key, order_purchase_type)
+    if not x_api_key:
+        raise RuntimeError(
+            f"Target: x-api-key missing from order-history request type={order_purchase_type}"
+        )
 
-    total_pages = int(page_data.get("total_pages", 1))
-    orders = page_data.get("orders", [])
-
+    page_data = await _fetch_list_page(page, page_number, x_api_key, order_purchase_type)
+    orders = cast(list[dict[str, Any]], page_data.get("orders", []))
     pagination = {
         "current_page": page_number,
-        "total_pages": total_pages,
+        "total_pages": int(page_data.get("total_pages", 1)),
         "page_size": LIST_PAGE_SIZE,
     }
 
-    id_field = _ORDER_ID_FIELD[order_purchase_type]
-    identifiers = [o[id_field] for o in orders if id_field in o]
+    # ONLINE list response is already fully populated - no per-order detail fetch.
+    if order_purchase_type == "ONLINE":
+        logger.info(f"Target ONLINE purchases fetched count={len(orders)} page={page_number}")
+        return {"target_purchases": orders, "pagination": pagination}
 
+    identifiers = [o["store_receipt_id"] for o in orders if "store_receipt_id" in o]
     if not identifiers:
+        logger.info(f"Target STORE list empty page={page_number}")
         return {"target_purchases": [], "pagination": pagination}
 
     try:
         details = await asyncio.wait_for(
-            _fetch_all_details(page, order_purchase_type, identifiers, x_api_key), timeout=60.0
+            _fetch_all_store_details(page, identifiers, x_api_key), timeout=60.0
         )
     except asyncio.TimeoutError:
         logger.warning("Target: detail fetch timed out")
         details = []
 
+    logger.info(f"Target STORE purchases fetched count={len(details)} page={page_number}")
     return {"target_purchases": details, "pagination": pagination}
 
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,6 +1,14 @@
-"""Unit tests for Target purchase-detail URL/identifier resolution.
+"""Guards Target's order-history extraction after the ONLINE endpoint change.
 
-Pure-function tests only — no browser or live server involved.
+_get_purchases navigates to /orders, captures the x-api-key off the page's own
+order-history request, then fetches the list page itself (with retry + per-attempt
+timeout).
+
+ONLINE uses /post_orders/v1/orders/history and its response is already fully
+populated, so its "orders" array is returned verbatim - no detail fetch.
+STORE keeps the legacy lean list + per-order /orders/{id}/store detail fetch.
+
+Pure-function / fake-tab tests only - no browser or live server involved.
 """
 
 # Importing declarative_mcp runs create_declarative_mcp_tools() at import time,
@@ -11,120 +19,112 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock
 
+import pytest
+
 from getgather.mcp import declarative_mcp
 
 assert "target" in declarative_mcp.MCPTool.registry
 
 import getgather.mcp.target as target_module  # noqa: E402
 from getgather.mcp.target import (  # noqa: E402
-    _DETAIL_BASE,  # pyright: ignore[reportPrivateUsage]
-    _ORDER_ID_FIELD,  # pyright: ignore[reportPrivateUsage]
-    _detail_url,  # pyright: ignore[reportPrivateUsage]
-    _fetch_all_details,  # pyright: ignore[reportPrivateUsage]
     _get_purchases,  # pyright: ignore[reportPrivateUsage]
 )
 
 
-def test_online_detail_url_is_unchanged():
-    url = _detail_url("ONLINE", "1234567890")
-    assert url == f"{_DETAIL_BASE}/1234567890"
-
-
-def test_store_detail_url_has_orders_and_store_suffix():
-    url = _detail_url("STORE", "5228-0324-0172-6691")
-    assert url == f"{_DETAIL_BASE}/orders/5228-0324-0172-6691/store"
-
-
-def test_order_id_field_mapping():
-    assert _ORDER_ID_FIELD == {"ONLINE": "order_number", "STORE": "store_receipt_id"}
-
-
 class _FakeTab:
-    """Captures the JS handed to evaluate() and returns a canned result."""
+    """Returns queued evaluate() results in order, recording the JS handed to each call."""
 
-    def __init__(self, result: Any) -> None:
-        self.result = result
-        self.last_js_code: str | None = None
+    def __init__(self, results: list[Any]) -> None:
+        self.results = list(results)
+        self.evaluate_calls: list[str] = []
 
     async def evaluate(self, js_code: str, return_by_value: bool = True) -> Any:
-        self.last_js_code = js_code
-        return self.result
-
-
-def test_fetch_all_details_builds_store_url_in_js():
-    fake_page = _FakeTab([{"store_receipt_id": "R1", "unit_price": "9.99"}])
-    result = asyncio.run(
-        _fetch_all_details(fake_page, "STORE", ["5228-0324-0172-6691"], "test-api-key")  # type: ignore[arg-type]
-    )
-    assert result == [{"store_receipt_id": "R1", "unit_price": "9.99"}]
-    assert fake_page.last_js_code is not None
-    assert "/orders/5228-0324-0172-6691/store" in fake_page.last_js_code
-
-
-def test_fetch_all_details_builds_online_url_in_js():
-    fake_page = _FakeTab([{"order_number": "O1"}])
-    result = asyncio.run(
-        _fetch_all_details(fake_page, "ONLINE", ["1234567890"], "test-api-key")  # type: ignore[arg-type]
-    )
-    assert result == [{"order_number": "O1"}]
-    assert fake_page.last_js_code is not None
-    assert "post_orders/v1/1234567890" in fake_page.last_js_code
-    assert "/orders/" not in fake_page.last_js_code
+        self.evaluate_calls.append(js_code)
+        return self.results.pop(0)
 
 
 async def _run_get_purchases(
     monkeypatch: Any, order_purchase_type: str, orders: list[dict[str, Any]]
 ):
     monkeypatch.setattr(target_module, "zen_navigate_with_retry", AsyncMock(return_value=None))
-
-    # ONLINE + page 1 reuses this intercepted page1 payload directly (see _get_purchases);
-    # every other case calls the mocked _fetch_list_page below instead.
-    intercept_page = _FakeTab({
-        "page1": {"orders": orders, "total_pages": 1},
-        "x_api_key": "test-api-key",
-    })
-
-    fetch_list_page_mock = AsyncMock(return_value={"orders": orders, "total_pages": 1})
-    monkeypatch.setattr(target_module, "_fetch_list_page", fetch_list_page_mock)
-
-    fetch_all_details_mock = AsyncMock(return_value=[{**o, "unit_price": "9.99"} for o in orders])
-    monkeypatch.setattr(target_module, "_fetch_all_details", fetch_all_details_mock)
-
-    result = await _get_purchases(intercept_page, 1, order_purchase_type)  # type: ignore[arg-type]
-    return result, fetch_all_details_mock
+    tab = _FakeTab(["test-api-key", {"orders": orders, "total_pages": 1}])
+    result = await _get_purchases(tab, 1, order_purchase_type)  # type: ignore[arg-type]
+    return result, tab
 
 
-def test_store_purchases_now_hit_detail_fetch(monkeypatch: Any):
-    orders = [{"store_receipt_id": "R1"}, {"store_receipt_id": "R2"}]
-    result, fetch_all_details_mock = asyncio.run(_run_get_purchases(monkeypatch, "STORE", orders))
+def test_key_capture_watches_both_list_endpoints(monkeypatch: Any):
+    _result, tab = asyncio.run(_run_get_purchases(monkeypatch, "ONLINE", []))
 
-    # full replace: target_purchases comes from the detail fetch, not the raw list orders
-    assert result["target_purchases"] == [
-        {"store_receipt_id": "R1", "unit_price": "9.99"},
-        {"store_receipt_id": "R2", "unit_price": "9.99"},
-    ]
-    fetch_all_details_mock.assert_awaited_once()
-    call_args = fetch_all_details_mock.await_args
-    assert call_args is not None
-    _page, order_purchase_type, identifiers, _x_api_key = call_args.args
-    assert order_purchase_type == "STORE"
-    assert identifiers == ["R1", "R2"]
+    capture_js = tab.evaluate_calls[0]
+    assert "/post_orders/v1/orders/history" in capture_js
+    assert "/guest_order_aggregations/v1/order_history" in capture_js
+    assert "x-api-key" in capture_js
 
 
-def test_online_purchases_still_use_order_number(monkeypatch: Any):
-    orders = [{"order_number": "O1"}]
-    result, fetch_all_details_mock = asyncio.run(_run_get_purchases(monkeypatch, "ONLINE", orders))
+def test_online_uses_new_post_orders_history_endpoint_with_captured_key(monkeypatch: Any):
+    _result, tab = asyncio.run(_run_get_purchases(monkeypatch, "ONLINE", []))
 
-    assert result["target_purchases"] == [{"order_number": "O1", "unit_price": "9.99"}]
-    call_args = fetch_all_details_mock.await_args
-    assert call_args is not None
-    _page, order_purchase_type, identifiers, _x_api_key = call_args.args
-    assert order_purchase_type == "ONLINE"
-    assert identifiers == ["O1"]
+    list_js = tab.evaluate_calls[1]
+    assert "api.target.com/post_orders/v1/orders/history" in list_js
+    assert "order_purchase_type=ONLINE" in list_js
+    assert "test-api-key" in list_js
+    assert "credentials: 'include'" in list_js
+    assert "https://www.target.com/" in list_js
+
+
+def test_online_returns_list_orders_verbatim_without_detail_fetch(monkeypatch: Any):
+    order = {"order_number": "123", "order_lines": [{"item": {"tcin": "t1"}}]}
+    result, tab = asyncio.run(_run_get_purchases(monkeypatch, "ONLINE", [order]))
+
+    assert result["target_purchases"] == [order]
+    # Only key-capture + list fetch ran - no detail fetch.
+    assert len(tab.evaluate_calls) == 2
+
+
+def test_store_still_fetches_detail_per_order(monkeypatch: Any):
+    monkeypatch.setattr(target_module, "zen_navigate_with_retry", AsyncMock(return_value=None))
+    tab = _FakeTab([
+        "test-api-key",
+        {"orders": [{"store_receipt_id": "R1"}], "total_pages": 1},
+        [{"store_receipt_id": "R1", "unit_price": "9.99"}],
+    ])
+
+    result = asyncio.run(_get_purchases(tab, 1, "STORE"))  # type: ignore[arg-type]
+
+    assert result["target_purchases"] == [{"store_receipt_id": "R1", "unit_price": "9.99"}]
+    detail_js = tab.evaluate_calls[2]
+    assert "orders/R1/store" in detail_js
 
 
 def test_store_with_no_orders_skips_detail_fetch(monkeypatch: Any):
-    result, fetch_all_details_mock = asyncio.run(_run_get_purchases(monkeypatch, "STORE", []))
+    result, tab = asyncio.run(_run_get_purchases(monkeypatch, "STORE", []))
 
     assert result["target_purchases"] == []
-    fetch_all_details_mock.assert_not_awaited()
+    # Only key-capture + list fetch ran - no orders means no detail fetch.
+    assert len(tab.evaluate_calls) == 2
+
+
+def test_missing_api_key_raises(monkeypatch: Any):
+    monkeypatch.setattr(target_module, "zen_navigate_with_retry", AsyncMock(return_value=None))
+    tab = _FakeTab(["", {"orders": [], "total_pages": 1}])
+
+    with pytest.raises(RuntimeError, match="x-api-key missing"):
+        asyncio.run(_get_purchases(tab, 1, "ONLINE"))  # type: ignore[arg-type]
+
+
+def test_list_fetch_retries_then_raises_on_repeated_failure(monkeypatch: Any):
+    monkeypatch.setattr(target_module, "zen_navigate_with_retry", AsyncMock(return_value=None))
+
+    class _FailingTab(_FakeTab):
+        async def evaluate(self, js_code: str, return_by_value: bool = True) -> Any:
+            self.evaluate_calls.append(js_code)
+            if len(self.evaluate_calls) == 1:
+                return "test-api-key"
+            raise RuntimeError("HTTP 500")
+
+    tab = _FailingTab([])
+    with pytest.raises(RuntimeError, match="list fetch failed after"):
+        asyncio.run(_get_purchases(tab, 1, "ONLINE"))  # type: ignore[arg-type]
+
+    # 1 key-capture call + 3 retried list-fetch attempts.
+    assert len(tab.evaluate_calls) == 1 + target_module._FETCH_RETRIES  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
## Summary
- **`getgather/mcp/target.py`** — ONLINE now hits the new `post_orders/v1/orders/history` endpoint and returns fully-populated orders in one call (no per-order detail fetch); `x-api-key` captured by watching for either list endpoint's own request instead of reusing an intercepted response as page 1; list fetch retries 3x with a 30s per-attempt timeout and raises after exhaustion; a missing key raises instead of degrading silently; STORE untouched (legacy list + per-order detail fetch)
- **`getgather/mcp/patterns/target-signin-otp.html`** — OTP input match switched from hardcoded CSS-module hash to a stable XPath on the class prefix
- **`getgather/mcp/patterns/target-signin-otp-2.html`** — same OTP selector fix
- **`getgather/mcp/patterns/target-signin-otp-invalid.html`** — same OTP selector fix
- **`tests/test_target.py`** — rewritten for the new contract: dual-endpoint key capture, ONLINE new-endpoint verbatim-list, STORE detail fetch, empty-list skip, missing-key raise, retry-then-raise

## Test Plan
- `uv run pytest tests/test_target.py -q` — 7 passed
- `uv run pyright .` — 0 errors
- `uv run ty check` — passed
- `make check` (ruff check/format, yamlfix, prettier, pyright, ty, pattern testid check) — all green, ran via pre-push hook
- Not run live against Chrome Fleet: `get_purchases` (ONLINE, new endpoint) and `get_purchases_in_store` (STORE, unchanged flow) need a manual pass against a real signed-in Target account to confirm the new endpoint response shape and the OTP XPath match against the live page