### PR TITLE
fix(walmart): match aria-label prefix for phone/email signin input

### DIFF
--- a/getgather/mcp/patterns/walmart-signin-email.html
+++ b/getgather/mcp/patterns/walmart-signin-email.html
@@ -17,9 +17,9 @@
       autofocus
       name="email"
       type="text"
-      placeholder="Phone number or email (required)"
+      placeholder="Phone number or email"
       data-testid="username"
-      rb-match="input[aria-label='Phone number or email (required)']"
+      rb-match="input[aria-label^='Phone number or email']"
     />
     <button
       type="submit"


### PR DESCRIPTION
## Summary
- `getgather/mcp/patterns/walmart-signin-email.html` — Walmart dropped the "(required)" suffix from the phone/email input's aria-label, breaking the exact-match selector. Input has no id or data-testid alternative pointing at it, so prefix-match the aria-label (`^=`) instead; placeholder text updated to match.