### PR TITLE
fix: race between browser deletion and browser resurection

### DIFF
--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -12,6 +12,28 @@ from getgather.config import FRIENDLY_CHARS, settings
 # `chromium-abc`. Both local backends derive names and parse ids from this single prefix.
 BROWSER_NAME_PREFIX = "chromium-"
 
+RECENTLY_DELETED_SECONDS = 60.0
+_deleted_at: dict[str, float] = {}
+
+
+def mark_browser_deleting(browser_id: str) -> None:
+    """Remember `browser_id` as deleted. Call before awaiting the delete, not after."""
+    now = asyncio.get_running_loop().time()
+    for stale in [b for b, t in _deleted_at.items() if now - t > RECENTLY_DELETED_SECONDS]:
+        del _deleted_at[stale]
+    _deleted_at[browser_id] = now
+
+
+def was_browser_recently_deleted(browser_id: str) -> bool:
+    deleted_at = _deleted_at.get(browser_id)
+    if deleted_at is None:
+        return False
+    if asyncio.get_running_loop().time() - deleted_at > RECENTLY_DELETED_SECONDS:
+        del _deleted_at[browser_id]
+        return False
+    return True
+
+
 # Which browsers a listing should include. `all` is the full inventory, including ones a
 # backend can resume on demand; `live` is only those able to serve CDP right now.
 BROWSER_SCOPE = Literal["all", "live"]
@@ -169,6 +191,7 @@ async def _cleanup_losers(backend: _CleanupBackend, ids: list[str], *, winner_id
         for _ in range(8):
             if await backend.browser_exists(browser_id):
                 try:
+                    mark_browser_deleting(browser_id)
                     await backend.delete_browser(browser_id)
                     logger.info(f"Best-of-N: deleted losing candidate {browser_id}")
                     deleted = True
@@ -180,6 +203,7 @@ async def _cleanup_losers(backend: _CleanupBackend, ids: list[str], *, winner_id
             # Never confirmed it existed; still issue one idempotent delete so per-id backend
             # state (e.g. Daytona's lock dict) is cleaned up. Swallow the not-found failure.
             try:
+                mark_browser_deleting(browser_id)
                 await backend.delete_browser(browser_id)
             except Exception as e:
                 logger.debug(f"Best-of-N: final delete for loser {browser_id} failed: {e}")

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -16,7 +16,9 @@ from getgather.browsers.backend import (
     BrowserNotFound,
     best_of_n,
     create_backend,
+    mark_browser_deleting,
     new_browser_id,
+    was_browser_recently_deleted,
 )
 from getgather.cdp_client import CDPClient, open_cdp_url
 from getgather.config import settings
@@ -272,6 +274,7 @@ async def delete_browser(browser_id: str) -> dict[str, Any]:
         logger.warning(detail)
         raise HTTPException(status_code=404, detail=detail)
     try:
+        mark_browser_deleting(browser_id)
         result = await backend.delete_browser(browser_id)
         logger.info(f"Browser {browser_id} is stopped.")
         return result
@@ -312,8 +315,13 @@ async def relay_browser_cdp(client_ws: WebSocket, browser_id: str, *, patch: boo
     await client_ws.accept()
     logger.debug("[CDP] WebSocket accepted")
 
-    # (1) Auto-launch the browser if it isn't running yet.
+    # (1) Auto-launch the browser if it isn't running yet, unless it was just deleted: a connect
+    # racing a teardown must not silently resurrect it under the same id.
     if not await backend.browser_exists(browser_id):
+        if was_browser_recently_deleted(browser_id):
+            logger.warning(f"[CDP] Browser {browser_id} was just deleted — refusing to relaunch")
+            await client_ws.close(code=1008)
+            return
         logger.info(f"[CDP] Browser {browser_id} not found — launching")
         try:
             origin_ip = client_ws.headers.get("x-origin-ip")

--- a/tests/test_recently_deleted.py
+++ b/tests/test_recently_deleted.py
@@ -1,0 +1,42 @@
+import asyncio
+
+import pytest
+from pytest import MonkeyPatch
+
+from getgather.browsers import backend as backend_mod
+from getgather.browsers.backend import mark_browser_deleting, was_browser_recently_deleted
+
+
+@pytest.mark.asyncio
+async def test_unknown_browser_is_not_recently_deleted() -> None:
+    assert not was_browser_recently_deleted("Bneverseen")
+
+
+@pytest.mark.asyncio
+async def test_delete_in_flight_blocks_relaunch() -> None:
+    """The observed leak: a CDP connect arriving while a delete was still in flight saw
+    `browser_exists() == False` and re-created the sandbox under the same id."""
+    exists = True
+
+    async def delete_browser(browser_id: str) -> None:
+        nonlocal exists
+        mark_browser_deleting(browser_id)
+        exists = False  # the backend drops it from `browser_exists` here...
+        await asyncio.sleep(0.05)  # ...but the delete call has not returned yet
+
+    task = asyncio.create_task(delete_browser("Binflight"))
+    await asyncio.sleep(0.01)
+
+    assert exists is False, "precondition: browser is already invisible mid-delete"
+    assert was_browser_recently_deleted("Binflight"), "auto-launch would resurrect it"
+    await task
+    assert was_browser_recently_deleted("Binflight")
+
+
+@pytest.mark.asyncio
+async def test_record_expires(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(backend_mod, "RECENTLY_DELETED_SECONDS", 0.01)
+    mark_browser_deleting("Bexpire")
+    assert was_browser_recently_deleted("Bexpire")
+    await asyncio.sleep(0.02)
+    assert not was_browser_recently_deleted("Bexpire")


### PR DESCRIPTION
 ## Why

In very rare cases, we sometimes resurrect a browser that was recently deleted. When this happens, we may end up using a browser that is in the middle of being destroyed. In the case of Daytona, this extends the lifecycle of the deleted sandbox.

## Changes

With this approach, we avoid accidentally choosing an instance that was just destroyed. By maintaining a pool of browsers that were deleted within the last 60 seconds.
