### PR TITLE
feat: make CDP websocket ping internal a backend decision

### DIFF
--- a/getgather/browser.py
+++ b/getgather/browser.py
@@ -19,6 +19,7 @@ from zendriver.core._contradict import ContraDict
 from zendriver.core.config import Config
 from zendriver.core.connection import Connection, ProtocolException
 
+from getgather.browsers.backend import get_backend
 from getgather.browsers.fleet_browsers import build_chromefleet_headers, call_chromefleet_api
 from getgather.config import FRIENDLY_CHARS, settings
 
@@ -41,6 +42,7 @@ def _traced_websocket_connect(*args: Any, **kwargs: Any) -> Any:
         merged.update(carrier)
     kwargs["additional_headers"] = merged
     kwargs.setdefault("open_timeout", settings.CHROMEFLEET_CDP_OPEN_TIMEOUT_SECONDS)
+    kwargs.setdefault("ping_interval", get_backend().cdp_ws_ping_interval())
 
     logger.info(
         "CDP websocket headers attached",

--- a/getgather/browsers/backend.py
+++ b/getgather/browsers/backend.py
@@ -8,6 +8,8 @@ from nanoid import generate
 
 from getgather.config import FRIENDLY_CHARS, settings
 
+CDP_WS_PING_INTERVAL_SECONDS = 60
+
 # Shared name prefix: a browser with id `abc` is a podman container / Daytona sandbox named
 # `chromium-abc`. Both local backends derive names and parse ids from this single prefix.
 BROWSER_NAME_PREFIX = "chromium-"
@@ -245,6 +247,11 @@ class Backend(Protocol):
         Fleet, the per-browser /json/version discovery for Podman/Daytona). Returns None when
         the URL can't (yet) be resolved."""
 
+    def cdp_ws_ping_interval(self) -> float | None:
+        """Seconds between websocket keepalive pings on CDP sockets opened against this backend,
+        or None to disable pings entirely."""
+        ...
+
     def cdp_targets_need_namespacing(self) -> bool:
         """Whether `websocket_proxy` should rewrite target ids to namespace them by `browser_id`
         when relaying to this backend's URL. True for backends that hand back a single browser's
@@ -272,6 +279,16 @@ class Backend(Protocol):
     async def get_vnc_endpoint(self, browser_id: str) -> tuple[str, int] | None: ...
 
     async def get_live_view_url(self, browser_id: str) -> str | None: ...
+
+
+_backend: Backend | None = None
+
+
+def get_backend() -> Backend:
+    global _backend
+    if _backend is None:
+        _backend = create_backend()
+    return _backend
 
 
 def create_backend() -> Backend:

--- a/getgather/browsers/browserbase_browsers.py
+++ b/getgather/browsers/browserbase_browsers.py
@@ -10,7 +10,7 @@ from fastapi.websockets import WebSocketState
 from loguru import logger
 from websockets.exceptions import ConnectionClosed, InvalidStatus
 
-from getgather.browsers.backend import BROWSER_SCOPE, BrowserNotFound
+from getgather.browsers.backend import BROWSER_SCOPE, CDP_WS_PING_INTERVAL_SECONDS, BrowserNotFound
 from getgather.browsers.residential_proxy import get_proxy_config
 from getgather.config import settings
 
@@ -315,6 +315,9 @@ class BrowserbaseBackend:
         # multiplexed CDP socket the router relays to directly; there is no /json/version
         # discovery step. None for an unknown / already-released session.
         return self._sessions.get(browser_id)
+
+    def cdp_ws_ping_interval(self) -> float | None:
+        return CDP_WS_PING_INTERVAL_SECONDS
 
     def cdp_targets_need_namespacing(self) -> bool:
         # The connectUrl is a single browser's socket; the router namespaces its target ids by

--- a/getgather/browsers/daytona_browsers.py
+++ b/getgather/browsers/daytona_browsers.py
@@ -273,6 +273,9 @@ class DaytonaBackend:
         cdp_base_url = await self.get_cdp_base_url(browser_id)
         return await get_browser_websocket_debugger_url(cdp_base_url)
 
+    def cdp_ws_ping_interval(self) -> float | None:
+        return None
+
     def cdp_targets_need_namespacing(self) -> bool:
         # The per-sandbox socket reports raw target ids; the router namespaces them by browser_id
         # so the devtools route can route /devtools/{browser_id@page_id} back to this sandbox.

--- a/getgather/browsers/fleet_browsers.py
+++ b/getgather/browsers/fleet_browsers.py
@@ -5,7 +5,7 @@ from fastapi import WebSocket
 from fastmcp.server.dependencies import get_http_headers
 from httpx_retries import Retry, RetryTransport
 
-from getgather.browsers.backend import BROWSER_SCOPE, BrowserNotFound
+from getgather.browsers.backend import BROWSER_SCOPE, CDP_WS_PING_INTERVAL_SECONDS, BrowserNotFound
 from getgather.client_ip import client_ip_var
 from getgather.config import settings
 
@@ -165,6 +165,9 @@ class FleetBackend:
         # ids; the router does not patch again (see cdp_targets_need_namespacing). Deterministic
         # from CHROMEFLEET_URL + browser_id, so this never returns None — no retry needed.
         return f"{self.cdp_websocket_base()}/cdp/{browser_id}"
+
+    def cdp_ws_ping_interval(self) -> float | None:
+        return CDP_WS_PING_INTERVAL_SECONDS
 
     def cdp_targets_need_namespacing(self) -> bool:
         # The external fleet's /cdp proxy already namespaces target ids by browser_id; the

--- a/getgather/browsers/podman_browsers.py
+++ b/getgather/browsers/podman_browsers.py
@@ -12,6 +12,7 @@ from loguru import logger
 from getgather.browsers.backend import (
     BROWSER_NAME_PREFIX,
     BROWSER_SCOPE,
+    CDP_WS_PING_INTERVAL_SECONDS,
     BrowserNotFound,
     ProxyVerificationError,
     get_browser_websocket_debugger_url,
@@ -436,6 +437,9 @@ class PodmanBackend:
         # missed boot race (chrome not ready yet) — the router retries 10x before giving up.
         cdp_base_url = await self.get_cdp_base_url(browser_id)
         return await get_browser_websocket_debugger_url(cdp_base_url)
+
+    def cdp_ws_ping_interval(self) -> float | None:
+        return CDP_WS_PING_INTERVAL_SECONDS
 
     def cdp_targets_need_namespacing(self) -> bool:
         # The per-browser socket reports raw target ids; the router namespaces them by browser_id

--- a/getgather/browsers/router.py
+++ b/getgather/browsers/router.py
@@ -15,7 +15,7 @@ from getgather.browsers.backend import (
     Backend,
     BrowserNotFound,
     best_of_n,
-    create_backend,
+    get_backend,
     new_browser_id,
 )
 from getgather.cdp_client import CDPClient, open_cdp_url
@@ -23,7 +23,7 @@ from getgather.config import settings
 
 router = APIRouter()
 
-backend: Backend = create_backend()
+backend: Backend = get_backend()
 logger.info(f"Using browser backend: {backend.__class__.__name__}")
 
 
@@ -156,7 +156,7 @@ async def websocket_proxy(
     try:
         async with websockets.connect(
             remote_url,
-            ping_interval=60,
+            ping_interval=backend.cdp_ws_ping_interval(),
             ping_timeout=30,
             close_timeout=10,
             max_size=10 * 1024 * 1024,

--- a/tests/test_browser_backend.py
+++ b/tests/test_browser_backend.py
@@ -7,7 +7,7 @@ from pytest import MonkeyPatch
 
 from getgather.browser import _setup_cdp_url  # pyright: ignore[reportPrivateUsage]
 from getgather.browsers import router as browsers_router
-from getgather.browsers.backend import create_backend
+from getgather.browsers.backend import CDP_WS_PING_INTERVAL_SECONDS, create_backend
 from getgather.browsers.fleet_browsers import FleetBackend
 from getgather.browsers.podman_browsers import PodmanBackend
 from getgather.config import settings
@@ -22,6 +22,12 @@ def test_create_backend_defaults_to_podman_without_url(monkeypatch: MonkeyPatch)
     monkeypatch.setattr(settings, "CHROMEFLEET_URL", "")
     monkeypatch.setattr(settings, "BROWSER_BACKEND", "podman")
     assert isinstance(create_backend(), PodmanBackend)
+
+
+def test_cdp_ws_ping_interval_defaults_to_keepalive(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "CHROMEFLEET_URL", "http://localhost:8300")
+    assert FleetBackend().cdp_ws_ping_interval() == CDP_WS_PING_INTERVAL_SECONDS
+    assert PodmanBackend().cdp_ws_ping_interval() == CDP_WS_PING_INTERVAL_SECONDS
 
 
 def test_fleet_cdp_websocket_base_rewrites_scheme(monkeypatch: MonkeyPatch) -> None:
@@ -112,6 +118,9 @@ class _FakeCDPBackend:
 
     async def get_cdp_websocket_remote_url(self, browser_id: str) -> str:
         return "ws://remote/devtools/browser/xyz"
+
+    def cdp_ws_ping_interval(self) -> float | None:
+        return 60
 
     def cdp_targets_need_namespacing(self) -> bool:
         return True

--- a/tests/test_daytona_browsers.py
+++ b/tests/test_daytona_browsers.py
@@ -311,3 +311,9 @@ def test_backend_default_best_of_n_consts(module_name: str, expected: int) -> No
 
     module = importlib.import_module(module_name)
     assert module.DEFAULT_BEST_OF_N == expected
+
+
+def test_cdp_ws_pings_disabled() -> None:
+    # Daytona is the one backend that opts out of CDP keepalive pings; the others keep the
+    # 60s default (see tests/test_browser_backend.py).
+    assert _backend().cdp_ws_ping_interval() is None


### PR DESCRIPTION
## Why

In Daytona, WebSocket pings keep the machine alive until it is explicitly deleted. This makes the code below effectively unusable because the machine is periodically pinged and never becomes idle.

```python
# Daytona auto-stops a sandbox after this many idle minutes (no sandbox events), parking it at
# $0 compute. Once it has been continuously stopped for TTL_MINUTES, Daytona's native
# auto_delete_interval (set at creation time) deletes it.
AUTO_STOP_MINUTES = 15
TTL_MINUTES = 60
```

## Changes

Disable CDP WebSocket pings for Daytona.
